### PR TITLE
feat: recruitment cascade + dead field cleanup (Stream B)

### DIFF
--- a/backend/src/helpers/slack/commands/briefHandler.ts
+++ b/backend/src/helpers/slack/commands/briefHandler.ts
@@ -83,6 +83,7 @@ interface BriefTemplateInput {
   methodology: string;
   methodology_value: string;
   participant_approach: string;
+  recruitment_sources: string;
   timeline_preference: string;
   start_date: string;
   decision_deadline: string;
@@ -292,6 +293,7 @@ async function handleBriefSubmission({ ack, body, view, client }: SlackViewMiddl
   const learningObjectives = (extract('learning_objectives_block', 'learning_objectives_input') as string) || '';
   const outOfScope = (extract('out_of_scope_block', 'out_of_scope_input') as string) || '';
   const participantApproach = (extract('participant_approach_block', 'participant_approach_input') as string) || '';
+  const recruitmentSources = (extract('recruitment_sources_block', 'recruitment_sources_input') as string) || '';
   const timelinePref = ((extract('timeline_block', 'timeline_radio') as { value: string } | null)?.value) || 'standard';
   const startDate = (extract('start_date_block', 'start_date_picker') as string) || '';
   const decisionDeadline = (extract('decision_deadline_block', 'decision_deadline_picker') as string) || '';
@@ -404,6 +406,7 @@ async function handleBriefSubmission({ ack, body, view, client }: SlackViewMiddl
     methodology: methodLabel,
     methodology_value: methodValue,
     participant_approach: participantApproach,
+    recruitment_sources: recruitmentSources,
     timeline_preference: timelinePref,
     start_date: startDate,
     decision_deadline: decisionDeadline,

--- a/backend/src/helpers/slack/commands/planHandler.ts
+++ b/backend/src/helpers/slack/commands/planHandler.ts
@@ -81,7 +81,6 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
 
   // ── Modal inputs ──
   const leadResearcher = (extract('lead_researcher_block', 'lead_researcher_input') as string) || '';
-  const recruitmentSources = (extract('recruitment_source_block', 'recruitment_source_input') as string) || '';
   const operationalRisks = (extract('operational_risks_block', 'operational_risks_input') as string) || '';
 
   // ── Compensation (mechanical) ──
@@ -95,11 +94,13 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
     { key: 'methodology_selection', required: false },
     { key: 'timeline_preference', required: false },
     { key: 'start_date', required: false },
+    { key: 'recruitment_sources', required: false },
   ]);
 
-  // ── Timeline from cascade (brief owns these — plan modal no longer has these fields) ──
+  // ── Cascade-owned fields (brief owns these — plan modal no longer has these fields) ──
   const timelinePref = (upstream.timeline_preference?.value as string) || 'standard';
   const startDate = (upstream.start_date?.value as string) || '';
+  const recruitmentSources = (upstream.recruitment_sources?.value as string) || '';
 
   // ── Timeline phases (mechanical) ──
   const timelinePhases = buildTimelinePhases(startDate, timelinePref);

--- a/backend/src/helpers/slack/ui/researchBriefModal.ts
+++ b/backend/src/helpers/slack/ui/researchBriefModal.ts
@@ -245,6 +245,28 @@ export const researchBriefModal = {
         multiline: true,
       },
     },
+    // Recruitment sources
+    {
+      type: "input",
+      block_id: "recruitment_sources_block",
+      optional: true,
+      label: {
+        type: "plain_text",
+        text: "Recruitment sources",
+      },
+      hint: {
+        type: "plain_text",
+        text: "Where will participants be recruited from?",
+      },
+      element: {
+        type: "plain_text_input",
+        action_id: "recruitment_sources_input",
+        placeholder: {
+          type: "plain_text",
+          text: "e.g., Perigean Recruiting, VA Section 508 Office, MHV coordinators",
+        },
+      },
+    },
     {
       type: "divider",
     },

--- a/backend/src/helpers/slack/ui/researchPlanGeneratorModal.ts
+++ b/backend/src/helpers/slack/ui/researchPlanGeneratorModal.ts
@@ -1,8 +1,12 @@
 /**
- * Research Plan Modal v4.8
+ * Research Plan Modal v5.0
  *
  * Plan = execution doc. Consumes scope from brief via cascade.
  * Only asks for operational details the brief doesn't cover.
+ *
+ * v5.0: Removed recruitment_source_block (now cascade from brief),
+ * note_taker_block and observer_block (dead fields — plan v7.0
+ * doesn't render a team section; observers managed via /qori-fieldwork).
  */
 export const researchPlanGeneratorModal = {
   type: "modal",
@@ -25,7 +29,7 @@ export const researchPlanGeneratorModal = {
       elements: [
         {
           type: "mrkdwn",
-          text: "Execution plan for an approved brief. Scope, method, and objectives come from the cascade.",
+          text: "Execution plan for an approved brief. Scope, method, participants, recruitment, and timeline come from the cascade.",
         },
       ],
     },
@@ -53,13 +57,6 @@ export const researchPlanGeneratorModal = {
     {
       type: "divider",
     },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Team*",
-      },
-    },
     // Lead researcher (auto-filled)
     {
       type: "input",
@@ -76,75 +73,6 @@ export const researchPlanGeneratorModal = {
         type: "plain_text_input",
         action_id: "lead_researcher_input",
         initial_value: "{{lead_researcher}}",
-      },
-    },
-    // Note-taker
-    {
-      type: "input",
-      block_id: "note_taker_block",
-      optional: true,
-      label: {
-        type: "plain_text",
-        text: "Note-taker",
-      },
-      element: {
-        type: "plain_text_input",
-        action_id: "note_taker_input",
-        placeholder: {
-          type: "plain_text",
-          text: "e.g., Alex Rodriguez",
-        },
-      },
-    },
-    // Observer
-    {
-      type: "input",
-      block_id: "observer_block",
-      optional: true,
-      label: {
-        type: "plain_text",
-        text: "Observer / stakeholder reviewer",
-      },
-      element: {
-        type: "plain_text_input",
-        action_id: "observer_input",
-        placeholder: {
-          type: "plain_text",
-          text: "e.g., Sarah Chen (Product)",
-        },
-      },
-    },
-    {
-      type: "divider",
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Recruitment*",
-      },
-    },
-    // Recruitment sources
-    {
-      type: "input",
-      block_id: "recruitment_source_block",
-      optional: true,
-      label: {
-        type: "plain_text",
-        text: "Recruitment sources",
-      },
-      hint: {
-        type: "plain_text",
-        text: "Where will you find participants?",
-      },
-      element: {
-        type: "plain_text_input",
-        action_id: "recruitment_source_input",
-        placeholder: {
-          type: "plain_text",
-          text: "e.g., VA disability services, VSOs, Perigean recruiting",
-        },
-        multiline: true,
       },
     },
     {

--- a/config/prompts/research_brief.yaml
+++ b/config/prompts/research_brief.yaml
@@ -154,6 +154,12 @@ emits:
     schema:
       type: string
     extract_from: "Participants section — composition and count"
+  - key: recruitment_sources
+    pool: false
+    pool_strategy: replace
+    schema:
+      type: string
+    extract_from: "Participants section — Recruitment line"
 
 # ═══════════════════════════════════════════════════════════
 # AI GENERATION — focused, bounded tasks
@@ -322,9 +328,11 @@ ai_generation_tasks:
       {% endif %}
 
       Output a markdown table: Segment | Count | Rationale
-      Then a brief paragraph about demographics and recruitment approach.
+      Then a brief paragraph about demographic composition rationale.
       Justify segments with discovery evidence if available (e.g., AT users
       if accessibility barriers were found, older veterans if age patterns emerged).
+      Do NOT mention recruitment sources — recruitment is rendered separately
+      by the template.
 
       CITATION RULES: {% if citation_convention %}{{citation_convention}}
       Number citations sequentially within this section, starting at [D1], [S1], or [V1].
@@ -462,6 +470,10 @@ output_template: |
   ## Participants
 
   {{ai_generated.participant_rationale}}
+
+  {{#if recruitment_sources}}
+  **Recruitment** — {{recruitment_sources}}
+  {{/if}}
 
   ---
 


### PR DESCRIPTION
## Summary

- Brief modal: new optional "Recruitment sources" field, emitted as cascade variable
- Brief YAML: recruitment rendered via Handlebars, participant_rationale prompt no longer mentions recruitment
- Plan handler: reads recruitment_sources from cascade instead of re-asking
- Plan modal: removed 3 dead fields (recruitment_source, note_taker, observer)
- Also includes Stream A fix: timeline_preference and start_date read from cascade

## Test plan

- [x] Typecheck clean
- [x] 76/76 unit tests passing
- [ ] Brief modal shows new recruitment_sources field
- [ ] Brief output shows recruitment in Participants section
- [ ] Plan modal shows only study, lead researcher, operational risks
- [ ] Plan output uses recruitment from cascade
- [ ] Plan timeline matches brief's timeline preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)