### PR TITLE
Standardize modal file naming and callback_ids

### DIFF
--- a/slack/modals/analyze/analyze_notes.json
+++ b/slack/modals/analyze/analyze_notes.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "qori_analyze_modal",
+  "callback_id": "analyze_notes",
   "title": {
     "type": "plain_text",
     "text": "Analyze notes"

--- a/slack/modals/analyze/research_request.json
+++ b/slack/modals/analyze/research_request.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "qori_request_modal",
+  "callback_id": "research_request",
   "title": {
     "type": "plain_text",
     "text": "Research Request"

--- a/slack/modals/analyze/synthesis.json
+++ b/slack/modals/analyze/synthesis.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "qori_synthesis",
+  "callback_id": "synthesis",
   "title": {
     "type": "plain_text",
     "text": "Synthesize study"

--- a/slack/modals/notes/manual_notes.json
+++ b/slack/modals/notes/manual_notes.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "session_notes_modal",
+  "callback_id": "manual_notes",
   "title": {
     "type": "plain_text",
     "text": "Session notes"

--- a/slack/modals/notes/take_notes.json
+++ b/slack/modals/notes/take_notes.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "take_notes_modal",
+  "callback_id": "take_notes",
   "title": {
     "type": "plain_text",
     "text": "Take notes"

--- a/slack/modals/notes/upload_transcript.json
+++ b/slack/modals/notes/upload_transcript.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "upload_transcript_modal",
+  "callback_id": "upload_transcript",
   "title": {
     "type": "plain_text",
     "text": "Upload transcript"

--- a/slack/modals/outreach/follow_up.json
+++ b/slack/modals/outreach/follow_up.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "follow_up_modal",
+  "callback_id": "follow_up",
   "title": {
     "type": "plain_text",
     "text": "Follow-up"

--- a/slack/modals/outreach/initial_recruitment.json
+++ b/slack/modals/outreach/initial_recruitment.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "initial_recruitment_modal",
+  "callback_id": "initial_recruitment",
   "title": {
     "type": "plain_text",
     "text": "Initial recruitment"

--- a/slack/modals/outreach/outreach_menu.json
+++ b/slack/modals/outreach/outreach_menu.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "participant_outreach_modal",
+  "callback_id": "outreach_menu",
   "title": {
     "type": "plain_text",
     "text": "Participant outreach"

--- a/slack/modals/outreach/rescheduling.json
+++ b/slack/modals/outreach/rescheduling.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "rescheduling_modal",
+  "callback_id": "rescheduling",
   "title": {
     "type": "plain_text",
     "text": "Rescheduling request"

--- a/slack/modals/outreach/session_confirmation.json
+++ b/slack/modals/outreach/session_confirmation.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "session_confirmation_modal",
+  "callback_id": "session_confirmation",
   "title": {
     "type": "plain_text",
     "text": "Session confirmation"

--- a/slack/modals/outreach/session_reminder.json
+++ b/slack/modals/outreach/session_reminder.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "session_reminder_modal",
+  "callback_id": "session_reminder",
   "title": {
     "type": "plain_text",
     "text": "Session reminder"

--- a/slack/modals/outreach/thank_you.json
+++ b/slack/modals/outreach/thank_you.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "thank_you_modal",
+  "callback_id": "thank_you",
   "title": {
     "type": "plain_text",
     "text": "Thank you"

--- a/slack/modals/participants/add_participant.json
+++ b/slack/modals/participants/add_participant.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "add_participant_modal",
+  "callback_id": "add_participant",
   "title": {
     "type": "plain_text",
     "text": "Add participant"

--- a/slack/modals/participants/observer_request.json
+++ b/slack/modals/participants/observer_request.json
@@ -1,6 +1,6 @@
 {
 	"type": "modal",
-	"callback_id": "observer_request_modal",
+	"callback_id": "observer_request",
 	"title": {
 		"type": "plain_text",
 		"text": "Observer request"

--- a/slack/modals/participants/update_participant.json
+++ b/slack/modals/participants/update_participant.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "update_participant_modal",
+  "callback_id": "update_participant",
   "title": {
     "type": "plain_text",
     "text": "Update participant"

--- a/slack/modals/plan/discussion_guide.json
+++ b/slack/modals/plan/discussion_guide.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "discussion_guide_modal",
+  "callback_id": "discussion_guide",
   "title": {
     "type": "plain_text",
     "text": "Discussion Guide"

--- a/slack/modals/plan/plan_menu.json
+++ b/slack/modals/plan/plan_menu.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "plan_study_modal",
+  "callback_id": "plan_menu",
   "title": {
     "type": "plain_text",
     "text": "Plan your study"

--- a/slack/modals/plan/research_brief.json
+++ b/slack/modals/plan/research_brief.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "qori_brief_modal",
+  "callback_id": "research_brief",
   "title": {
     "type": "plain_text",
     "text": "Research Brief"

--- a/slack/modals/plan/research_plan.json
+++ b/slack/modals/plan/research_plan.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "research_plan_modal",
+  "callback_id": "research_plan",
   "title": {
     "type": "plain_text",
     "text": "Research plan"

--- a/slack/modals/plan/stakeholder_interview_guide.json
+++ b/slack/modals/plan/stakeholder_interview_guide.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "stakeholder_interview_guide_modal",
+  "callback_id": "stakeholder_interview_guide",
   "title": {
     "type": "plain_text",
     "text": "Stakeholder guide"

--- a/slack/modals/plan/upload_desk_research.json
+++ b/slack/modals/plan/upload_desk_research.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "upload_desk_research_modal",
+  "callback_id": "upload_desk_research",
   "title": {
     "type": "plain_text",
     "text": "Desk research"

--- a/slack/modals/plan/upload_stakeholder_notes.json
+++ b/slack/modals/plan/upload_stakeholder_notes.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "upload_stakeholder_notes_modal",
+  "callback_id": "upload_stakeholder_notes",
   "title": {
     "type": "plain_text",
     "text": "Stakeholder notes"

--- a/slack/modals/plan/upload_survey_data.json
+++ b/slack/modals/plan/upload_survey_data.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "upload_survey_data_modal",
+  "callback_id": "upload_survey_data",
   "title": {
     "type": "plain_text",
     "text": "Survey data"

--- a/slack/modals/report/report_menu.json
+++ b/slack/modals/report/report_menu.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "reports_modal",
+  "callback_id": "report_menu",
   "title": {
     "type": "plain_text",
     "text": "Research reports"

--- a/slack/modals/report/targeted_readouts.json
+++ b/slack/modals/report/targeted_readouts.json
@@ -1,6 +1,6 @@
 {
   "type": "modal",
-  "callback_id": "targeted_readouts_modal",
+  "callback_id": "targeted_readouts",
   "title": {
     "type": "plain_text",
     "text": "Targeted readouts"


### PR DESCRIPTION
- Create analyze/ folder for research request, synthesis, and analyze_notes
- Remove _modal suffix from all callback_ids for consistency
- Rename entry point modals to *_menu.json for clarity
- Standardize on underscores (no hyphens) in file names
- Rename confusing files (session_notes→manual_notes, qori_brief→research_brief)

File changes:
- qori-request.json → analyze/research_request.json
- qori-synthesis.json → analyze/synthesis.json
- qori_analyze.json → analyze/analyze_notes.json
- notes/session_notes.json → notes/manual_notes.json
- notes/take_notes_modal.json → notes/take_notes.json
- outreach/participant_outreach_modal.json → outreach/outreach_menu.json
- outreach/rescheduling_modal.json → outreach/rescheduling.json
- plan/plan_study_modal.json → plan/plan_menu.json
- plan/qori_brief.json → plan/research_brief.json
- report/reports_modal.json → report/report_menu.json

https://claude.ai/code/session_014GewhxXUQKkjWeSd3nS9EF