### PR TITLE
fix: brief restructure final polish + discovery table fix

### DIFF
--- a/backend/src/helpers/slack/commands/briefHandler.ts
+++ b/backend/src/helpers/slack/commands/briefHandler.ts
@@ -342,7 +342,7 @@ async function handleBriefSubmission({ ack, body, view, client }: SlackViewMiddl
             const prefix = markerPrefixes[a.type as DiscoveryType] || '?';
             return `| **${prefix}** | ${a.slug} | ${typeLabels[a.type as DiscoveryType] || a.type} | ${a.date} | ${a.variableCount} variables |`;
           })
-          .join('\n  ');
+          .join('\n');
         citationConvention = selectedArtifacts
           .map((a: DiscoveryArtifact) => `[${markerPrefixes[a.type as DiscoveryType] || '?'}N] = ${typeLabels[a.type as DiscoveryType] || a.type} (${a.slug})`)
           .join('; ');

--- a/config/prompts/research_brief.yaml
+++ b/config/prompts/research_brief.yaml
@@ -196,6 +196,12 @@ ai_generation_tasks:
       covers that). Example opening: "This card sorting study with 8
       veterans will reveal..." NOT "The mobile app faces critical..."
 
+      The summary describes what this study WILL DO during its execution.
+      Downstream impacts (informs redesign, supports decision) should be
+      framed as outcomes the study enables, not actions the study performs.
+      Example: "This study will reveal X, informing the Y redesign"
+      NOT "This study will reveal X to redesign Y"
+
       Output ONLY the summary paragraph. No heading, no preamble.
       Bold key metrics from discovery data if available.
 

--- a/docs/product-backlog.md
+++ b/docs/product-backlog.md
@@ -16,11 +16,11 @@ The migration paused template standardization. The plan template (v7.0) is the c
 
 Per the post-migration audit, 26 of 27 templates have no unit tests, and 12 use the older "minimal static + single LLM" pattern instead of the canonical interleaved Handlebars + bounded LLM slots (ADR 0005).
 
-### Brief restructure (first priority)
+### Brief restructure (complete — ADR 0016)
 
-The brief template is upstream of plan. Restructuring brief improves the cascade variables plan consumes. Brief restructure also exposes any contract drift between what brief emits and what downstream templates expect.
+Restructured to v7.0 interleaved Handlebars/AI architecture. Handler is the data assembly point; LLM writes bounded prose only. See ADR 0016 for the decision record.
 
-Brief should emit `research_objectives` as a clean `string[]` (per ADR 0006), `research_questions` and `target_barriers` as fully typed object arrays. The current brief works but doesn't follow v7.0's discipline around factual vs. generative content separation.
+**Known finding: cascade variable count non-determinism.** The pre-render LLM tasks for research questions and target barriers produce variable-length arrays (e.g., 5 questions on one run, 6 on another with the same inputs). The prompts specify ranges ("3-7 questions") and the LLM picks within that range non-deterministically. This means brief outputs aren't fully reproducible — same study, same inputs, different question/barrier counts. The plan template inherits this property since it consumes the brief's emissions. Not blocking but worth knowing for any future reproducibility requirements.
 
 ### Discovery templates
 


### PR DESCRIPTION
## Summary

- Fix discovery sources table indentation (trailing spaces in `.join()`)
- Tighten summary prompt — downstream impacts framed as outcomes, not actions
- File cascade variable count non-determinism finding in product backlog

Follows the brief restructure smoke test. All 7 original issues from the first rendered output were resolved in the previous merge. These are the three remaining items from the second review pass.

## Test plan

- [x] Typecheck clean
- [x] 76/76 unit tests passing
- [ ] Re-run `/qori-brief` on test study after deploy — verify table alignment and summary framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)