### PR TITLE
fix: plan reads timeline and start_date from cascade

### DIFF
--- a/backend/src/helpers/slack/commands/planHandler.ts
+++ b/backend/src/helpers/slack/commands/planHandler.ts
@@ -83,15 +83,9 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
   const leadResearcher = (extract('lead_researcher_block', 'lead_researcher_input') as string) || '';
   const recruitmentSources = (extract('recruitment_source_block', 'recruitment_source_input') as string) || '';
   const operationalRisks = (extract('operational_risks_block', 'operational_risks_input') as string) || '';
-  const startDate = (extract('start_date_block', 'start_date_picker') as string) || '';
-  const timelinePref = (extract('timeline_block', 'timeline_radio') as string) || 'standard';
 
   // ── Compensation (mechanical) ──
   const perParticipantComp: number | null = calculatePerPersonCompensation(study);
-
-  // ── Timeline phases (mechanical) ──
-  const timelinePhases = buildTimelinePhases(startDate, timelinePref);
-  const timelineSummary = buildTimelineSummary(timelinePhases);
 
   // ── Load upstream cascade variables (ADR 0007: fail loudly on missing required data) ──
   const upstream = await readUpstreamVariables(study!.path || '', [
@@ -99,7 +93,17 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
     { key: 'research_questions', required: true },
     { key: 'target_barriers', required: true },
     { key: 'methodology_selection', required: false },
+    { key: 'timeline_preference', required: false },
+    { key: 'start_date', required: false },
   ]);
+
+  // ── Timeline from cascade (brief owns these — plan modal no longer has these fields) ──
+  const timelinePref = (upstream.timeline_preference?.value as string) || 'standard';
+  const startDate = (upstream.start_date?.value as string) || '';
+
+  // ── Timeline phases (mechanical) ──
+  const timelinePhases = buildTimelinePhases(startDate, timelinePref);
+  const timelineSummary = buildTimelineSummary(timelinePhases);
 
   const upstreamObjectives = upstream.research_objectives?.value as string[] | undefined;
   const upstreamQuestions = (upstream.research_questions?.value || []) as ResearchQuestion[];


### PR DESCRIPTION
## Summary

- Plan handler read `timeline_preference` and `start_date` from modal blocks that no longer exist — every plan silently used 'standard' timeline and a start date 7 days from generation
- Now reads both from cascade via `readUpstreamVariables` (brief already emits both)
- Also includes: brief prompt polish (discovery table indentation, summary action framing) and non-determinism finding filed in backlog

## Test plan

- [x] Typecheck clean
- [x] 76/76 unit tests passing
- [ ] Generate brief with accelerated/extended timeline, verify plan inherits it
- [ ] Generate brief with specific start date, verify plan timeline starts there

🤖 Generated with [Claude Code](https://claude.com/claude-code)