### PR TITLE
fix: Dockerfile — enable build step for TypeScript

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ docker-compose up    # Starts app (3000), postgres (5432), redis (6379)
 
 3. **Postgres public URL for migrations.** Railway's internal Postgres hostname (`postgres.railway.internal`) only resolves inside the private network. To run `npx sequelize-cli db:migrate` from your local machine or via `railway run`, use the **public** connection URL (with `DATABASE_PUBLIC_URL` fields) from the Postgres service's Connect tab (it has a `railway.app` hostname and a mapped port). The internal URL works for the backend service at runtime since it's on the same private network.
 
-**Start command:** Railway's Custom Start Command is `npm run build && npm start`. This compiles `src/` → `dist/` via Babel (handling both `.js` and `.ts` files), then runs `node ./dist/bin/www.js`. Do **not** use `npm run prod` (runs raw source, can't load `.ts` files). Do **not** put the build in Pre-deploy Command — Railway runs pre-deploy in a separate ephemeral container whose filesystem doesn't persist to the start container.
+**Start command:** Railway uses a Dockerfile (`backend/Dockerfile`) which runs `npm run build` during image creation and `node ./dist/app.js` at runtime. Clear the Custom Start Command in Railway's UI — the Dockerfile CMD handles it. Do **not** use `npm run prod` (runs raw source, can't load `.ts` files). Do **not** use `npm start` (`dist/bin/www.js` has broken relative paths).
 
 **Deploy flow:** Push to `main` → Railway auto-deploys. GitHub Actions CI runs typecheck + tests on every PR.
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,8 +15,8 @@ RUN npm ci --legacy-peer-deps
 # Copy application code
 COPY . .
 
-# Build the project (if using babel - currently not needed)
-# RUN npm run build
+# Build the project (Babel compiles .js and .ts from src/ to dist/)
+RUN npm run build
 
 # Expose port
 EXPOSE 3000
@@ -28,5 +28,5 @@ ENV NODE_ENV=production
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
   CMD node -e "require('http').get('http://localhost:3000/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})" || exit 1
 
-# Use the prod script which includes module-alias
-CMD ["npm", "run", "prod"]
+# Run the compiled app
+CMD ["node", "./dist/app.js"]


### PR DESCRIPTION
## Summary

The Dockerfile had `RUN npm run build` commented out and used `npm run prod` (runs from raw source). Since the codebase now has `.ts` files, Babel must compile `src/` → `dist/` during Docker image creation.

- Uncomments `RUN npm run build`
- Changes CMD from `npm run prod` to `node ./dist/app.js`
- Updates CLAUDE.md with correct Railway deployment instructions

**Action required:** Clear the Custom Start Command in Railway's UI (leave it blank). The Dockerfile CMD handles startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)