### PR TITLE
fix: /qori-brief modal crash — wrong params + missing await

### DIFF
--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -170,8 +170,14 @@ slackApp.command('/qori', qoriMainCommand);
 slackApp.command('/qori-start', startResearchHandler);
 slackApp.command('/qori-brief', async ({ ack, body, client, command }: any) => {
   await ack();
-  const studies = await getStudiesByUser(command.user_id);
-  const modal = buildBriefEntryModal(studies, command.channel_id);
+  let leadResearcher = '';
+  try {
+    const userInfo = await client.users.info({ user: command.user_id });
+    leadResearcher = userInfo.user?.real_name || userInfo.user?.profile?.display_name || '';
+  } catch (err: any) {
+    console.warn('Could not fetch Slack profile for brief modal:', err.message);
+  }
+  const modal = await buildBriefEntryModal(leadResearcher, command.channel_id);
   await client.views.open({ trigger_id: command.trigger_id, view: modal });
 });
 slackApp.command('/qori-plan', async ({ ack, body, client, command }: any) => {


### PR DESCRIPTION
## Summary
`/qori-brief` was broken by two bugs in the inline handler in events.ts:
1. **Wrong argument:** Passed `studies` array as the `leadResearcher` parameter (should be researcher name string)
2. **Missing await:** `buildBriefEntryModal` is async but wasn't awaited, so `views.open` received a Promise instead of a modal object

Now resolves the researcher name from Slack profile and awaits the modal builder.

## Test plan
- [ ] `/qori-brief` → modal opens with researcher name pre-filled
- [ ] Submit brief → generates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)