### PR TITLE
feat: timeline simplification + cascade context polish

### DIFF
--- a/backend/src/helpers/slack/commands/briefHandler.ts
+++ b/backend/src/helpers/slack/commands/briefHandler.ts
@@ -13,7 +13,7 @@
 
 import type { AllMiddlewareArgs, SlackViewMiddlewareArgs, ViewSubmitAction } from '@slack/bolt';
 
-import { format } from 'date-fns';
+import { format, parseISO, differenceInCalendarDays, isValid } from 'date-fns';
 import { getConfigRepo, YAML_TEMPLATE_PATH, fetchFileFromRepo, readFolders, copyFilesToFolder } from '../../github';
 import { getResearchStudyWithRoles, addResearchStudyWithRoles } from '../../../services/research_study.service';
 import { getChannelConfigByChannelId } from '../../../services/channel-config.service';
@@ -294,7 +294,6 @@ async function handleBriefSubmission({ ack, body, view, client }: SlackViewMiddl
   const outOfScope = (extract('out_of_scope_block', 'out_of_scope_input') as string) || '';
   const participantApproach = (extract('participant_approach_block', 'participant_approach_input') as string) || '';
   const recruitmentSources = (extract('recruitment_sources_block', 'recruitment_sources_input') as string) || '';
-  const timelinePref = ((extract('timeline_block', 'timeline_radio') as { value: string } | null)?.value) || 'standard';
   const startDate = (extract('start_date_block', 'start_date_picker') as string) || '';
   const decisionDeadline = (extract('decision_deadline_block', 'decision_deadline_picker') as string) || '';
   const budgetStr = (extract('budget_block', 'budget_input') as string) || '';
@@ -315,9 +314,23 @@ async function handleBriefSubmission({ ack, body, view, client }: SlackViewMiddl
     }
   }
 
+  // ── Compute timeline_preference from date gap (replaces modal radio) ──
+  // Researchers think in dates, not buckets. Handler infers the preference
+  // from (decision_deadline - start_date): <35 days = accelerated, 35-49 = standard, >49 = extended.
+  let timelinePref: TimelinePreference = 'standard';
+  if (startDate && decisionDeadline) {
+    const start = parseISO(startDate);
+    const deadline = parseISO(decisionDeadline);
+    if (isValid(start) && isValid(deadline)) {
+      const gap = differenceInCalendarDays(deadline, start);
+      if (gap < 35) timelinePref = 'accelerated';
+      else if (gap > 49) timelinePref = 'extended';
+    }
+  }
+
   // ── Mechanical computations (ADR 0005: handler computes, not LLM) ──
   const displayDate = format(new Date(), 'MMMM d, yyyy');
-  const timelineDisplay = TIMELINE_DISPLAY_LABELS[timelinePref as TimelinePreference] || TIMELINE_DISPLAY_LABELS.standard;
+  const timelineDisplay = TIMELINE_DISPLAY_LABELS[timelinePref] || TIMELINE_DISPLAY_LABELS.standard;
   const timelinePhases = buildTimelinePhases(startDate, timelinePref);
 
   // ── Discovery injection (unchanged from v6.0) ──

--- a/backend/src/helpers/slack/ui/cascadeReadinessBlocks.ts
+++ b/backend/src/helpers/slack/ui/cascadeReadinessBlocks.ts
@@ -110,6 +110,7 @@ const TEMPLATE_CONSUMES: Record<string, ConsumeSpec[]> = {
     { key: 'timeline_preference', required: false, label: 'Timeline', source_hint: 'Create research brief first' },
     { key: 'budget', required: false, label: 'Budget', source_hint: 'Create research brief first' },
     { key: 'decision_deadline', required: false, label: 'Decision deadline', source_hint: 'Create research brief first' },
+    { key: 'recruitment_sources', required: false, label: 'Recruitment sources', source_hint: 'Create research brief first' },
   ],
   discussion_guide: [
     { key: 'research_objectives', required: true, label: 'Research objectives', source_hint: 'Create research brief first' },

--- a/backend/src/helpers/slack/ui/cascadeReadinessBlocks.ts
+++ b/backend/src/helpers/slack/ui/cascadeReadinessBlocks.ts
@@ -173,6 +173,9 @@ function buildCascadeBlocks(cascadeData: CascadeData | null) {
   const blocks: Record<string, unknown>[] = [
     { type: "divider" },
     { type: "section", text: { type: "mrkdwn", text: "*Cascade Context*" } },
+    { type: "context", block_id: "cascade_legend", elements: [
+      { type: "mrkdwn", text: ":white_check_mark: Required (present)  :large_blue_circle: Optional (present)  :warning: Required (missing)  :white_circle: Optional (missing)" },
+    ] },
   ];
 
   // Available variables

--- a/backend/src/helpers/slack/ui/researchBriefModal.ts
+++ b/backend/src/helpers/slack/ui/researchBriefModal.ts
@@ -277,24 +277,6 @@ export const researchBriefModal = {
         text: "*Timeline & Budget*",
       },
     },
-    // Timeline preference
-    {
-      type: "input",
-      block_id: "timeline_block",
-      label: {
-        type: "plain_text",
-        text: "Timeline *",
-      },
-      element: {
-        type: "radio_buttons",
-        action_id: "timeline_radio",
-        options: [
-          { text: { type: "plain_text", text: "Standard (5 weeks)" }, value: "standard" },
-          { text: { type: "plain_text", text: "Accelerated (2 weeks)" }, value: "accelerated" },
-          { text: { type: "plain_text", text: "Extended (8 weeks)" }, value: "extended" },
-        ],
-      },
-    },
     // Start date
     {
       type: "input",

--- a/backend/src/utils/timelineComputation.ts
+++ b/backend/src/utils/timelineComputation.ts
@@ -28,13 +28,30 @@ export interface TimelinePhase {
 
 // ─── Constants ──────────────────────────────────────────────────
 
+/**
+ * Qori-compressed phase durations (ADR 0011). Analysis and reporting are
+ * 1 day each because the cascade does the heavy lifting — the day is for
+ * researcher review, not manual analysis.
+ *
+ * Phase totals: standard = 17 days, accelerated = 11 days, extended = 36 days.
+ * These are shorter than TIMELINE_DISPLAY_LABELS because the labels represent
+ * total calendar time INCLUDING review buffer between the last phase ending
+ * and the decision deadline. The gap (e.g., standard: 6 weeks minus 17 days
+ * = ~25 days buffer) is stakeholder review, iteration cycles, and scheduling
+ * slack. This is intentional — not a bug. See ADR 0011.
+ */
 export const PHASE_DURATIONS: Record<TimelinePreference, PhaseDurations> = {
   standard:    { planning: 3, recruitment: 7, fieldwork: 5, analysis: 1, reporting: 1 },
   accelerated: { planning: 2, recruitment: 4, fieldwork: 3, analysis: 1, reporting: 1 },
   extended:    { planning: 7, recruitment: 14, fieldwork: 10, analysis: 3, reporting: 2 },
 };
 
-/** Human-readable duration labels for each timeline preference. */
+/**
+ * Human-readable total calendar time labels for each timeline preference.
+ * These represent the full researcher timeline from start to decision deadline,
+ * including review buffer after phases complete. They are intentionally longer
+ * than the sum of PHASE_DURATIONS — see comment above.
+ */
 export const TIMELINE_DISPLAY_LABELS: Record<TimelinePreference, string> = {
   standard: '6 weeks',
   accelerated: '4 weeks',

--- a/docs/v1.1-followups.md
+++ b/docs/v1.1-followups.md
@@ -105,3 +105,10 @@ Some modals use `channelId` in private_metadata, others use `channel_id`. Both w
 **Why deferred:** Bounded category. The casts are at the Slack API boundary, not in business logic.
 **Effort:** M (1–2 days). Add `as const` to string literals, use `satisfies` where possible.
 **Source:** Phase 6 Stream 1 `any` audit.
+
+### Cascade context block hardcoded against TEMPLATE_CONSUMES table
+The cascade context display in plan modal (and other modals) is hardcoded against a specific variable list in `cascadeReadinessBlocks.ts` (`TEMPLATE_CONSUMES`). Every new cascade variable requires manual update to this table in addition to YAML `emits`/`consumes` and TypeScript interfaces — three places to keep in sync. Should generate dynamically from the YAML cascade variable registry to eliminate drift surface. Discovered when `recruitment_sources` was added to brief's cascade emissions and didn't appear in plan modal until manual update.
+
+**Why deferred:** Works correctly once updated. The drift risk is low when template restructures happen infrequently.
+**Effort:** M (1–2 days). Parse YAML `consumes` blocks at startup or build time, generate `TEMPLATE_CONSUMES` automatically.
+**Source:** Brief restructure Stream B field audit.


### PR DESCRIPTION
## Summary

- **Cascade context**: add `recruitment_sources` to `TEMPLATE_CONSUMES` for plan modal
- **Cascade context**: add icon legend (check/circle/warning/white-circle)
- **Timeline**: document phase duration buffer (intentional, not a bug — ADR 0011)
- **Timeline**: compute `timeline_preference` from `decision_deadline - start_date` gap; remove modal radio
- **v1.1 followup**: filed `TEMPLATE_CONSUMES` hardcoding drift surface

## Timeline preference computation

Researchers think in dates, not buckets. Handler now infers preference:
- `<35 days` = accelerated
- `35-49 days` = standard
- `>49 days` = extended

Brief still emits `timeline_preference` as the same cascade variable. Plan handler unchanged.

## Test plan

- [x] Typecheck clean
- [x] 76/76 unit tests passing
- [ ] Brief modal no longer has timeline preference radio
- [ ] Brief still emits timeline_preference correctly (computed from dates)
- [ ] Plan modal shows recruitment_sources in cascade context with legend
- [ ] Plan timeline matches brief's computed preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)