### PR TITLE
fix: /qori-plan modal launch + notification failures

### DIFF
--- a/backend/.dockertrigger
+++ b/backend/.dockertrigger
@@ -1,1 +1,2 @@
 # Force Docker rebuild - Thu May 14 11:45:30 CDT 2026
+Thu May 14 11:59:21 CDT 2026

--- a/backend/src/helpers/slack/ui/studySetupModal.js
+++ b/backend/src/helpers/slack/ui/studySetupModal.js
@@ -1,195 +1,195 @@
 /* eslint-disable max-len */
 /* eslint-disable quotes */
 
-// Modal for /plan-study command
-const studySetupModalPlanStudy = {
-  type: "modal",
-  callback_id: "plan_study_modal",
-  title: {
-    type: "plain_text",
-    text: "Plan your study",
-  },
-  submit: {
-    type: "plain_text",
-    text: "Done",
-  },
-  close: {
-    type: "plain_text",
-    text: "Close",
-  },
-  blocks: [
-    {
-      type: "context",
-      elements: [
-        {
-          type: "mrkdwn",
-          text: "Select a study, then create documents or upload files. Start a new study with `/qori-brief`.",
-        },
-      ],
+// Modal builder for /qori-plan command
+function studySetupModalPlanStudy(studies, channelId) {
+  const studyOptions = studies && studies.length > 0
+    ? studies.map((s) => ({
+        text: { type: "plain_text", text: s.name.substring(0, 75) },
+        value: String(s.id),
+      }))
+    : [{ text: { type: "plain_text", text: "No studies yet — use /qori-brief" }, value: "none" }];
+
+  return {
+    type: "modal",
+    callback_id: "plan_study_modal",
+    private_metadata: JSON.stringify({ channel_id: channelId }),
+    title: {
+      type: "plain_text",
+      text: "Plan your study",
     },
-    {
-      type: "divider",
+    submit: {
+      type: "plain_text",
+      text: "Done",
     },
-    {
-      type: "input",
-      block_id: "study_selection",
-      label: {
-        type: "plain_text",
-        text: "Study",
-      },
-      element: {
-        type: "static_select",
-        action_id: "study_select",
-        placeholder: {
-          type: "plain_text",
-          text: "Select a study...",
-        },
-        options: [
+    close: {
+      type: "plain_text",
+      text: "Close",
+    },
+    blocks: [
+      {
+        type: "context",
+        elements: [
           {
-            text: {
-              type: "plain_text",
-              text: "Loading studies...",
-            },
-            value: "loading",
+            type: "mrkdwn",
+            text: "Select a study, then create documents or upload files. Start a new study with `/qori-brief`.",
           },
         ],
       },
-    },
-    {
-      type: "divider",
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Create Documents*",
+      {
+        type: "divider",
       },
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Research plan*\nTimeline, logistics, and session design",
-      },
-      accessory: {
-        type: "button",
-        text: {
+      {
+        type: "input",
+        block_id: "study_selection",
+        label: {
           type: "plain_text",
-          text: "Create",
+          text: "Study",
         },
-        action_id: "create_research_plan",
-        value: "research_plan",
+        element: {
+          type: "static_select",
+          action_id: "study_select",
+          placeholder: {
+            type: "plain_text",
+            text: "Select a study...",
+          },
+          options: studyOptions,
+        },
       },
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Discussion guide*\nConversation guide for user research sessions",
+      {
+        type: "divider",
       },
-      accessory: {
-        type: "button",
+      {
+        type: "section",
         text: {
-          type: "plain_text",
-          text: "Create",
-        },
-        action_id: "create_discussion_guide",
-        value: "discussion_guide",
-      },
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Stakeholder interview guide*\nQuestions for PMs, engineers, policy SMEs",
-      },
-      accessory: {
-        type: "button",
-        text: {
-          type: "plain_text",
-          text: "Create",
-        },
-        action_id: "create_stakeholder_guide",
-        value: "stakeholder_guide",
-      },
-    },
-    {
-      type: "divider",
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Upload Files*",
-      },
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Desk research*\nReports, competitive analysis, background docs",
-      },
-      accessory: {
-        type: "button",
-        text: {
-          type: "plain_text",
-          text: "Upload",
-        },
-        action_id: "upload_desk_research",
-        value: "desk_research",
-      },
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Stakeholder notes*\nTranscripts from internal interviews",
-      },
-      accessory: {
-        type: "button",
-        text: {
-          type: "plain_text",
-          text: "Upload",
-        },
-        action_id: "upload_stakeholder_notes",
-        value: "stakeholder_notes",
-      },
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Survey data*\nSurvey exports (CSV, Excel) for synthesis",
-      },
-      accessory: {
-        type: "button",
-        text: {
-          type: "plain_text",
-          text: "Upload",
-        },
-        action_id: "upload_survey_data",
-        value: "survey_data",
-      },
-    },
-    {
-      type: "divider",
-    },
-    {
-      type: "context",
-      elements: [
-        {
           type: "mrkdwn",
-          text: "Upload stakeholder notes to unlock Service Blueprint analysis.",
+          text: "*Create Documents*",
         },
-      ],
-    },
-  ],
-};
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*Research plan*\nTimeline, logistics, and session design",
+        },
+        accessory: {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "Create",
+          },
+          action_id: "create_research_plan",
+          value: "research_plan",
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*Discussion guide*\nConversation guide for user research sessions",
+        },
+        accessory: {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "Create",
+          },
+          action_id: "create_discussion_guide",
+          value: "discussion_guide",
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*Stakeholder interview guide*\nQuestions for PMs, engineers, policy SMEs",
+        },
+        accessory: {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "Create",
+          },
+          action_id: "create_stakeholder_guide",
+          value: "stakeholder_guide",
+        },
+      },
+      {
+        type: "divider",
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*Upload Files*",
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*Desk research*\nReports, competitive analysis, background docs",
+        },
+        accessory: {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "Upload",
+          },
+          action_id: "upload_desk_research",
+          value: "desk_research",
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*Stakeholder notes*\nTranscripts from internal interviews",
+        },
+        accessory: {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "Upload",
+          },
+          action_id: "upload_stakeholder_notes",
+          value: "stakeholder_notes",
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*Survey data*\nSurvey exports (CSV, Excel) for synthesis",
+        },
+        accessory: {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "Upload",
+          },
+          action_id: "upload_survey_data",
+          value: "survey_data",
+        },
+      },
+      {
+        type: "divider",
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "Upload stakeholder notes to unlock Service Blueprint analysis.",
+          },
+        ],
+      },
+    ],
+  };
+}
 
-// Modal for /start-research command (post-study-creation)
+// Aliases for backward compatibility
 const studySetupModalStartResearch = studySetupModalPlanStudy;
-
-// Keep the original for backward compatibility
 const studySetupModal = studySetupModalStartResearch;
 
 module.exports = { studySetupModal, studySetupModalPlanStudy, studySetupModalStartResearch };


### PR DESCRIPTION
## Summary
- **Modal crash:** `studySetupModalPlanStudy` was a static object called as a function — converted to a function that dynamically populates the study dropdown from DB
- **No notification after plan generation:** `userId` was never added to `private_metadata` in the modal opener, and `channelId` was keyed as `channel_id` (underscore) but read as `channelId` (camelCase) — both now passed correctly
- **Silent failures:** Added generic error DM in the global error middleware so users aren't left waiting when unhandled errors occur
- **Dev plan:** Filed modal metadata contract typing as Phase 5 / v1.1 work item

## Commits
1. `fix: convert studySetupModalPlanStudy from static object to function`
2. `fix: pass userId and channelId through plan modal metadata chain`
3. `fix: send generic error DM when unhandled errors leave user waiting`
4. `docs: add modal metadata contracts to Phase 5 pending list`

## Test plan
- [ ] `/qori-plan` opens modal with user's studies in dropdown
- [ ] Select study → Create research plan → submit modal
- [ ] Plan generates to GitHub, success DM ("✅ Research Plan Created") arrives
- [ ] No `created_by cannot be null` errors in Railway logs
- [ ] Intentional failure triggers generic "something went wrong" DM

🤖 Generated with [Claude Code](https://claude.com/claude-code)