### PR TITLE
feat: cascade context block surfaces problems, not status

### DIFF
--- a/backend/src/helpers/slack/commands/discovery/stakeholderHandler.ts
+++ b/backend/src/helpers/slack/commands/discovery/stakeholderHandler.ts
@@ -113,9 +113,9 @@ async function openStakeholderGuideModal({ ack, body, client }: SlackActionMiddl
       const studyForCascade = await getResearchStudyWithRoles(studyName);
       if (studyForCascade?.path) {
         const studyVars = await readStudyVariables(decodeURIComponent(studyForCascade.path));
-        if (Object.keys(studyVars.variables).length > 0) {
-          const cascadeData = buildCascadeReadiness(studyVars, 'stakeholder_interview_guide');
-          const cascadeBlocks = buildCascadeBlocks(cascadeData);
+        const cascadeData = buildCascadeReadiness(studyVars, 'stakeholder_interview_guide');
+        const cascadeBlocks = buildCascadeBlocks(cascadeData);
+        if (cascadeBlocks.length > 0) {
           const firstDivider = modalBlocks.findIndex(b => b.type === 'divider');
           if (firstDivider !== -1) {
             // @ts-expect-error — pre-existing type mismatch from require() → import migration

--- a/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
+++ b/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
@@ -121,9 +121,9 @@ async function openDiscussionGuideModal({ ack, body, client }: SlackActionMiddle
       const studyForCascade = await getResearchStudyWithRoles(studyName);
       if (studyForCascade?.path) {
         const studyVars = await readStudyVariables(decodeURIComponent(studyForCascade.path));
-        if (Object.keys(studyVars.variables).length > 0) {
-          const cascadeData = buildCascadeReadiness(studyVars, 'discussion_guide');
-          const cascadeBlocks = buildCascadeBlocks(cascadeData);
+        const cascadeData = buildCascadeReadiness(studyVars, 'discussion_guide');
+        const cascadeBlocks = buildCascadeBlocks(cascadeData);
+        if (cascadeBlocks.length > 0) {
           const firstDivider = blocks.findIndex(b => b.type === 'divider');
           if (firstDivider !== -1) {
             // @ts-expect-error — pre-existing type mismatch from require() → import migration

--- a/backend/src/helpers/slack/commands/modal-openers/briefModalOpener.ts
+++ b/backend/src/helpers/slack/commands/modal-openers/briefModalOpener.ts
@@ -101,9 +101,9 @@ async function openResearchBriefModal({ ack, body, client }: SlackActionMiddlewa
         const studyForCascade = await getResearchStudyWithRoles(preselectStudyName);
         if (studyForCascade?.path) {
           const studyVars = await readStudyVariables(decodeURIComponent(studyForCascade.path));
-          if (Object.keys(studyVars.variables).length > 0) {
-            const cascadeData = buildCascadeReadiness(studyVars, 'research_brief');
-            const cascadeBlocks = buildCascadeBlocks(cascadeData);
+          const cascadeData = buildCascadeReadiness(studyVars, 'research_brief');
+          const cascadeBlocks = buildCascadeBlocks(cascadeData);
+          if (cascadeBlocks.length > 0) {
             const firstDivider = modalBlocks.findIndex(b => b.type === 'divider');
             if (firstDivider !== -1) {
               // @ts-expect-error — pre-existing type mismatch from require() → import migration

--- a/backend/src/helpers/slack/commands/modal-openers/briefToStudyHandler.ts
+++ b/backend/src/helpers/slack/commands/modal-openers/briefToStudyHandler.ts
@@ -67,9 +67,9 @@ async function openPlanFromBrief({ ack, body, client }: SlackActionMiddlewareArg
     try {
       if (study?.path) {
         const studyVars = await readStudyVariables(decodeURIComponent(study.path));
-        if (Object.keys(studyVars.variables).length > 0) {
-          const cascadeData = buildCascadeReadiness(studyVars, 'research_plan');
-          const cascadeBlocks = buildCascadeBlocks(cascadeData);
+        const cascadeData = buildCascadeReadiness(studyVars, 'research_plan');
+        const cascadeBlocks = buildCascadeBlocks(cascadeData);
+        if (cascadeBlocks.length > 0) {
           const firstDivider = blocks.findIndex(b => b.type === 'divider');
           if (firstDivider !== -1) {
             // @ts-expect-error — pre-existing type mismatch from require() → import migration

--- a/backend/src/helpers/slack/commands/modal-openers/planModalOpener.ts
+++ b/backend/src/helpers/slack/commands/modal-openers/planModalOpener.ts
@@ -122,10 +122,9 @@ async function openResearchPlanModal({ ack, body, client }: SlackActionMiddlewar
       const studyForCascade = await getResearchStudyWithRoles(preselectStudyName);
       if (studyForCascade?.path) {
         const studyVars = await readStudyVariables(decodeURIComponent(studyForCascade.path));
-        if (Object.keys(studyVars.variables).length > 0) {
-          const cascadeData = buildCascadeReadiness(studyVars, 'research_plan');
-          const cascadeBlocks = buildCascadeBlocks(cascadeData);
-          // Insert cascade blocks after the first divider
+        const cascadeData = buildCascadeReadiness(studyVars, 'research_plan');
+        const cascadeBlocks = buildCascadeBlocks(cascadeData);
+        if (cascadeBlocks.length > 0) {
           const firstDivider = blocks.findIndex(b => b.type === 'divider');
           if (firstDivider !== -1) {
             // @ts-expect-error — pre-existing type mismatch from require() → import migration

--- a/backend/src/helpers/slack/commands/researchSynthesisHandler.ts
+++ b/backend/src/helpers/slack/commands/researchSynthesisHandler.ts
@@ -537,9 +537,11 @@ const handleLoadSynthesisFiles = async ({ ack, body, client }: SlackActionMiddle
         if (study?.path) {
           const decodedPath = decodeURIComponent(study.path);
           const studyVars = await readStudyVariables(decodedPath);
-          if (studyVars && Object.keys(studyVars.variables).length > 0) {
+          if (studyVars) {
             cascadeData = buildCascadeReadiness(studyVars, currentAnalysisMethod ?? '');
-            console.log(`✅ Cascade: ${cascadeData!.available.length} variables available, ${cascadeData!.missing.length} missing`);
+            if (cascadeData) {
+              console.log(`✅ Cascade: ${cascadeData.available.length} variables available, ${cascadeData.missing.length} missing`);
+            }
           }
         }
       }

--- a/backend/src/helpers/slack/ui/cascadeReadinessBlocks.ts
+++ b/backend/src/helpers/slack/ui/cascadeReadinessBlocks.ts
@@ -164,69 +164,57 @@ function buildCascadeReadiness(studyVars: StudyVars, templateKey: string): Casca
 
 /**
  * Build Slack Block Kit blocks for cascade readiness display.
- * Returns an array of blocks to insert into any modal.
- * Returns empty array if no cascade data.
+ *
+ * Problem-surfacing, not status recap:
+ * - All required + all optional present → return [] (hide block entirely)
+ * - All required present, optional missing → return [] (handler fallbacks cover this)
+ * - Required missing → show actionable warning listing what's missing and how to fix
+ *
+ * TemplateContractError at handler submission time is the second line of defense.
+ * This block is the first — it warns before the researcher wastes time filling out the form.
  */
 function buildCascadeBlocks(cascadeData: CascadeData | null) {
   if (!cascadeData) return [];
 
+  const requiredMissing = cascadeData.missing.filter(v => v.required);
+
+  // Happy path: all required variables present → hide block entirely.
+  // Optional missing is fine — handler fallbacks cover it.
+  if (requiredMissing.length === 0) return [];
+
+  // Problem state: required variables missing → actionable warning
   const blocks: Record<string, unknown>[] = [
     { type: "divider" },
-    { type: "section", text: { type: "mrkdwn", text: "*Cascade Context*" } },
-    { type: "context", block_id: "cascade_legend", elements: [
-      { type: "mrkdwn", text: ":white_check_mark: Required (present)  :large_blue_circle: Optional (present)  :warning: Required (missing)  :white_circle: Optional (missing)" },
-    ] },
-  ];
-
-  // Available variables
-  if (cascadeData.available.length > 0) {
-    blocks.push({
-      type: "context",
-      block_id: "cascade_available",
-      elements: [
-        {
-          type: "mrkdwn",
-          text: cascadeData.available.map(v => {
-            const countStr = v.count === 1 ? '1 item' : `${v.count} items`;
-            const sessionStr = v.sessions > 1 ? ` from ${v.sessions} sessions` : '';
-            return `${v.required ? ':white_check_mark:' : ':large_blue_circle:'} *${v.label}* — ${countStr}${sessionStr}`;
-          }).join('\n'),
-        },
-      ],
-    });
-  }
-
-  // Missing variables
-  if (cascadeData.missing.length > 0) {
-    blocks.push({
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:warning: *Cannot generate — ${requiredMissing.length} required input${requiredMissing.length > 1 ? 's' : ''} missing*`,
+      },
+    },
+    {
       type: "context",
       block_id: "cascade_missing",
       elements: [
         {
           type: "mrkdwn",
-          text: cascadeData.missing.map(v => {
-            const icon = v.required ? ':warning:' : ':white_circle:';
-            return `${icon} *${v.label}* — ${v.hint}`;
-          }).join('\n'),
+          text: requiredMissing.map(v =>
+            `:warning: *${v.label}* — ${v.hint}`
+          ).join('\n'),
         },
       ],
-    });
-  }
-
-  // Summary
-  const requiredMissing = cascadeData.missing.filter(v => v.required).length;
-  blocks.push({
-    type: "context",
-    block_id: "cascade_summary",
-    elements: [
-      {
-        type: "mrkdwn",
-        text: requiredMissing === 0
-          ? '_All required cascade variables are present. Synthesis will use structured upstream context._'
-          : `_${requiredMissing} required variable(s) missing. Synthesis will use raw file content as fallback._`,
-      },
-    ],
-  });
+    },
+    {
+      type: "context",
+      block_id: "cascade_action",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: '_Complete the upstream steps above, then re-open this modal._',
+        },
+      ],
+    },
+  ];
 
   return blocks;
 }


### PR DESCRIPTION
## Summary

Cascade context block in modals now surfaces problems instead of showing a status recap:

- **All required present** → block hidden entirely (no redundant recap)
- **Required missing** → actionable warning: what's missing + what command to run
- **No variables at all** → required specs show as missing naturally

Applied consistently across all 6 modals: plan, brief, discussion guide, synthesis, stakeholder interview guide, brief-to-study.

`TemplateContractError` at handler submission time remains as second line of defense (ADR 0007).

## Test plan

- [x] Typecheck clean
- [x] 76/76 unit tests passing
- [ ] Happy path: open plan modal on study with brief → no cascade block visible
- [ ] Missing state: open plan modal on study without brief → warning with missing vars listed
- [ ] Failsafe: submit plan on missing state → TemplateContractError DM fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)