### PR TITLE
fix: GithubWebhookService CJS compat — controller uses require()

### DIFF
--- a/backend/src/services/github-webhook.service.ts
+++ b/backend/src/services/github-webhook.service.ts
@@ -137,3 +137,6 @@ class GithubWebhookService {
 }
 
 export default GithubWebhookService;
+
+// CJS compat — controller/route files still use require()
+module.exports = GithubWebhookService;


### PR DESCRIPTION
## Summary
- The TS migration changed `module.exports` to `export default`, which Babel compiles to `exports.default`
- The JS controller still uses `require()` and got `{ default: Class }` instead of the class
- Adds `module.exports` alongside `export default` for CJS consumers

## Test plan
- [ ] CI status check passes
- [ ] Verify webhook controller can require the service without `.default`

🤖 Generated with [Claude Code](https://claude.com/claude-code)