### PR TITLE
fix: approval handler import names mismatched exports

### DIFF
--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -33,7 +33,7 @@ const { handlePlanSubmission } = require('./commands/planHandler');
 const { openPlanFromBrief, openStudyFromBrief } = require('./commands/modal-openers/briefToStudyHandler');
 
 // Approval flows
-const { approvePlan, confirmApprovePlan, requestChangesPlan, requestChangesPlanSubmission, approveBrief, confirmApproveBrief, requestChangesBrief, requestChangesBriefSubmission } = require('./commands/approval/approvalFlowHandler');
+const { handleApprovePlan: approvePlan, handleConfirmApprovePlan: confirmApprovePlan, handleRequestChangesPlan: requestChangesPlan, handleRequestChangesPlanModal: requestChangesPlanSubmission, handleApproveBrief: approveBrief, handleConfirmApproveBrief: confirmApproveBrief, handleRequestChangesBrief: requestChangesBrief, handleRequestChangesBriefModal: requestChangesBriefSubmission } = require('./commands/approval/approvalFlowHandler');
 const { handleMarkChangesCompleteAction, handleMarkChangesCompleteModal, handleApproveChanges } = require('./markChangesCompleteHandler');
 
 // Discussion guide


### PR DESCRIPTION
## Summary
Follow-up to #119 — pushed after merge.

events.ts destructured `approvePlan` but the handler exports `handleApprovePlan`. All 8 approval handlers were `undefined`, causing approve/request-changes buttons to silently fail.

## Test plan
- [ ] Click approve_plan from a brief result — approval flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)