### PR TITLE
feat: TypeScript Phase 2 — type definitions

### DIFF
--- a/backend/src/types/cascade.ts
+++ b/backend/src/types/cascade.ts
@@ -1,0 +1,642 @@
+/**
+ * Cascade variable types for the Qori research pipeline.
+ *
+ * Every variable emitted by a YAML template and stored in the study_variables
+ * table has a corresponding TypeScript interface here. Types are derived from
+ * the schema files at backend/config/schemas/*.yaml and the emits blocks in
+ * config/prompts/*.yaml.
+ *
+ * Variables are either "pool" (multiple rows per variable_key, one per item)
+ * or "singleton" (one row containing the full value as JSONB). Pool variables
+ * have an item_key; singletons have item_key = null.
+ *
+ * See docs/cascade-spec/ and ADR 0007 for the cascade contract system.
+ */
+
+// ---------------------------------------------------------------------------
+// Shared enums and types
+// ---------------------------------------------------------------------------
+
+export type ConfidenceLevel = 'Strong' | 'Moderate' | 'Limited';
+
+export type NielsenSeverity = 0 | 1 | 2 | 3 | 4;
+
+export type PoolStrategy = 'append' | 'replace' | 'append_or_replace_per_participant';
+
+// ---------------------------------------------------------------------------
+// Discovery phase — desk research
+// ---------------------------------------------------------------------------
+
+/** Schema: discovered_barrier.yaml. Emitted by desk_research, survey_synthesis. Pool. */
+export interface DiscoveredBarrier {
+  id: string;
+  title: string;
+  summary: string;
+  magnitude: string | null;
+  evidence: string[] | null;
+  affected_population: string | null;
+  source_document: string;
+  confidence: ConfidenceLevel | null;
+}
+
+/** Schema: discovered_metric.yaml. Emitted by desk_research, survey_synthesis. Pool. */
+export interface DiscoveredMetric {
+  id: string;
+  metric_name: string;
+  value: string;
+  context: string | null;
+  baseline_or_target: string | null;
+  source_document: string;
+}
+
+/** Schema: discovered_journey.yaml. Emitted by desk_research, journey_mapping. Pool. */
+export interface DiscoveredJourney {
+  id: string;
+  journey_name: string;
+  success_pattern: string | null;
+  failure_pattern: string | null;
+  completion_rate: string | null;
+  satisfaction: string | null;
+  source_document: string;
+}
+
+/** Schema: methodology_recommendation.yaml. Emitted by desk_research. Pool. */
+export interface MethodologyRecommendation {
+  id: string;
+  method: string;
+  addresses: string;
+  rationale: string;
+  source_document: string;
+}
+
+/** Inline schema. Emitted by desk_research, survey_synthesis. Pool. */
+export interface KnowledgeGap {
+  id: string;
+  gap: string;
+  why_matters: string | null;
+  suggested_resolution: string | null;
+  source_document: string;
+}
+
+/** Inline schema. Emitted by desk_research. Pool. */
+export interface SourceArtifact {
+  title: string;
+  source_org: string;
+  date: string;
+  type: string | null;
+  contribution: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Discovery phase — stakeholder synthesis
+// ---------------------------------------------------------------------------
+
+export type ConstraintType = 'Technical' | 'Policy' | 'Resource' | 'Organizational';
+
+/** Schema: stakeholder_constraint.yaml. Emitted by stakeholder_synthesis. Pool (replace). */
+export interface StakeholderConstraint {
+  id: string;
+  type: ConstraintType;
+  constraint: string;
+  impact: string;
+  source: string;
+  source_role: string | null;
+  source_team: string | null;
+  verbatim_quote: string | null;
+  broader_pattern: string | null;
+  research_implication: string | null;
+  implementation_implication: string | null;
+}
+
+/** Schema: stakeholder_priority.yaml. Emitted by stakeholder_synthesis. Pool (replace). */
+export interface StakeholderPriority {
+  id: string;
+  priority: string;
+  stated_by: string[];
+  aligns_with_user_need: 'Yes' | 'No' | 'Partial' | 'Unknown';
+  driver: string | null;
+  timeline: string | null;
+  effort_estimate: string | null;
+}
+
+/** Schema: alignment_gap.yaml. Emitted by stakeholder_synthesis. Pool (replace). */
+export interface AlignmentGap {
+  id: string;
+  gap_description: string;
+  stated_position: string;
+  actual_behavior: string;
+  acknowledged_by: string | null;
+  verbatim_quote: string | null;
+  consequence: string | null;
+  addressable_in_research: boolean | null;
+}
+
+/** Schema: stakeholder_question.yaml. Emitted by stakeholder_synthesis. Pool (replace). */
+export interface StakeholderQuestion {
+  id: string;
+  priority: 'Blocking' | 'Important' | 'Validation';
+  question: string;
+  asked_by: string;
+  stakeholder_insight: string | null;
+  suggested_method: string | null;
+}
+
+/** Inline schema. Emitted by stakeholder_synthesis. Pool (replace). */
+export interface BackstageObservation {
+  id: string;
+  title: string;
+  pattern_type: 'working' | 'broken' | 'organizational' | 'resource';
+  observation: string;
+  verbatim_quote: string | null;
+  flow_description: string | null;
+  source: string;
+}
+
+/** Inline schema. Emitted by stakeholder_synthesis. Pool (replace). */
+export interface SystemFailureMode {
+  id: string;
+  flow_name: string;
+  where_it_breaks: string;
+  consequence: string;
+  source: string;
+  verbatim_quote: string | null;
+  mermaid_diagram: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Discovery phase — survey synthesis
+// ---------------------------------------------------------------------------
+
+export interface SurveyQuoteAttribution {
+  quote: string;
+  respondent: string;
+}
+
+/** Schema: survey_theme.yaml. Emitted by survey_synthesis. Pool. */
+export interface SurveyTheme {
+  id: string;
+  theme_name: string;
+  frequency_count: number;
+  frequency_percentage: number;
+  sentiment: 'Negative' | 'Positive' | 'Mixed' | 'Neutral';
+  priority: 'High' | 'Medium' | 'Low';
+  pattern: string;
+  verbatim_quotes: SurveyQuoteAttribution[] | null;
+}
+
+/** Schema: survey_finding.yaml. Emitted by survey_synthesis. Pool. */
+export interface SurveyFinding {
+  id: string;
+  finding: string;
+  metric_name: string | null;
+  sample_size: number | null;
+  affected_segment: string | null;
+  supporting_quotes: string[] | null;
+  source_question: string | null;
+}
+
+/** Schema: survey_recommendation.yaml. Emitted by survey_synthesis. Pool. */
+export interface SurveyRecommendation {
+  id: string;
+  action: string;
+  based_on_theme: string;
+  priority: 'High' | 'Medium' | 'Low';
+  suggested_owner: string | null;
+}
+
+/** Inline schema. Emitted by survey_synthesis. Singleton. */
+export interface SampleDemographics {
+  total_responses: number;
+  composition: string;
+  response_rate: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Planning phase — research brief
+// ---------------------------------------------------------------------------
+
+/** Schema: research_question.yaml. Emitted by research_brief. Singleton (array). */
+export interface ResearchQuestion {
+  id: string;
+  question: string;
+  priority: 'Primary' | 'Secondary' | 'Exploratory' | null;
+}
+
+/**
+ * Schema: target_barrier.yaml. Emitted by research_brief. Singleton (array).
+ * Consumed by session_summary for validation. See ADR 0006.
+ */
+export interface TargetBarrier {
+  id: string;
+  barrier: string;
+  source: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Planning phase — research plan
+// ---------------------------------------------------------------------------
+
+/** Schema: study_timeline.yaml. Emitted by research_plan. Singleton (array). */
+export interface StudyTimelinePhase {
+  id: string;
+  phase_name: string;
+  duration: string;
+  start_date: string | null;
+  end_date: string | null;
+  activities: string[] | null;
+  deliverables: string[] | null;
+  responsible_party: string | null;
+}
+
+/** Schema: study_risk.yaml. Emitted by research_plan. Singleton (array). */
+export interface StudyRisk {
+  id: string;
+  risk: string;
+  source_constraint: string | null;
+  likelihood: 'High' | 'Medium' | 'Low' | null;
+  impact: 'High' | 'Medium' | 'Low' | null;
+  mitigation: string;
+  contingency: string | null;
+}
+
+/** Schema: study_deliverable.yaml. Emitted by research_plan. Singleton (array). */
+export interface StudyDeliverable {
+  id: string;
+  deliverable_name: string;
+  format: string;
+  due_date: string | null;
+  audience: string | null;
+  addresses_objective: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Research execution — session summary (per-participant pools)
+// ---------------------------------------------------------------------------
+
+export type NuggetType =
+  | 'task_success'
+  | 'task_failure'
+  | 'pain_point'
+  | 'workaround'
+  | 'quote'
+  | 'positive'
+  | 'surprise'
+  | 'accessibility_issue'
+  | 'behavioral_pattern'
+  | 'mental_model';
+
+/**
+ * Schema: atomic_nugget_core.yaml. Emitted by session_summary.
+ * Pool (append_or_replace_per_participant). Per-participant.
+ *
+ * This is the primary unit of qualitative data in the cascade. Each nugget
+ * is a single atomic observation from a research session. Downstream templates
+ * (affinity_mapping, persona_generator, etc.) consume nuggets to build
+ * higher-order patterns.
+ */
+export interface AtomicNuggetCore {
+  id: string;
+  nugget_type: NuggetType;
+  severity: NielsenSeverity;
+  text: string;
+  participant: string;
+  session: string;
+}
+
+/**
+ * Schema: atomic_nugget_detail.yaml. Emitted by session_summary.
+ * Pool (append_or_replace_per_participant). Per-participant.
+ * Linked to AtomicNuggetCore by id.
+ */
+export interface AtomicNuggetDetail {
+  id: string;
+  verbatim_quote: string | null;
+  participant_context: string | null;
+  task_context: string | null;
+  timestamp: string | null;
+  linked_barrier: string | null;
+  linked_question: string | null;
+  observed_behavior: string | null;
+  inferred_meaning: string | null;
+  emotional_state: string | null;
+  confidence: ConfidenceLevel | null;
+}
+
+/**
+ * Schema: participant_metadata.yaml. Emitted by session_summary.
+ * Pool (append_or_replace_per_participant). Per-participant.
+ */
+export interface ParticipantMetadata {
+  participant_id: string;
+  background: string;
+  tech_setup: string;
+  accessibility: string | null;
+  recruitment_source: string | null;
+  consent_recording: boolean | null;
+  app_usage: string | null;
+  session_notes: string | null;
+  key_contribution: string;
+}
+
+/**
+ * Schema: task_completion_record.yaml. Emitted by session_summary.
+ * Pool (append_or_replace_per_participant). Per-participant.
+ */
+export interface TaskCompletionRecord {
+  id: string;
+  participant: string;
+  task_number: number;
+  task_name: string;
+  success: boolean;
+  completion_time: string | null;
+  attempts: number | null;
+  workaround_used: boolean;
+  notes: string;
+  blockers: string[];
+  linked_nuggets: string[];
+}
+
+/**
+ * Schema: barrier_validation.yaml. Emitted by session_summary.
+ * Pool (append_or_replace_per_participant). Per-participant.
+ * References TargetBarrier.id via barrier_ref.
+ */
+export interface BarrierValidation {
+  id: string;
+  barrier_ref: string;
+  participant: string;
+  validated: boolean;
+  evidence: string;
+  verbatim_evidence: string | null;
+  confidence: ConfidenceLevel;
+  notes: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Synthesis — affinity mapping
+// ---------------------------------------------------------------------------
+
+export type ThemeValidationStatus =
+  | 'validates_barrier'
+  | 'refutes_barrier'
+  | 'unexpected_pattern';
+
+/**
+ * Schema: validated_theme.yaml. Emitted by affinity_mapping.
+ * Singleton (array). Study-scoped.
+ *
+ * Themes are the primary synthesis output — cross-participant patterns
+ * grounded in atomic nuggets. Consumed by most downstream templates.
+ */
+export interface ValidatedTheme {
+  id: string;
+  theme_name: string;
+  summary: string;
+  supporting_nuggets: string[];
+  confidence: ConfidenceLevel;
+  pattern_description: string | null;
+  evidence_count: number;
+  participants_observed: string[];
+  participant_coverage: string | null;
+  severity_distribution: Record<string, number> | null;
+  representative_quote: string | null;
+  representative_quote_source: string | null;
+  linked_barriers: string[] | null;
+  validation_status: ThemeValidationStatus | null;
+  linked_questions: string[] | null;
+  cross_cutting_dimensions: string[] | null;
+  confidence_reasoning: string | null;
+}
+
+/** Schema: unexpected_pattern.yaml. Emitted by affinity_mapping. Singleton (array). */
+export interface UnexpectedPattern {
+  id: string;
+  pattern: string;
+  why_unexpected: string;
+  supporting_nuggets: string[];
+  significance: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Synthesis — persona generator
+// ---------------------------------------------------------------------------
+
+export interface PersonaFrustration {
+  frustration: string;
+  evidence_nugget: string | null;
+  verbatim_quote: string | null;
+  severity: NielsenSeverity | null;
+}
+
+export interface PersonaBehavior {
+  behavior: string;
+  context: string;
+  evidence_nugget: string | null;
+}
+
+/** Schema: persona.yaml. Emitted by persona_generator. Singleton (array). */
+export interface Persona {
+  id: string;
+  persona_name: string;
+  archetype: string;
+  summary: string;
+  based_on_participants: string[];
+  confidence: ConfidenceLevel;
+  representative_participant: string | null;
+  demographics: {
+    age_range: string | null;
+    service_era: string | null;
+    tech_comfort: string | null;
+  } | null;
+  context: {
+    device_environment: string | null;
+    assistive_technology: string | null;
+    usage_frequency: string | null;
+  } | null;
+  goals: string[];
+  frustrations: PersonaFrustration[];
+  behaviors: PersonaBehavior[] | null;
+  workarounds: string[] | null;
+  needs: string[] | null;
+  linked_themes: string[] | null;
+  affected_by_barriers: string[] | null;
+  representative_quote: string | null;
+  representative_quote_source: string | null;
+  confidence_reasoning: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Readout schemas
+// ---------------------------------------------------------------------------
+
+/** Schema: prioritized_finding.yaml. Used in research readout templates. */
+export interface PrioritizedFinding {
+  id: string;
+  finding: string;
+  severity: NielsenSeverity | null;
+  confidence: ConfidenceLevel;
+  evidence_count: number;
+  participants_affected: string[];
+  linked_theme: string | null;
+  recommendation: string | null;
+}
+
+/** Schema: prioritized_recommendation.yaml. Used in research readout templates. */
+export interface PrioritizedRecommendation {
+  id: string;
+  recommendation: string;
+  priority: 'High' | 'Medium' | 'Low';
+  effort: string | null;
+  impact: string | null;
+  addresses_finding: string | null;
+}
+
+/** Schema: exec_summary_point.yaml. Used in executive readout. */
+export interface ExecSummaryPoint {
+  id: string;
+  point: string;
+  supporting_data: string | null;
+}
+
+/** Schema: decision_input.yaml. Used in decision readout. */
+export interface DecisionInput {
+  id: string;
+  decision: string;
+  options: string[] | null;
+  recommendation: string | null;
+  evidence: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Ticket candidate schemas
+// ---------------------------------------------------------------------------
+
+/** Schema: accessibility_ticket_candidate.yaml */
+export interface AccessibilityTicketCandidate {
+  id: string;
+  title: string;
+  description: string;
+  severity: NielsenSeverity;
+  wcag_criteria: string | null;
+  affected_users: string | null;
+  linked_nuggets: string[];
+}
+
+/** Schema: design_ticket_candidate.yaml */
+export interface DesignTicketCandidate {
+  id: string;
+  title: string;
+  description: string;
+  priority: 'High' | 'Medium' | 'Low';
+  linked_theme: string | null;
+  linked_nuggets: string[];
+}
+
+/** Schema: engineering_ticket_candidate.yaml */
+export interface EngineeringTicketCandidate {
+  id: string;
+  title: string;
+  description: string;
+  priority: 'High' | 'Medium' | 'Low';
+  linked_constraint: string | null;
+  linked_nuggets: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Variable storage metadata
+// ---------------------------------------------------------------------------
+
+/**
+ * Represents a row in the study_variables table. This is the storage format,
+ * not the domain type — the `value` field contains one of the interfaces above
+ * as JSONB.
+ */
+export interface StudyVariableRow {
+  id: number;
+  study_name: string;
+  variable_key: string;
+  variable_type: string | null;
+  item_key: string | null;
+  value: unknown;
+  participant_id: string | null;
+  source_template: string;
+  source_version: string | null;
+  source_date: Date | null;
+  value_hash: string | null;
+  entry_count: number | null;
+  is_pool: boolean;
+  confidence: string | null;
+  scope: string | null;
+  discovery_artifact_id: string | null;
+  stale: boolean;
+  extracted_at: Date;
+  created_at: Date;
+  updated_at: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Variable key registry — maps variable_key strings to their value types
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps each cascade variable_key to its TypeScript type.
+ * Pool variables map to their item type (each row's value is one item).
+ * Singleton variables map to their full value type (one row contains the whole value).
+ */
+export interface CascadeVariableMap {
+  // Discovery — desk research
+  discovered_barriers: DiscoveredBarrier;
+  discovered_metrics: DiscoveredMetric;
+  discovered_journeys: DiscoveredJourney;
+  methodology_recommendations: MethodologyRecommendation;
+  knowledge_gaps: KnowledgeGap;
+  source_artifacts: SourceArtifact;
+
+  // Discovery — stakeholder synthesis
+  stakeholder_constraints: StakeholderConstraint;
+  stakeholder_priorities: StakeholderPriority;
+  alignment_gaps: AlignmentGap;
+  stakeholder_questions_for_users: StakeholderQuestion;
+  backstage_observations: BackstageObservation;
+  system_failure_modes: SystemFailureMode;
+
+  // Discovery — survey synthesis
+  survey_themes: SurveyTheme;
+  survey_findings: SurveyFinding;
+  survey_recommendations: SurveyRecommendation;
+  sample_demographics: SampleDemographics;
+
+  // Planning — research brief
+  research_objectives: string[];
+  research_questions: ResearchQuestion[];
+  target_barriers: TargetBarrier[];
+  methodology_selection: string;
+  participant_criteria: string;
+  out_of_scope: string[];
+  business_context: string;
+  timeline_preference: string;
+  start_date: string;
+  decision_deadline: string;
+  budget: string;
+  participant_approach: string;
+
+  // Planning — research plan
+  study_timeline: StudyTimelinePhase[];
+  risks: StudyRisk[];
+  deliverables: StudyDeliverable[];
+
+  // Research execution — session summary (per-participant)
+  atomic_nugget_core: AtomicNuggetCore;
+  atomic_nugget_detail: AtomicNuggetDetail;
+  participant_metadata: ParticipantMetadata;
+  task_completion_records: TaskCompletionRecord;
+  barrier_validations: BarrierValidation;
+
+  // Synthesis
+  validated_themes: ValidatedTheme[];
+  unexpected_patterns: UnexpectedPattern[];
+  personas: Persona[];
+}
+
+/** All valid cascade variable keys. */
+export type CascadeVariableKey = keyof CascadeVariableMap;

--- a/backend/src/types/common.ts
+++ b/backend/src/types/common.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared types used across multiple domains.
+ *
+ * Types here are referenced by cascade, model, handler, and template-processor
+ * types. A type belongs here when it's used in more than one place and benefits
+ * from a single definition.
+ */
+
+// ---------------------------------------------------------------------------
+// Branded ID types
+// ---------------------------------------------------------------------------
+
+/**
+ * Branded type helper. Prevents accidentally passing a raw number where
+ * a specific ID is expected (e.g., passing a participant ID where a study ID
+ * is required). The __brand property exists only at the type level.
+ */
+type Brand<T, B extends string> = T & { readonly __brand: B };
+
+/** Auto-increment integer ID for a research study (research_studies.id). */
+export type StudyId = Brand<number, 'StudyId'>;
+
+/** Auto-increment integer ID for a study participant (study_participants.id). */
+export type ParticipantId = Brand<number, 'ParticipantId'>;
+
+/** Slack user ID string (e.g., "U0123ABCDEF"). */
+export type SlackUserId = Brand<string, 'SlackUserId'>;
+
+// ---------------------------------------------------------------------------
+// Participant status (re-exported from constants for type use)
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-export ParticipantStatus from the constants module.
+ * The canonical values live in constants/participantStatus.ts (ADR 0002).
+ * Import from there for runtime values; import from here for type-only use.
+ */
+export type { ParticipantStatus } from '../constants/participantStatus';
+
+// ---------------------------------------------------------------------------
+// Cascade variable ID patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * Participant identifier used in cascade variables (e.g., "PT-001", "PT-002").
+ * This is the human-readable participant ID used in session summaries and
+ * cascade data, NOT the database auto-increment ID.
+ */
+export type CascadeParticipantId = string;
+
+/**
+ * Discovery artifact synthetic study_id pattern used in study_variables.
+ * Format: "discovery:{team}:{type}" (e.g., "discovery:friends-lab:desk-research").
+ */
+export type DiscoveryStudyId = `discovery:${string}:${string}`;
+
+// ---------------------------------------------------------------------------
+// Outreach method
+// ---------------------------------------------------------------------------
+
+/** Valid outreach methods for participant contact. */
+export type OutreachMethod = 'email' | 'slack' | 'phone' | 'other';
+
+// ---------------------------------------------------------------------------
+// Study status
+// ---------------------------------------------------------------------------
+
+/** Status values for study approval workflow. */
+export type StudyApprovalStatus = 'approve' | 'rejected' | 'need_changes' | 'created';
+
+// ---------------------------------------------------------------------------
+// Session observer types
+// ---------------------------------------------------------------------------
+
+/** Roles an observer can hold in a research session. */
+export type ObserverRole =
+  | 'note_taker'
+  | 'silent_observer'
+  | 'pm_observer'
+  | 'stakeholder'
+  | 'observer';
+
+/** Status of an observer request. */
+export type ObserverStatus = 'pending' | 'approved' | 'denied' | 'removed' | 'confirmed';
+
+/** How the observer was added to the session. */
+export type ObserverJoinedVia = 'researcher_add' | 'channel_cta' | 'request';

--- a/backend/src/types/handlers.ts
+++ b/backend/src/types/handlers.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared handler context types for Slack interactions.
+ *
+ * Individual handler-specific types (what each handler passes to templates,
+ * what each handler returns) will be co-located with the handler files when
+ * they migrate to .ts in Phase 4. This file defines only the shared base
+ * shapes that multiple handlers use.
+ *
+ * These types wrap the Slack Bolt SDK types to provide a consistent contract
+ * for handler functions.
+ */
+
+import type {
+  AckFn,
+  ViewSubmitAction,
+  SlashCommand,
+  BlockAction,
+} from '@slack/bolt';
+import type { WebClient } from '@slack/web-api';
+
+// ---------------------------------------------------------------------------
+// Slack interaction contexts
+// ---------------------------------------------------------------------------
+
+/**
+ * Common shape every Slack view submission handler receives.
+ * Handlers for modal submissions (e.g., /qori-plan, /qori-brief) get this.
+ */
+export interface ViewSubmissionContext {
+  ack: AckFn<ViewSubmitAction>;
+  body: ViewSubmitAction;
+  view: ViewSubmitAction['view'];
+  client: WebClient;
+}
+
+/**
+ * Common shape every slash command handler receives.
+ * Handlers for /qori-* commands get this before opening a modal.
+ */
+export interface SlashCommandContext {
+  ack: AckFn<void>;
+  body: SlashCommand;
+  client: WebClient;
+}
+
+/**
+ * Common shape for block action handlers (button clicks, menu selections
+ * within messages or modals).
+ */
+export interface BlockActionContext {
+  ack: AckFn<void>;
+  body: BlockAction;
+  client: WebClient;
+}
+
+// ---------------------------------------------------------------------------
+// Handler result types
+// ---------------------------------------------------------------------------
+
+/**
+ * Standard success result from a YAML-processing handler.
+ * Returned after template processing completes and the document is committed
+ * to GitHub.
+ */
+export interface HandlerSuccessResult {
+  success: true;
+  studyId: number;
+  documentUrl: string;
+  templateId: string;
+}
+
+/**
+ * Standard error result from a handler.
+ * Sent as a DM to the researcher when processing fails.
+ */
+export interface HandlerErrorResult {
+  success: false;
+  error: string;
+  templateId?: string;
+  /** User-facing message (may omit internal details). */
+  userMessage?: string;
+}
+
+export type HandlerResult = HandlerSuccessResult | HandlerErrorResult;
+
+// ---------------------------------------------------------------------------
+// Template contract error
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when a cascade variable contract is violated.
+ * See ADR 0007: cascade contracts fail loudly.
+ *
+ * Handlers catch this and send a DM to the researcher explaining which
+ * upstream template needs to run first.
+ */
+export class TemplateContractError extends Error {
+  constructor(
+    message: string,
+    public readonly templateId?: string,
+    public readonly variableKey?: string,
+    public readonly userMessage?: string,
+  ) {
+    super(message);
+    this.name = 'TemplateContractError';
+  }
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Central type exports for the Qori backend.
+ *
+ * Import from '@/types' for convenience, or from specific files
+ * (e.g., '@/types/cascade') when you need a narrower import.
+ */
+
+export * from './cascade';
+export * from './common';
+export * from './models';
+export * from './handlers';
+export * from './template-processor';

--- a/backend/src/types/models.ts
+++ b/backend/src/types/models.ts
@@ -1,0 +1,387 @@
+/**
+ * Model attribute types for Sequelize models.
+ *
+ * These interfaces describe the shape of each model's attributes as they
+ * appear at the application layer. They will be used as generic parameters
+ * on the Model class when models are migrated to .ts in Phase 3 (ADR 0014).
+ *
+ * Until Phase 3, these serve as reference documentation and are used by
+ * service and handler types to describe what data they expect.
+ *
+ * DECIMAL fields (parsed_budget_amount, compensation_amount) are typed as
+ * string | null because Sequelize returns DECIMAL values as strings.
+ * Phase 3 may add boundary coercion so consumers see numbers. See ADR 0014.
+ */
+
+import type {
+  ParticipantStatus,
+  OutreachMethod,
+  StudyApprovalStatus,
+  ObserverRole,
+  ObserverStatus,
+  ObserverJoinedVia,
+} from './common';
+
+// ---------------------------------------------------------------------------
+// User
+// ---------------------------------------------------------------------------
+
+export interface UserAttributes {
+  id: number;
+  first_name: string;
+  last_name: string | null;
+  email: string | null;
+  phone: string | null;
+  avatar: string | null;
+  is_admin: boolean;
+  password: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface UserCreationAttributes
+  extends Omit<UserAttributes, 'id' | 'created_at' | 'updated_at' | 'is_admin'> {
+  is_admin?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// ChannelConfig
+// ---------------------------------------------------------------------------
+
+export interface ChannelConfigAttributes {
+  id: number;
+  channel_id: string;
+  github_id: string | null;
+  repo_id: string | null;
+  repo: string | null;
+  product_folder_name: string | null;
+  sub_folder_name: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface ChannelConfigCreationAttributes
+  extends Omit<ChannelConfigAttributes, 'id' | 'created_at' | 'updated_at'> {}
+
+// ---------------------------------------------------------------------------
+// ResearchStudy
+// ---------------------------------------------------------------------------
+
+export interface ResearchStudyAttributes {
+  id: number;
+  name: string;
+  channel_name: string;
+  description: string | null;
+  link: string | null;
+  path: string | null;
+  sha4: string | null;
+  created_by: string;
+  researcher_name: string;
+  researcher_email: string;
+  total_participants: number;
+  /** DECIMAL(10,2) — Sequelize returns as string. See ADR 0014. */
+  parsed_budget_amount: string | null;
+  target_participants: number | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface ResearchStudyCreationAttributes
+  extends Omit<ResearchStudyAttributes,
+    'id' | 'created_at' | 'updated_at' | 'total_participants' |
+    'description' | 'link' | 'path' | 'sha4' | 'parsed_budget_amount' | 'target_participants'
+  > {
+  total_participants?: number;
+  description?: string | null;
+  link?: string | null;
+  path?: string | null;
+  sha4?: string | null;
+  parsed_budget_amount?: string | null;
+  target_participants?: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// ResearchStudyUserRole
+// ---------------------------------------------------------------------------
+
+export interface ResearchStudyUserRoleAttributes {
+  id: number;
+  research_id: number;
+  user_id: string;
+  role: string;
+  created_at: Date;
+}
+
+export interface ResearchStudyUserRoleCreationAttributes
+  extends Omit<ResearchStudyUserRoleAttributes, 'id' | 'created_at'> {}
+
+// ---------------------------------------------------------------------------
+// StudyStatus
+// ---------------------------------------------------------------------------
+
+export interface StudyStatusAttributes {
+  id: number;
+  study_name: string | null;
+  approved_by: string | null;
+  requested_by: string | null;
+  reason: string | null;
+  status: StudyApprovalStatus;
+  path: string | null;
+  file_name: string | null;
+  approved_at: Date;
+  updated_at: Date;
+  created_by: string | null;
+}
+
+export interface StudyStatusCreationAttributes
+  extends Omit<StudyStatusAttributes, 'id' | 'approved_at' | 'updated_at' | 'status'> {
+  status?: StudyApprovalStatus;
+}
+
+// ---------------------------------------------------------------------------
+// StudyParticipant
+// ---------------------------------------------------------------------------
+
+export interface StudyParticipantAttributes {
+  id: number;
+  study_id: number;
+  participant_name: string;
+  contact_details: string | null;
+  recruitment_source: string | null;
+  scheduled_date: string | null;
+  scheduled_time: string | null;
+  status_select: ParticipantStatus | null;
+  notes_field: string | null;
+  demographics_info: Record<string, unknown> | null;
+  /** DECIMAL(10,2) — Sequelize returns as string. See ADR 0014. */
+  compensation_amount: string | null;
+  outreach_sent_at: Date | null;
+  outreach_method: OutreachMethod | null;
+  outreach_count: number;
+  added_by: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface StudyParticipantCreationAttributes
+  extends Omit<StudyParticipantAttributes,
+    'id' | 'created_at' | 'updated_at' | 'outreach_count' |
+    'contact_details' | 'recruitment_source' | 'scheduled_date' | 'scheduled_time' |
+    'status_select' | 'notes_field' | 'demographics_info' | 'compensation_amount' |
+    'outreach_sent_at' | 'outreach_method'
+  > {
+  outreach_count?: number;
+  contact_details?: string | null;
+  recruitment_source?: string | null;
+  scheduled_date?: string | null;
+  scheduled_time?: string | null;
+  status_select?: ParticipantStatus | null;
+  notes_field?: string | null;
+  demographics_info?: Record<string, unknown> | null;
+  compensation_amount?: string | null;
+  outreach_sent_at?: Date | null;
+  outreach_method?: OutreachMethod | null;
+}
+
+// ---------------------------------------------------------------------------
+// SessionObserver
+// ---------------------------------------------------------------------------
+
+export interface SessionObserverAttributes {
+  id: number;
+  study_id: number;
+  participant_id: number | null;
+  session_id: string;
+  /** JSONB array of Slack user IDs. Custom getter ensures always array. */
+  requester_id: string[];
+  /** JSONB array of display names. Custom getter ensures always array. */
+  requester_name: string[];
+  role: ObserverRole;
+  reason: string | null;
+  status: ObserverStatus;
+  joined_via: ObserverJoinedVia | null;
+  approved_by: string | null;
+  approved_at: Date | null;
+  guidelines_sent: boolean;
+  guidelines_sent_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface SessionObserverCreationAttributes
+  extends Omit<SessionObserverAttributes,
+    'id' | 'created_at' | 'updated_at' | 'status' | 'guidelines_sent' |
+    'participant_id' | 'reason' | 'joined_via' | 'approved_by' | 'approved_at' | 'guidelines_sent_at'
+  > {
+  status?: ObserverStatus;
+  guidelines_sent?: boolean;
+  participant_id?: number | null;
+  reason?: string | null;
+  joined_via?: ObserverJoinedVia | null;
+  approved_by?: string | null;
+  approved_at?: Date | null;
+  guidelines_sent_at?: Date | null;
+}
+
+// ---------------------------------------------------------------------------
+// StudyNotes
+// ---------------------------------------------------------------------------
+
+export interface StudyNotesAttributes {
+  id: number;
+  study_id: number;
+  study_name: string;
+  filename: string;
+  file_path: string | null;
+  file_url: string | null;
+  transcript: boolean;
+  session_date: string | null;
+  session_time: string | null;
+  participant_name: string | null;
+  researcher: string | null;
+  created_at: Date;
+  updated_at: Date;
+  created_by: string;
+}
+
+export interface StudyNotesCreationAttributes
+  extends Omit<StudyNotesAttributes,
+    'id' | 'created_at' | 'updated_at' | 'transcript' |
+    'file_path' | 'file_url' | 'session_date' | 'session_time' | 'participant_name' | 'researcher'
+  > {
+  transcript?: boolean;
+  file_path?: string | null;
+  file_url?: string | null;
+  session_date?: string | null;
+  session_time?: string | null;
+  participant_name?: string | null;
+  researcher?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// ResearchPlan
+// ---------------------------------------------------------------------------
+
+export interface ResearchPlanAttributes {
+  id: number;
+  study_id: number;
+  study_name: string;
+  filename: string;
+  file_path: string | null;
+  file_url: string | null;
+  created_at: Date;
+  updated_at: Date;
+  created_by: string;
+}
+
+export interface ResearchPlanCreationAttributes
+  extends Omit<ResearchPlanAttributes, 'id' | 'created_at' | 'updated_at' | 'file_path' | 'file_url'> {
+  file_path?: string | null;
+  file_url?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// SessionSummary
+// ---------------------------------------------------------------------------
+
+export interface SessionSummaryAttributes {
+  id: number;
+  study_id: number;
+  study_name: string;
+  filename: string;
+  file_path: string | null;
+  file_url: string | null;
+  created_at: Date;
+  updated_at: Date;
+  created_by: string;
+}
+
+export interface SessionSummaryCreationAttributes
+  extends Omit<SessionSummaryAttributes, 'id' | 'created_at' | 'updated_at' | 'file_path' | 'file_url'> {
+  file_path?: string | null;
+  file_url?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// StudyVariable
+// ---------------------------------------------------------------------------
+
+export interface StudyVariableAttributes {
+  id: number;
+  study_name: string;
+  variable_key: string;
+  variable_type: string | null;
+  item_key: string | null;
+  value: unknown;
+  participant_id: string | null;
+  source_template: string;
+  source_version: string | null;
+  source_date: Date | null;
+  value_hash: string | null;
+  entry_count: number | null;
+  is_pool: boolean;
+  confidence: string | null;
+  scope: string | null;
+  discovery_artifact_id: string | null;
+  stale: boolean;
+  extracted_at: Date;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface StudyVariableCreationAttributes
+  extends Omit<StudyVariableAttributes,
+    'id' | 'created_at' | 'updated_at' | 'extracted_at' | 'is_pool' | 'stale' |
+    'variable_type' | 'item_key' | 'participant_id' | 'source_version' | 'source_date' |
+    'value_hash' | 'entry_count' | 'confidence' | 'scope' | 'discovery_artifact_id'
+  > {
+  is_pool?: boolean;
+  stale?: boolean;
+  extracted_at?: Date;
+  variable_type?: string | null;
+  item_key?: string | null;
+  participant_id?: string | null;
+  source_version?: string | null;
+  source_date?: Date | null;
+  value_hash?: string | null;
+  entry_count?: number | null;
+  confidence?: string | null;
+  scope?: string | null;
+  discovery_artifact_id?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// CreatedIssue
+// ---------------------------------------------------------------------------
+
+export interface CreatedIssueAttributes {
+  id: number;
+  study_name: string;
+  audience: string;
+  ticket_id: string;
+  github_issue_number: number;
+  github_url: string;
+  github_repo: string;
+  created_by: string;
+  created_at: Date;
+}
+
+export interface CreatedIssueCreationAttributes
+  extends Omit<CreatedIssueAttributes, 'id' | 'created_at'> {}
+
+// ---------------------------------------------------------------------------
+// SlackUserState
+// ---------------------------------------------------------------------------
+
+export interface SlackUserStateAttributes {
+  slack_user_id: string;
+  active_study_id: number | null;
+  onboarded_at: Date | null;
+  updated_at: Date;
+}
+
+export interface SlackUserStateCreationAttributes
+  extends Omit<SlackUserStateAttributes, 'updated_at' | 'active_study_id' | 'onboarded_at'> {
+  active_study_id?: number | null;
+  onboarded_at?: Date | null;
+}

--- a/backend/src/types/template-processor.ts
+++ b/backend/src/types/template-processor.ts
@@ -1,0 +1,142 @@
+/**
+ * Types for the YAML template processor pipeline.
+ *
+ * The processor (yamlProcessor.js) takes a template ID, input data, and
+ * study context, then: (1) fetches the YAML config from GitHub, (2) runs
+ * chained AI generation tasks, (3) renders the output template with Handlebars,
+ * (4) optionally extracts cascade variables from the rendered output.
+ *
+ * Types here describe the processor's inputs and outputs. The `inputs` field
+ * is intentionally `Record<string, unknown>` — Phase 2 doesn't lock down
+ * per-template input shapes. Phase 4 (handler migration) tightens this on
+ * a per-handler basis.
+ *
+ * See ADR 0005 (Handlebars template architecture), ADR 0006 (transform on
+ * consume), ADR 0012 (structured JSON for LLM outputs).
+ */
+
+import type { CascadeVariableKey } from './cascade';
+
+// ---------------------------------------------------------------------------
+// YAML config shape (parsed from the YAML template files)
+// ---------------------------------------------------------------------------
+
+/** A single AI generation task in the YAML template's ai_generation_tasks array. */
+export interface AiGenerationTask {
+  task_id: string;
+  prompt: string;
+  /** Dead config — parsed but never read. See CLAUDE.md "Model resolution." */
+  llm_config?: {
+    model?: string;
+    temperature?: number;
+    max_tokens?: number;
+  };
+  depends_on?: string[];
+}
+
+/** An input variable declared in the YAML template. */
+export interface YamlInputVariable {
+  name: string;
+  type: 'string' | 'text' | 'select' | 'multiselect' | 'number' | 'date' | 'file_content';
+  required?: boolean;
+  default?: string;
+  description?: string;
+}
+
+/** A variable emitted by the YAML template after processing. */
+export interface YamlEmitDeclaration {
+  key: string;
+  schema?: string;
+  pool?: boolean;
+  pool_strategy?: 'append' | 'replace' | 'append_or_replace_per_participant';
+  extract_from?: string;
+  extraction_model?: 'haiku' | 'sonnet';
+  description?: string;
+}
+
+/** An upstream variable consumed by the YAML template. */
+export interface YamlConsumeDeclaration {
+  key: CascadeVariableKey | string;
+  source: string;
+  required: boolean;
+  inject_as?: 'grounding' | 'context' | 'reference';
+  description?: string;
+}
+
+/** The full parsed YAML template configuration. */
+export interface YamlTemplateConfig {
+  id: string;
+  name: string;
+  version?: string;
+  description?: string;
+  discovery_scope?: boolean;
+  input_variables: YamlInputVariable[];
+  ai_generation_tasks: AiGenerationTask[];
+  output_template: string;
+  emits?: YamlEmitDeclaration[];
+  consumes?: YamlConsumeDeclaration[];
+}
+
+// ---------------------------------------------------------------------------
+// Processor inputs and outputs
+// ---------------------------------------------------------------------------
+
+/**
+ * Input to processYamlTemplate. This is the data the handler passes to the
+ * processor after collecting modal submission values.
+ *
+ * The `inputs` field is loosely typed because each template expects different
+ * fields. Phase 4 handler migration will define per-handler input types that
+ * narrow this.
+ */
+export interface ProcessYamlTemplateInput {
+  /** Which YAML template to process (e.g., "research_plan", "research_brief"). */
+  templateId: string;
+  /** The study this template is being processed for. */
+  studyName: string;
+  /** The study's GitHub path (e.g., "friends-lab/study-name"). */
+  studyPath: string;
+  /** Input values from the modal submission. */
+  inputs: Record<string, unknown>;
+  /** Slack user ID of the researcher running the command. */
+  userId: string;
+}
+
+/**
+ * Result of processing a YAML template.
+ */
+export interface ProcessYamlTemplateResult {
+  success: boolean;
+  /** The rendered markdown document. */
+  rendered?: string;
+  /** GitHub URL of the committed document. */
+  documentUrl?: string;
+  /** Error message if processing failed. */
+  error?: string;
+  /** Number of cascade variables extracted and stored. */
+  variableCount?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Variable extraction types
+// ---------------------------------------------------------------------------
+
+/**
+ * Result from the variable extraction phase.
+ * Maps variable keys to their extracted values (shaped per the YAML schema).
+ */
+export type ExtractionResult = Record<string, unknown>;
+
+/**
+ * A single variable merge operation ready to be applied to the database.
+ */
+export interface VariableMergeOperation {
+  variable_key: string;
+  value: unknown;
+  item_key?: string;
+  participant_id?: string;
+  is_pool: boolean;
+  pool_strategy?: 'append' | 'replace' | 'append_or_replace_per_participant';
+  source_template: string;
+  source_version?: string;
+}

--- a/docs/architecture-decisions/0014-sequelize-typescript-pattern.md
+++ b/docs/architecture-decisions/0014-sequelize-typescript-pattern.md
@@ -1,0 +1,65 @@
+# ADR 0014: Use Sequelize v6 built-in TypeScript generics for model typing
+
+**Status:** Accepted  
+**Date:** 2026-05-13  
+**Decision drivers:** Phase 2 of the TypeScript migration (ADR 0013) requires choosing how Sequelize models get typed. The choice locks in conventions for all 13 models and affects every service and handler that touches the database. Three patterns were evaluated; this ADR documents the chosen approach.
+
+## Context
+
+The codebase has 13 Sequelize v6 models, all using `Class extends Model` with `Model.init()` factory functions. The TypeScript migration needs to add type safety to model attributes so that:
+
+- Handlers cannot access fields a service didn't return (the attribute-whitelist bug class from ADR L001)
+- Service return types accurately reflect what's queried
+- JSONB field shapes are explicit at the type level
+- Instance methods have typed signatures
+
+Three patterns exist for typing Sequelize v6 models. Full evaluation with code examples is in `docs/typescript-sequelize-pattern-proposal.md`.
+
+## Decision
+
+Use Sequelize v6's built-in TypeScript generics: `InferAttributes`, `InferCreationAttributes`, `CreationOptional`, `NonAttribute`, and `ForeignKey`. These ship with Sequelize itself (available since v6.14.0, present in our v6.37.7).
+
+The primary reason is **lowest disruption with real type safety today.** The `Model.init()` calls stay identical. The factory export pattern stays unchanged. What gets added: `declare` property declarations above init, generic type parameters on `extends Model<...>`, and association mixin declarations. This gives us compile-time enforcement of model attributes without rewriting the model layer.
+
+The v7 forward path is a genuine secondary benefit — Sequelize v7 keeps the same generic pattern and adds optional decorators on top — but it is not the lead argument. We are choosing this pattern because it works for our v6 codebase today.
+
+## Alternatives considered
+
+**sequelize-typescript decorators.** Replaces `Model.init()` with `@Table`, `@Column` decorators. Most TypeScript-native feel, but requires a full model rewrite — the factory pattern is incompatible. The library has 231 open issues, and Sequelize v7 built its own decorator system from scratch rather than absorbing it. Rejected: too disruptive, dead-end library.
+
+**Manual interfaces alongside existing models.** Keep all `.js` model files, create parallel TypeScript interfaces in a `types/` directory. Zero model changes, but the interface and the `Model.init()` call can drift out of sync — which is the exact class of bug we're migrating to prevent. Rejected: adds types without adding safety.
+
+## Consequences
+
+**Intended:**
+
+- Model attributes are compile-time enforced. A handler accessing `study.parsed_budget_amount` when the service used an `attributes:` whitelist that excluded it will fail compilation.
+- JSONB fields have explicit TypeScript shapes. The runtime data is `DataTypes.JSONB`; the compile-time type is the actual interface.
+- Instance methods have typed signatures (`recordOutreachSent(method: 'email' | 'slack' | 'phone' | 'other')`).
+- Association mixins provide typed return values (`getParticipants(): Promise<StudyParticipant[]>`).
+
+**Accepted costs:**
+
+- **Mixin declaration verbosity.** Every association requires manual mixin declarations (`HasManyGetAssociationsMixin<T>`, `HasManyAddAssociationMixin<T, number>`, etc.). For ResearchStudy with 5 `hasMany` associations, this is ~15-20 lines of declarations. The migrated models read more verbosely than the current JavaScript versions. This is the main ergonomic cost and we accept it as the price of typed associations.
+
+- **DECIMAL fields return strings.** Sequelize's `DECIMAL(10,2)` type (`parsed_budget_amount`, `compensation_amount`) returns JavaScript strings, not numbers. The TypeScript type will be `string | null`, which is accurate to Sequelize's actual behavior but surprising to consumers expecting numbers. When Phase 3 migrates the service layer, we may need boundary coercion (e.g., `parseFloat` at the service return boundary) so consumers see numbers consistently. Phase 3 should address this per-field rather than inventing a blanket pattern now.
+
+- **~15-20 lines of `declare` statements per model.** For 13 models, roughly 200-250 lines of type declarations total. This is one-time work that permanently closes the attribute-whitelist bug class.
+
+**Patterns requiring special handling in Phase 3:**
+
+- SessionObserver custom getters on JSONB array fields — use `NonAttribute` for getter return types
+- User hooks (beforeSave, afterCreate, afterDestroy) — remain in init config, `this` is typed by model generics
+- SlackUserState non-standard PK (`slack_user_id: string`) — declare without `CreationOptional`
+- DECIMAL fields — type as `string | null`, add boundary coercion in Phase 3 if needed
+
+## When to revisit
+
+- If Sequelize v7 migration happens, evaluate whether the new decorator support changes the ergonomics enough to adopt decorators. The generic pattern carries forward regardless.
+- If the mixin verbosity becomes a significant maintenance burden across 13+ models, consider generating mixin declarations from model definitions (tooling, not pattern change).
+
+## References
+
+- Full evaluation with code examples: `docs/typescript-sequelize-pattern-proposal.md`
+- TypeScript migration decision: ADR 0013, `docs/typescript-migration-plan.md`
+- Attribute whitelist bug that motivates typed models: ADR L001

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -86,6 +86,7 @@ Start with `0001` and read forward. The history is itself useful — it shows ho
 - [0010 — YAML-processing handlers live in commands/](./0010-handlers-in-commands-directory.md) — events.js is a registration manifest
 - [0011 — Hardcoded Qori-style timeline durations](./0011-hardcoded-timeline-durations.md) — Alpha-only; revisit when we have signal
 - [0012 — LLM emits structured JSON when output is a table or list](./0012-structured-json-for-llm-outputs.md) — Constrained shape can't drift through paraphrasing
+- [0014 — Sequelize v6 built-in TypeScript generics for model typing](./0014-sequelize-typescript-pattern.md) — Lowest disruption with real type safety; no new dependencies
 
 ### Lessons (informal ADRs from failure modes)
 

--- a/docs/typescript-sequelize-pattern-proposal.md
+++ b/docs/typescript-sequelize-pattern-proposal.md
@@ -1,0 +1,266 @@
+# Sequelize TypeScript Pattern Proposal
+
+**Date:** 2026-05-13  
+**Status:** Awaiting owner review  
+**Context:** Phase 2 of the TypeScript migration (ADR 0013). This decision affects how all 13 models get typed in Phase 3.
+
+---
+
+## Current state
+
+All 13 models use the same pattern: factory functions exporting a `Class extends Model` with `Model.init()`, CommonJS modules, manual timestamp management. The codebase uses Sequelize v6 (package.json says `^6.20.1`, lockfile resolves to `6.37.7`).
+
+Key patterns to accommodate:
+- **Associations:** 5 `hasMany` on ResearchStudy, 6 `belongsTo` on child models
+- **JSONB fields:** `StudyVariable.value`, `SessionObserver.requester_id/requester_name`
+- **Custom getters:** SessionObserver has array-coercion getters on JSONB fields
+- **Instance methods:** `StudyParticipant.recordOutreachSent()`, `User.generateToken/validatePassword/sendMail`
+- **Validators:** `isIn` on StudyParticipant's `status_select` and `outreach_method`
+- **ENUM types:** SessionObserver uses `DataTypes.ENUM`, StudyStatus uses `DataTypes.ENUM`
+- **Non-standard PK:** SlackUserState uses `slack_user_id` (STRING) instead of auto-increment integer
+
+---
+
+## Options evaluated
+
+### Option 1: `sequelize-typescript` decorators
+
+Replaces `Model.init()` with `@Table`, `@Column`, `@HasMany` decorators. Requires `reflect-metadata` and `experimentalDecorators`.
+
+**Pros:**
+- Most "TypeScript-native" feel — decorators infer column types
+- Associations are expressed as decorators, automatically typed
+
+**Cons:**
+- **Full model rewrite.** Every `Model.init()` call must be converted to decorator syntax. The factory pattern (`module.exports = (sequelize) => {}`) is incompatible — `sequelize-typescript` uses `sequelize.addModels([])` instead.
+- **Dead-end library.** Sequelize v7 built its own decorator system from scratch rather than absorbing this package. 231 open issues, slowing release cadence. Using it ties us to a library with no forward path.
+- **New dependency** (`sequelize-typescript` + `reflect-metadata`) for a migration whose goal is type safety, not framework changes.
+
+**Verdict:** Rejected. Too disruptive, and the library has no future past v6.
+
+### Option 2: Manual interfaces alongside existing models
+
+Keep all `.js` model files unchanged. Create parallel TypeScript interfaces in `types/models.ts`. Consumers import the interface for compile-time checking.
+
+**Pros:**
+- **Zero model changes.** Interface files are purely additive.
+- **No library dependency.**
+- **Lowest risk.** Can't break anything since runtime code is untouched.
+
+**Cons:**
+- **Synchronization burden.** The interface and the `Model.init()` call can drift — adding a column to `.init()` without updating the interface, or vice versa. This is the exact class of bug we're migrating to prevent.
+- **Association typing is manual boilerplate.** Every association mixin (`getParticipants`, `addParticipant`, etc.) must be hand-declared.
+- **Models stay `.js` forever.** Since the interface is separate, there's no natural migration path to typed model files. We'd be creating a parallel system rather than migrating.
+- **Lowest type safety.** TypeScript can't verify that the interface matches reality.
+
+**Verdict:** Too weak. It adds types without adding safety. The synchronization problem is the same class of bug we're trying to eliminate.
+
+### Option 3: Sequelize v6 built-in TypeScript generics (recommended)
+
+Uses generic type parameters on `Model` plus utility types that ship with Sequelize itself: `InferAttributes`, `InferCreationAttributes`, `CreationOptional`, `NonAttribute`, `ForeignKey`.
+
+**Pros:**
+- **`Model.init()` stays identical.** The init config object doesn't change. What changes: `declare` property declarations above init, generic params on `extends Model<...>`.
+- **No new dependencies.** These types ship with Sequelize v6.14+. Already available in our v6.37.7.
+- **Best v7 migration path.** Sequelize v7 keeps the same generic pattern and adds optional decorators on top. This approach carries forward cleanly.
+- **Real type enforcement.** `InferAttributes` derives the type from the `declare` statements. If a `declare` doesn't exist for a column, it won't be in the type. If a handler accesses a field that doesn't exist on the type, it fails compilation.
+- **Association mixins are typed.** `HasManyGetAssociationsMixin<StudyParticipant>` etc. — verbose but correct.
+
+**Cons:**
+- **Moderate migration effort.** Each model file gets ~15-20 lines of `declare` statements added. Still, the init call and association setup are untouched.
+- **Mixin declarations are boilerplate.** For a model with 5 `hasMany` associations (ResearchStudy), you need ~15-20 lines of mixin declarations. This is the main papercut.
+- **Models must be `.ts` files.** The `declare` syntax doesn't work in `.js`. This means Phase 3 migrates model files to `.ts` as part of the service migration.
+
+**Verdict:** Best balance of safety, effort, and forward compatibility.
+
+---
+
+## Concrete example: StudyParticipant
+
+### Current code (JavaScript)
+
+```javascript
+module.exports = (sequelize) => {
+  class StudyParticipant extends Model {
+    static associate(models) {
+      this.belongsTo(models.ResearchStudy, {
+        foreignKey: "study_id",
+        as: "study",
+        onDelete: "CASCADE",
+      });
+    }
+
+    async recordOutreachSent(method = 'email') {
+      this.outreach_sent_at = new Date();
+      this.outreach_method = method;
+      this.outreach_count = (this.outreach_count || 0) + 1;
+      this.updated_at = new Date();
+      if (this.status_select === PARTICIPANT_STATUS.NOT_CONTACTED) {
+        this.status_select = PARTICIPANT_STATUS.CONTACTED;
+      }
+      await this.save();
+    }
+  }
+
+  StudyParticipant.init({ /* ... columns ... */ }, { sequelize });
+  return StudyParticipant;
+};
+```
+
+### Option 2 (manual interfaces) — what it would look like
+
+```typescript
+// types/models.ts — separate file, model stays .js
+export interface StudyParticipantAttributes {
+  id: number;
+  study_id: number;
+  participant_name: string;
+  contact_details: string | null;
+  status_select: ParticipantStatus | null;
+  outreach_sent_at: Date | null;
+  outreach_method: 'email' | 'slack' | 'phone' | 'other' | null;
+  outreach_count: number;
+  // ... every column
+}
+
+// Consumer has to cast:
+const p = await StudyParticipant.findByPk(id) as StudyParticipantAttributes;
+```
+
+The model file stays `.js`. The interface is a separate assertion that can drift from reality.
+
+### Option 3 (built-in generics) — what it would look like
+
+```typescript
+// models/study_participant.ts — model file itself becomes .ts
+
+import {
+  Model, DataTypes, ForeignKey, NonAttribute,
+  InferAttributes, InferCreationAttributes, CreationOptional,
+  BelongsToGetAssociationMixin,
+} from 'sequelize';
+import type { Sequelize } from 'sequelize';
+import type { ResearchStudy } from './research_study';
+import {
+  PARTICIPANT_STATUS, PARTICIPANT_STATUS_VALUES,
+  type ParticipantStatus,
+} from '../../constants/participantStatus';
+
+export default (sequelize: Sequelize) => {
+  class StudyParticipant extends Model<
+    InferAttributes<StudyParticipant>,
+    InferCreationAttributes<StudyParticipant>
+  > {
+    // — Attributes —
+    declare id: CreationOptional<number>;
+    declare study_id: ForeignKey<number>;
+    declare participant_name: string;
+    declare contact_details: string | null;
+    declare recruitment_source: string | null;
+    declare scheduled_date: string | null;
+    declare scheduled_time: string | null;
+    declare status_select: ParticipantStatus | null;
+    declare notes_field: string | null;
+    declare demographics_info: Record<string, unknown> | null;
+    declare compensation_amount: number | null;
+    declare outreach_sent_at: Date | null;
+    declare outreach_method: 'email' | 'slack' | 'phone' | 'other' | null;
+    declare outreach_count: CreationOptional<number>;
+    declare added_by: string;
+    declare created_at: CreationOptional<Date>;
+    declare updated_at: CreationOptional<Date>;
+
+    // — Association mixins —
+    declare getStudy: BelongsToGetAssociationMixin<ResearchStudy>;
+    declare study?: NonAttribute<ResearchStudy>;
+
+    // — Associations —
+    static associate(models: Record<string, typeof Model>) {
+      this.belongsTo(models.ResearchStudy, {
+        foreignKey: 'study_id',
+        as: 'study',
+        onDelete: 'CASCADE',
+      });
+    }
+
+    // — Instance methods —
+    async recordOutreachSent(method: 'email' | 'slack' | 'phone' | 'other' = 'email') {
+      this.outreach_sent_at = new Date();
+      this.outreach_method = method;
+      this.outreach_count = (this.outreach_count || 0) + 1;
+      this.updated_at = new Date();
+      if (this.status_select === PARTICIPANT_STATUS.NOT_CONTACTED) {
+        this.status_select = PARTICIPANT_STATUS.CONTACTED;
+      }
+      await this.save();
+    }
+  }
+
+  StudyParticipant.init(
+    {
+      // ... identical init call as today ...
+    },
+    {
+      tableName: 'study_participants',
+      underscored: true,
+      timestamps: false,
+      sequelize,
+    }
+  );
+
+  return StudyParticipant;
+};
+```
+
+**What changed from the current code:**
+1. Generic params added to `extends Model<...>`
+2. `declare` statements above init — these are the type definitions
+3. Association mixin declaration (`getStudy`)
+4. Instance method parameter gets a type annotation
+5. File is `.ts` instead of `.js`
+
+**What did NOT change:**
+- The `Model.init()` call (identical columns, config)
+- The `static associate()` method (same logic)
+- The factory export pattern
+- The `recordOutreachSent` logic
+
+---
+
+## Patterns that need special handling
+
+1. **SessionObserver custom getters.** The JSONB array fields with custom `get()` functions that coerce null → `[]`. These would use `NonAttribute` for the getter return type and `declare` the underlying field as `unknown[] | null`. Workable but needs care.
+
+2. **User hooks (beforeSave, afterCreate, afterDestroy).** Hooks remain in the init config, untyped. The hook bodies reference `this` which will be typed by the model generics. Should work without issues.
+
+3. **SlackUserState non-standard PK.** Uses `slack_user_id: STRING` as PK instead of auto-increment `id`. The `declare` pattern handles this — just declare `slack_user_id: string` without `CreationOptional`.
+
+4. **DECIMAL fields.** `parsed_budget_amount` and `compensation_amount` are `DECIMAL(10,2)`. Sequelize returns these as strings in some contexts, numbers in others. The type should be `string | null` (Sequelize's actual behavior for DECIMAL) with a note about this footgun.
+
+---
+
+## Recommendation
+
+**Use Sequelize v6 built-in TypeScript generics (Option 3).** 
+
+- No new dependencies
+- `Model.init()` calls stay unchanged
+- Forward-compatible with Sequelize v7
+- Provides real compile-time enforcement of model attributes
+- Moderate, predictable migration effort per model file
+
+The main cost is ~15-20 lines of `declare` statements per model. For 13 models, that's ~200-250 lines of type declarations total — a one-time investment that permanently closes the attribute-whitelist bug class.
+
+---
+
+## Status
+
+**Approved 2026-05-13.** Owner approved Option 3. ADR 0014 filed. Phase 2 Part B (type definitions) completed same day.
+
+Type files created:
+- `backend/src/types/cascade.ts` — 38 interfaces covering all cascade variables
+- `backend/src/types/common.ts` — branded IDs, shared enums
+- `backend/src/types/models.ts` — 13 model attribute + creation interfaces
+- `backend/src/types/handlers.ts` — shared handler context types, TemplateContractError
+- `backend/src/types/template-processor.ts` — YAML processor I/O types
+- `backend/src/types/index.ts` — barrel export


### PR DESCRIPTION
## Summary

- Defines TypeScript interfaces for every cascade variable, model, handler context, and template processor type
- Chooses Sequelize v6 built-in generics (ADR 0014) — lowest disruption, real type safety, no new dependencies
- No runtime changes — all types are compile-time only

### Type files (1,709 lines)
- `types/cascade.ts` — 38 interfaces covering all cascade variables across discovery, planning, session, and synthesis phases
- `types/models.ts` — attribute + creation interfaces for all 13 Sequelize models
- `types/handlers.ts` — shared Slack handler context types
- `types/template-processor.ts` — YAML processor pipeline I/O types
- `types/common.ts` — branded IDs, shared enums

### Decision docs
- ADR 0014: Sequelize v6 built-in TypeScript generics
- Sequelize pattern proposal with concrete code examples

## Test plan

- [x] `npm run typecheck` passes with zero errors
- [x] `npm test` passes (24/24)
- [ ] CI passes on this PR
- [ ] Owner reviews type definitions for domain accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)