### PR TITLE
fix: remove test throws, keep name-based error check

### DIFF
--- a/backend/src/helpers/slack/commands/planHandler.ts
+++ b/backend/src/helpers/slack/commands/planHandler.ts
@@ -141,11 +141,6 @@ interface PlanTemplateInput {
 async function handlePlanSubmission({ ack, body, view, client }: ViewSubmissionContext) {
   await ack();
 
-  // TEMPORARY: Test 2 — verify generic error DM reaches user
-  if (Date.now() > 0) {
-    throw new Error('test generic error');
-  }
-
   const values = view.state.values;
   const { channelId, studyName: metaStudyName, userId } = JSON.parse(view.private_metadata || '{}');
 


### PR DESCRIPTION
## Summary
Removes temporary test throws from planHandler. The permanent fix remains:
- `instanceof TemplateContractError` → `error.name === 'TemplateContractError'` (Babel class identity fix)
- Bolt error unwrapping via `error.original`

## Verification results (2026-05-14)
- ✅ TemplateContractError → cascade-specific DM with userMessage
- ✅ Generic error → "Something went wrong on our end" DM
- ✅ Happy path → plan generates, success DM arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)