### PR TITLE
chore: force Docker rebuild

### DIFF
--- a/backend/.dockertrigger
+++ b/backend/.dockertrigger
@@ -1,0 +1,1 @@
+# Force Docker rebuild - Thu May 14 11:45:30 CDT 2026


### PR DESCRIPTION
Forces Docker cache invalidation. The COPY layer was cached and not picking up events.ts changes from PR #109.