### PR TITLE
test: verify error middleware (TEMPORARY — revert after test)

### DIFF
--- a/backend/src/helpers/slack/commands/planHandler.ts
+++ b/backend/src/helpers/slack/commands/planHandler.ts
@@ -141,6 +141,11 @@ interface PlanTemplateInput {
 async function handlePlanSubmission({ ack, body, view, client }: ViewSubmissionContext) {
   await ack();
 
+  // TEMPORARY: Test 1 — verify TemplateContractError middleware delivers DM
+  if (Date.now() > 0) {
+    throw new TemplateContractError('test contract violation', 'research_plan', 'research_objectives', 'This is a test of the cascade contract DM — if you see this, the middleware works.');
+  }
+
   const values = view.state.values;
   const { channelId, studyName: metaStudyName, userId } = JSON.parse(view.private_metadata || '{}');
 


### PR DESCRIPTION
## Purpose
Temporary test to verify TemplateContractError middleware delivers DMs. Will be reverted immediately after verification.

**Do not leave merged.** Revert commit after both tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)