### PR TITLE
feat: desk_research v7.0 restructure + delta doc

### DIFF
--- a/backend/src/helpers/slack/commands/discovery/deskResearchHandler.ts
+++ b/backend/src/helpers/slack/commands/discovery/deskResearchHandler.ts
@@ -1,12 +1,12 @@
 /**
  * deskResearchHandler.ts — Desk research upload modal opener + submission
  *
- * Extracted from events.js. Handles the upload_desk_research action (opens
- * modal with study picker) and the upload_desk_research_modal submission
- * (processes uploaded files, runs YAML template, emits cascade variables).
+ * DATA ASSEMBLY POINT for the desk research template (ADR 0005/0016 pattern).
+ * The handler extracts modal fields, processes uploaded files, builds
+ * mechanical document inventory data, and passes the complete data to
+ * yamlProcessor for AI analysis tasks + rendering.
  *
- * This is a CASCADE-EMITTING handler: it doesn't consume upstream variables,
- * it produces them. The desk_research.yaml template emits discovered_barriers,
+ * This is a CASCADE-EMITTING handler: it produces discovered_barriers,
  * discovered_metrics, discovered_journeys, methodology_recommendations,
  * knowledge_gaps, and source_artifacts.
  */
@@ -33,11 +33,17 @@ interface MutableBlock {
 
 // ─── Template input contract ──────────────────────────────────────
 
+/** Data shape passed to the desk_research YAML template. Co-located with handler. */
 interface DeskResearchTemplateInput {
-  research_topic: string;
   selected_study: string;
+  topic: string;
+  research_topic: string;
   description: string;
   document_content: string;
+  // Mechanical data from file processing (handler-assembled, not LLM-generated)
+  document_count: number;
+  document_names: string[];
+  document_types: string[];
 }
 
 // ─── Modal opener ─────────────────────────────────────────────────
@@ -145,6 +151,11 @@ async function handleDeskResearchSubmission({ ack, body, view, client }: SlackVi
     return;
   }
 
+  // ── Extract modal fields (previously ignored — Bug 1 from delta) ──
+  const description = (values.description_block?.description?.value || '').trim() || studyName;
+  const researchTopic = (values.research_focus_block?.research_topic?.value || '').trim() || studyName;
+  const topic = researchTopic;
+
   const uploadedFiles = values.file_upload_block?.file_upload?.files?.map((file: any) => ({
     id: file.id,
     name: file.name,
@@ -182,12 +193,22 @@ async function handleDeskResearchSubmission({ ack, body, view, client }: SlackVi
     const parsedDocuments = parseDocuments(documents);
     const formattedDocumentContent: string = parsedDocuments.structured_format;
 
+    // ── Mechanical document inventory (handler-assembled, not LLM) ──
+    const documentNames = processedFiles.map((f: any) => f.name as string);
+    const documentTypes = processedFiles.map((f: any) => f.type as string);
+
     const deskResearchData: DeskResearchTemplateInput = {
-      research_topic: studyName,
       selected_study: studyName,
-      description: studyName,
+      topic,
+      research_topic: researchTopic,
+      description,
       document_content: formattedDocumentContent,
+      document_count: processedFiles.length,
+      document_names: documentNames,
+      document_types: documentTypes,
     };
+
+    console.log(`📚 Assembled desk research data: ${deskResearchData.document_count} documents, topic: "${topic}", study: ${studyName}`);
 
     const study = await getResearchStudyWithRoles(studyName);
 

--- a/config/prompts/desk_research.yaml
+++ b/config/prompts/desk_research.yaml
@@ -3,17 +3,19 @@
 # ═══════════════════════════════════════════════════════════
 id: desk_research_processor
 name: run_desk_research
-label: "📚 Desk Research"
-version: v5.1
+label: "Desk Research"
+version: v7.0
 
 description: |
-  Analyze uploaded research documents and generate a polished, professional synthesis
-  with key themes, findings, and actionable recommendations. Optimized for GitHub
-  rendering with industry-standard research documentation practices.
+  Analyze uploaded research documents and generate a synthesis with key
+  themes, findings, and actionable recommendations.
+  v7.0: Interleaved Handlebars/AI architecture — document inventory
+  rendered mechanically from handler data, LLM writes analytical prose.
+  Per ADR 0005/0016 pattern.
 
 author: Qori R&D
 created: 2025-08-27
-last_updated: 2026-04-29
+last_updated: 2026-05-19
 
 # ═══════════════════════════════════════════════════════════
 # CONFIGURATION
@@ -26,18 +28,30 @@ discovery_scope: true
 # INPUTS
 # ═══════════════════════════════════════════════════════════
 input_variables:
-  # Study context (from modal)
   - selected_study:
       type: "select"
       required: true
-      description: "Study folder name - provides context for analysis"
+      description: "Study folder name"
 
-  - study_name:
-      type: "string"
+  - topic:
+      type: "text"
       required: true
-      description: "Human-readable study name"
+      placeholder: "e.g., Veteran telehealth adoption barriers"
+      description: "Researcher-provided topic — slugified for filename and variable store path"
 
-  # Document upload
+  - research_topic:
+      type: "text"
+      required: false
+      placeholder: "e.g., Veteran telehealth adoption barriers"
+      description: "Optional focus area. Defaults to topic if not provided."
+      default: "{{topic}}"
+
+  - description:
+      type: "textarea"
+      required: false
+      placeholder: "e.g., Competitive analysis from Q3, industry reports on telehealth"
+      description: "Optional context about the uploaded documents"
+
   - document_content:
       type: "textarea"
       required: true
@@ -46,40 +60,23 @@ input_variables:
         min_length: 100
         error_message: "Document content is required. Please upload documents."
 
-  - description:
-      type: "textarea"
-      required: false
-      placeholder: "e.g., Competitive analysis from Q3, industry reports on telehealth"
-      description: "Optional context about the uploaded documents"
-
-  # Discovery topic (required for /qori-discover; added to modal in Step 2)
-  - topic:
-      type: "text"
-      required: true
-      placeholder: "e.g., Veteran telehealth adoption barriers"
-      description: "Researcher-provided topic — slugified for filename and variable store path"
-
-  # Optional refinement
-  - research_topic:
-      type: "text"
-      required: false
-      placeholder: "e.g., Veteran telehealth adoption barriers"
-      description: "Optional focus area. Defaults to topic if not provided."
-      default: "{{topic}}"
-
 # ═══════════════════════════════════════════════════════════
-# AI GENERATION
+# AI GENERATION — focused, bounded tasks
 # ═══════════════════════════════════════════════════════════
 ai_generation_tasks:
 
-  # Task 1: Document inventory with richer metadata
-  - task_id: "document_inventory"
+  # Document analysis: per-document summaries and relevance (analytical, not inventory)
+  # File names, types, and count are rendered mechanically by Handlebars.
+  # This task adds the analytical layer: what each document contributes.
+  - task_id: "document_analysis"
     prompt: |
-      Review the following document content and create a detailed source inventory.
+      Review the following document content and provide analytical summaries.
 
       **Study:** {{selected_study}}
       **Research Topic:** {{effective_topic}}
-      **Document Description:** {{description}}
+
+      **Documents uploaded:** {{document_count}} files
+      **File names:** {{document_names}}
 
       **Document Content:**
       ---BEGIN CONTENT---
@@ -89,13 +86,13 @@ ai_generation_tasks:
       CRITICAL RULES:
       - If the content between BEGIN/END markers is empty, respond ONLY with:
         "> **No documents provided.** Please upload research documents and try again."
-      - ONLY list documents explicitly identifiable in the provided content
+      - ONLY analyze documents explicitly present in the provided content
       - Do NOT invent document titles, authors, dates, or sources
       - If a field is not stated in the content, write "Not specified"
 
-      If documents ARE present, create this format for EACH document:
+      For EACH document, output:
 
-      ### [Document Title]
+      **[Document Title or Filename]**
 
       | Attribute | Value |
       |:----------|:------|
@@ -104,13 +101,16 @@ ai_generation_tasks:
       | **Type** | [Report / Study / Survey / Brief / Article / Guide] |
       | **Relevance** | [High / Medium / Low] to {{effective_topic}} |
 
-      **Summary:** [2-3 sentence description of what this document covers and its key contribution to the research topic]
+      [2-3 sentence description of what this document covers and its key contribution]
 
       ---
 
-      Repeat for each distinct document. If you cannot identify distinct documents, describe the content as a single source.
+      OUTPUT BOUNDARIES: Do not generate section headings, sub-headings,
+      citation appendices, reference lists, horizontal rules, or markdown
+      section dividers beyond the per-document separators above. The template
+      handles all document structure.
 
-  # Task 2: Executive summary
+  # Executive summary
   - task_id: "executive_summary"
     prompt: |
       Create a publication-quality executive summary of the desk research.
@@ -130,37 +130,34 @@ ai_generation_tasks:
       4. Do NOT cite authors or studies not mentioned in the content
       5. If content doesn't address research questions, state this explicitly
 
-      If documents ARE present, structure as:
+      Structure as:
 
-      ### Overview
+      **Overview:** 2-3 sentences on what this research covers and its significance for {{effective_topic}}. Ground in actual document content.
 
-      [2-3 sentences on what this research covers and its significance for {{effective_topic}}. Ground in actual document content.]
+      **Key Findings:** Present 3-5 major findings. For each:
 
-      ### Key Findings
-
-      Present 3-5 major findings. For each finding:
-
-      > **Finding 1: [Descriptive title]**
+      > **Finding N: [Descriptive title]**
       >
-      > [1-2 sentence explanation of the finding, with specific data if available]
+      > [1-2 sentence explanation with specific data if available]
       >
       > *Source: [Document name]*
 
-      Use this blockquote format for each finding. Include the specific document source.
+      **Strategic Implications:** 2-3 sentences on what these findings mean for decision-making. Only draw from actual findings.
 
-      ### Strategic Implications
-
-      [2-3 sentences on what these findings mean for decision-making related to {{effective_topic}}. Only draw from actual findings.]
-
-      ### Confidence Assessment
+      **Confidence Assessment:**
 
       | Aspect | Confidence | Rationale |
       |:-------|:-----------|:----------|
-      | Evidence quality | [High/Medium/Low] | [Brief explanation based on document types and rigor] |
-      | Coverage of topic | [High/Medium/Low] | [How well documents address the research questions] |
-      | Actionability | [High/Medium/Low] | [Whether findings translate to clear actions] |
+      | Evidence quality | [High/Medium/Low] | [Brief explanation] |
+      | Coverage of topic | [High/Medium/Low] | [How well documents address questions] |
+      | Actionability | [High/Medium/Low] | [Whether findings translate to actions] |
 
-  # Task 3: Key themes
+      OUTPUT BOUNDARIES: Do not generate section headings, sub-headings,
+      citation appendices, reference lists, horizontal rules, or markdown
+      section dividers. The template handles all document structure.
+      Output only the prose content for this section.
+
+  # Key themes
   - task_id: "themes"
     prompt: |
       Identify and analyze major themes across the research documents.
@@ -179,33 +176,21 @@ ai_generation_tasks:
       4. QUOTE directly from documents when providing evidence
       5. If you can only identify 1-2 themes, that's fine - do not pad
 
-      If documents ARE present, use this format for each theme:
+      For each theme:
 
-      ---
+      **Theme N: [Theme Title]**
 
-      ### Theme [N]: [Theme Title]
+      *What the Research Shows:* 2-3 sentences synthesizing findings. Be specific.
 
-      #### What the Research Shows
-
-      [2-3 sentences synthesizing findings related to this theme. Be specific.]
-
-      #### Supporting Evidence
-
-      > "[Direct quote from document 1]"
-      >
+      > "[Direct quote from document]"
       > — *[Document name/source]*
 
       > "[Direct quote from document 2]"
-      >
       > — *[Document name/source]*
 
-      #### Implications for {{effective_topic}}
+      *Implications for {{effective_topic}}:* 1-2 sentences on why this matters.
 
-      [1-2 sentences on why this theme matters and what it suggests for decisions/actions]
-
-      #### Confidence: `[HIGH]` / `[MEDIUM]` / `[LOW]`
-
-      [One sentence explaining confidence level based on evidence strength]
+      *Confidence:* `[HIGH]` / `[MEDIUM]` / `[LOW]` — one sentence explaining.
 
       ---
 
@@ -214,7 +199,12 @@ ai_generation_tasks:
       - Maximum 5 themes
       - Each theme must have clear implications stated
 
-  # Task 4: Recommendations
+      OUTPUT BOUNDARIES: Do not generate section headings, sub-headings,
+      citation appendices, reference lists, horizontal rules, or markdown
+      section dividers beyond the per-theme separators above. The template
+      handles all document structure.
+
+  # Recommendations
   - task_id: "recommendations"
     prompt: |
       Generate actionable recommendations based on the desk research findings.
@@ -232,35 +222,37 @@ ai_generation_tasks:
       3. Do NOT recommend things not supported by the content
       4. Quote or paraphrase the evidence base for each recommendation
 
-      If documents ARE present, structure as:
+      Structure as:
 
-      ### Immediate Actions (This Week)
-
-      | Priority | Action | Evidence Base |
-      |:--------:|:-------|:--------------|
-      | 1 | **[Specific action]** | Based on document finding: "[brief quote or paraphrase]" |
-      | 2 | **[Specific action]** | Based on document finding: "[brief quote or paraphrase]" |
-      | 3 | **[Specific action]** | Based on document finding: "[brief quote or paraphrase]" |
-
-      ### Short-Term Priorities (This Month)
+      **Immediate Actions (This Week)**
 
       | Priority | Action | Evidence Base |
       |:--------:|:-------|:--------------|
-      | 1 | **[Specific action]** | Based on document finding: "[brief quote or paraphrase]" |
-      | 2 | **[Specific action]** | Based on document finding: "[brief quote or paraphrase]" |
-      | 3 | **[Specific action]** | Based on document finding: "[brief quote or paraphrase]" |
+      | 1 | **[Specific action]** | Based on: "[brief quote or paraphrase]" |
+      | 2 | **[Specific action]** | Based on: "[brief quote or paraphrase]" |
+      | 3 | **[Specific action]** | Based on: "[brief quote or paraphrase]" |
 
-      ### Further Research Needed
+      **Short-Term Priorities (This Month)**
+
+      | Priority | Action | Evidence Base |
+      |:--------:|:-------|:--------------|
+      | 1 | **[Specific action]** | Based on: "[brief quote or paraphrase]" |
+      | 2 | **[Specific action]** | Based on: "[brief quote or paraphrase]" |
+
+      **Further Research Needed**
 
       | Gap Identified | Why It Matters | Suggested Approach |
       |:---------------|:---------------|:-------------------|
-      | [Gap from documents] | [Impact of not addressing] | [How to investigate] |
-      | [Gap from documents] | [Impact] | [Approach] |
+      | [Gap from documents] | [Impact] | [How to investigate] |
 
-      If the documents don't provide enough substance for a section, write:
+      If insufficient evidence for a section:
       > The documents do not provide sufficient evidence for [section name] recommendations.
 
-  # Task 5: Sources
+      OUTPUT BOUNDARIES: Do not generate section headings, sub-headings,
+      citation appendices, reference lists, horizontal rules, or markdown
+      section dividers. The template handles all document structure.
+
+  # Sources
   - task_id: "sources"
     prompt: |
       Create a professional reference list for the desk research.
@@ -276,49 +268,39 @@ ai_generation_tasks:
       3. Do NOT invent titles, authors, organizations, or dates
       4. If author/date not stated, write "Not specified"
 
-      If sources ARE identifiable, format as:
-
-      ### Primary Sources
+      Format as:
 
       | # | Document | Author/Org | Date | Contribution |
       |:-:|:---------|:-----------|:-----|:-------------|
-      | 1 | **[Title]** | [Author] | [Date] | [Key contribution in one phrase] |
-      | 2 | **[Title]** | [Author] | [Date] | [Key contribution] |
+      | 1 | **[Title]** | [Author] | [Date] | [Key contribution] |
 
-      ### Source Details
+      For each source, add a details block:
 
       <details>
-      <summary><strong>1. [Document Title]</strong></summary>
+      <summary><strong>N. [Document Title]</strong></summary>
 
       - **Full Citation:** [Author/Org]. ([Date]). *[Title]*. [Publisher if known].
       - **Document Type:** [Report / Study / Survey / etc.]
-      - **Key Contribution:** [2-3 sentences on what this source provided to the analysis]
-      - **Limitations:** [Any noted limitations or caveats about this source]
+      - **Key Contribution:** [2-3 sentences]
+      - **Limitations:** [Any noted limitations]
 
       </details>
 
-      Repeat the details block for each source.
-
-      If no distinct sources identifiable but content exists:
-
+      If no distinct sources identifiable:
       > **Source Attribution:** The analyzed content did not include clear source attribution. Findings are derived from the provided document text.
 
+      OUTPUT BOUNDARIES: Do not generate section headings or markdown
+      section dividers. The template handles all document structure.
+
 # ═══════════════════════════════════════════════════════════
-# OUTPUT
+# OUTPUT — interleaved Handlebars + AI prose
 # ═══════════════════════════════════════════════════════════
 output_template: |
-  <div align="center">
+  # Desk Research Report: {{effective_topic}}
 
-  # Desk Research Report
-  ## {{effective_topic}}
-
-  **Study:** {{selected_study}}
-  **Prepared by:** Qori Research Assistant
-  **Date:** {{current_date}}
+  **Study:** {{selected_study}} &nbsp; | &nbsp; **Prepared by:** Qori Research Assistant &nbsp; | &nbsp; **Date:** {{current_date}}
 
   ---
-
-  </div>
 
   ## Research Overview
 
@@ -327,6 +309,7 @@ output_template: |
   | **Study** | {{selected_study}} |
   | **Topic** | {{effective_topic}} |
   | **Date Conducted** | {{current_date}} |
+  | **Documents Analyzed** | {{document_count}} |
   | **Analysis Type** | Secondary Research / Literature Review |
 
   {{#if description}}
@@ -338,15 +321,23 @@ output_template: |
 
   ---
 
-  ## Executive Summary
+  ## Documents Analyzed
 
-  {{ai_generated.executive_summary}}
+  {{document_count}} document(s) uploaded for analysis:
+
+  | # | Filename | Type |
+  |:-:|:---------|:-----|
+  {{#each document_names}}
+  | {{@index}} | {{this}} | {{lookup ../document_types @index}} |
+  {{/each}}
+
+  {{ai_generated.document_analysis}}
 
   ---
 
-  ## Documents Analyzed
+  ## Executive Summary
 
-  {{ai_generated.document_inventory}}
+  {{ai_generated.executive_summary}}
 
   ---
 
@@ -368,11 +359,7 @@ output_template: |
 
   ---
 
-  <div align="center">
-
-  ### Methodology Note
-
-  This desk research synthesis follows industry-standard secondary research practices:
+  ## Methodology Note
 
   | Practice | Implementation |
   |:---------|:---------------|
@@ -383,18 +370,22 @@ output_template: |
 
   ---
 
-  **References**
-
-  This analysis methodology aligns with:
-  - Cooper, A. et al. — *About Face: The Essentials of Interaction Design*
-  - Goodman, E. et al. — *Observing the User Experience*
-  - Portigal, S. — *Interviewing Users*
-
   ---
 
-  *Generated by Qori • {{current_date}}*
+  ## Cascade summary
 
-  </div>
+  This desk research emits discovery variables for downstream templates.
+
+  | Variable | Description |
+  |----------|-------------|
+  | discovered_barriers | Barriers, challenges, pain points from the research |
+  | discovered_metrics | Quantitative findings — percentages, scores, rates |
+  | discovered_journeys | User task flow patterns — success and failure paths |
+  | methodology_recommendations | Suggested research methods from the literature |
+  | knowledge_gaps | Areas the research could not answer |
+  | source_artifacts | Document metadata for provenance tracking |
+
+  **Documents analyzed:** {{document_count}}
 
 output_options:
   filename: "{{topic_slug}}-desk-research-{{current_date_iso}}.md"
@@ -413,7 +404,7 @@ output_options:
 
         **Study:** {{selected_study}}
         **Topic:** {{effective_topic}}
-        **Documents Analyzed:** See full report
+        **Documents Analyzed:** {{document_count}}
 
         View the full analysis for findings, evidence, and actionable recommendations.
 
@@ -527,3 +518,17 @@ slack_ui:
   error_messages:
     no_documents: "Please upload at least one document before running desk research."
     processing_failed: "Analysis failed. Please check that your documents are readable text files (PDF, DOCX, TXT, MD)."
+
+notes: |
+  v7.0: Interleaved Handlebars/AI architecture (ADR 0005/0016 pattern).
+  - Document inventory (file names, types, count) rendered mechanically
+    via Handlebars. LLM document_analysis task adds per-document summaries
+    and relevance assessments on top of the mechanical list.
+  - Handler now extracts modal fields (description, research_topic, topic)
+    that were previously silently ignored.
+  - Masthead standardized to match brief/plan pattern (no centered div).
+  - Cascade summary section added at bottom.
+  - Anti-fabrication guards preserved (already strong from v5.1).
+  - OUTPUT BOUNDARIES rule added to all tasks.
+
+  v5.1: Per-section LLM tasks (superseded by v7.0).

--- a/docs/desk-research-restructure-delta.md
+++ b/docs/desk-research-restructure-delta.md
@@ -1,0 +1,212 @@
+# Desk Research Restructure Delta: v5.1 to v7.0 Conformance
+
+**Date:** 2026-05-19
+**Status:** Proposed (awaiting approval before implementation)
+**Reference:** `research_brief.yaml` v7.0 (ADR 0016), `research_plan.yaml` v7.0 (ADR 0005)
+
+---
+
+## 1. Current state of desk research
+
+The desk research template (v5.1) uses the **"minimal static + single LLM per section" pattern**. It's closer to v7.0 than the brief was pre-restructure — each section has its own LLM task (not a single monolithic body task) — but the output template is essentially `{{ai_generated.X}}` stacked vertically with no mechanical rendering. Every value in the rendered document passes through the LLM.
+
+### Architecture
+
+Five AI tasks, each generating one major section:
+- `document_inventory` — document metadata table
+- `executive_summary` — overview, findings, implications, confidence
+- `themes` — thematic analysis with evidence
+- `recommendations` — actionable recommendations with evidence base
+- `sources` — reference list
+
+The output template is a thin wrapper: masthead (centered `<div>`, LLM-free), then five `{{ai_generated.X}}` blocks, then a hardcoded methodology note footer.
+
+### What the LLM controls that it shouldn't
+
+| Value | Current | Should be |
+|-------|---------|-----------|
+| Document count | LLM generates inventory | Handler counts parsed documents |
+| Document names | LLM generates from content | Handler has `processedFiles` array with filenames |
+| Analysis date | Template uses `{{current_date}}` (mechanical — correct) | No change needed |
+| Study name | Template uses `{{selected_study}}` (mechanical — correct) | No change needed |
+| Topic | Template uses `{{effective_topic}}` (mechanical — correct) | No change needed |
+
+The gap here is smaller than the brief was. Most metadata is already mechanical. The main issue is that document inventory (file names, types, counts) is LLM-generated when the handler already has this data from file processing.
+
+### Handler bugs (pre-existing, not related to v7.0)
+
+**Bug 1: Modal fields ignored.** The handler sets `research_topic`, `selected_study`, and `description` all to `studyName` (line 186-188). The modal's "Description" field (`description_block`) and "Research focus" field (`research_focus_block`) are collected from the researcher but never extracted. The researcher's input is silently discarded.
+
+**Bug 2: `topic` variable never set.** The YAML declares `topic` as required (used for filename slug via `topic_slug` and discovery variable scoping). The handler doesn't include `topic` in `DeskResearchTemplateInput`. It's unclear how the filename renders correctly — either `yamlProcessor` silently swallows the missing variable or `topic` gets injected elsewhere.
+
+**Bug 3: `DeskResearchTemplateInput` is minimal.** Only 4 fields (`research_topic`, `selected_study`, `description`, `document_content`). The YAML expects more (`topic`, `effective_topic`, `topic_slug`, `team`). The handler relies on yamlProcessor's `derived_variables` block in the YAML to compute `effective_topic` and `topic_slug`, but `topic` itself is never provided.
+
+### What it emits
+
+Six cascade variables, all with `pool: true` / `pool_strategy: append`:
+
+| Variable | Schema | Shape | Downstream consumers |
+|----------|--------|-------|---------------------|
+| `discovered_barriers` | `$ref: schemas/discovered_barrier.yaml` | `{id, title, summary, magnitude, evidence[], affected_population, source_document, confidence}[]` | `stakeholder_synthesis` (formal consumes), `research_brief` (manual load) |
+| `discovered_metrics` | `$ref: schemas/discovered_metric.yaml` | `{id, metric_name, value, context, baseline_or_target, source_document}[]` | `research_brief` (manual load) |
+| `discovered_journeys` | `$ref: schemas/discovered_journey.yaml` | `{id, journey_name, success_pattern, failure_pattern, completion_rate, satisfaction, source_document}[]` | `research_brief` (manual load) |
+| `methodology_recommendations` | `$ref: schemas/methodology_recommendation.yaml` | `{id, method, addresses, rationale, source_document}[]` | `research_brief` (manual load) |
+| `knowledge_gaps` | inline schema | `{id, gap, why_matters, suggested_resolution, source_document}[]` | `stakeholder_synthesis` (formal consumes), `research_brief` (manual load) |
+| `source_artifacts` | inline schema | `{title, source_org, date, type, contribution}[]` | Not consumed by any template (orphaned per v1.1 followups) |
+
+All extraction is LLM-driven via `extract_from` hints in the emits block. The variable extractor reads the rendered output and extracts structured data. This is the correct pattern and doesn't need to change.
+
+### Anti-fabrication guards
+
+**Present and strong.** Every task has "CRITICAL ANTI-HALLUCINATION RULES" with specific instructions:
+- "EVERY finding must be directly quoted or paraphrased from the provided content"
+- "Do NOT invent statistics, percentages, or data points"
+- "Do NOT cite authors or studies not mentioned in the content"
+- Empty content detection with graceful fallback messages
+
+This is actually better than the brief's anti-fabrication guards. The desk research template was designed defensively from the start because it processes uploaded documents (untrusted input).
+
+### Cascade summary section
+
+**Missing.** No cascade summary at the bottom documenting what the template emits.
+
+### What's missing vs. v7.0
+
+| v7.0 feature | Desk research status |
+|--------------|---------------------|
+| Interleaved Handlebars + bounded LLM slots | Partially. Masthead is Handlebars; body is stacked LLM sections. No mechanical rendering of computed values within the body. |
+| Computed values rendered mechanically | Partially. Date and study name are mechanical. Document inventory is LLM-generated when handler has the data. |
+| Anti-fabrication guards | Present and strong |
+| Cascade summary section | Missing |
+| Handler assembles all mechanical data | No. Handler passes minimal data; YAML derived_variables compute topic variants. Modal fields are ignored. |
+| JSON-emitting AI tasks | No. All tasks emit prose. Extraction is post-render via variable extractor. |
+
+---
+
+## 2. Target state
+
+The restructured desk research should follow the v7.0 pattern with one important distinction: **desk research is a document analysis template, not a scope-definition template**. The brief and plan define scope commitments. Desk research synthesizes uploaded documents. This affects what "computed values" means:
+
+- **Brief/plan:** Computed values = dates, counts, IDs, budget math. Handler computes these.
+- **Desk research:** Computed values = document count, document names, file types. Handler already has these from file processing.
+
+The LLM's role in desk research is genuinely analytical — it reads documents and extracts findings. Most of its current tasks are legitimately generative. The restructure is smaller than the brief's.
+
+### Specific target
+
+1. Handler fixes: extract modal fields, pass `topic`, build document inventory data mechanically
+2. Output template: interleave Handlebars for document inventory (handler-assembled), mechanical metadata
+3. Add cascade summary section
+4. Keep existing anti-fabrication guards (they're already strong)
+5. No pre-render JSON tasks needed (unlike brief — desk research doesn't need handler-assigned IDs before prose tasks run)
+
+---
+
+## 3. Specific changes required
+
+### 3a. Handler changes (`deskResearchHandler.ts`)
+
+**Fix modal field extraction:**
+```typescript
+const description = (values.description_block?.description?.value || '').trim();
+const researchTopic = (values.research_focus_block?.research_topic?.value || '').trim();
+const topic = researchTopic || studyName;
+```
+
+**Expand `DeskResearchTemplateInput`:**
+```typescript
+interface DeskResearchTemplateInput {
+  selected_study: string;
+  topic: string;
+  research_topic: string;
+  description: string;
+  document_content: string;
+  // Mechanical data from file processing
+  document_count: number;
+  document_names: string[];
+  document_types: string[];
+}
+```
+
+**Build document inventory data mechanically:**
+```typescript
+const documentNames = processedFiles.map(f => f.name);
+const documentTypes = processedFiles.map(f => f.type);
+```
+
+### 3b. YAML changes (`desk_research.yaml`)
+
+**Update output template** to render document metadata mechanically:
+
+Replace `{{ai_generated.document_inventory}}` with a Handlebars-rendered document list for the metadata portion (file names, types, count), followed by a bounded LLM task for the per-document summaries and relevance assessments.
+
+**Split `document_inventory` task:** The current task generates both mechanical data (file names, types) and analytical content (summaries, relevance ratings). Split into:
+- Mechanical: Handlebars renders file list table
+- AI: `document_analysis` task generates per-document summaries and relevance only
+
+**Add cascade summary section** to output template.
+
+**Remove centered `<div>` formatting.** The brief and plan templates use standard markdown mastheads. The desk research template uses `<div align="center">` which doesn't render consistently across all markdown renderers. Align with the established pattern.
+
+### 3c. Schema changes
+
+None. The existing emit schemas are well-designed and match what downstream consumers expect. The shapes don't change.
+
+### 3d. No pre-render JSON tasks needed
+
+Unlike the brief (which needed handler-assigned IDs for barriers and questions), desk research's emitted variables don't have handler-assigned IDs. The `barrier-001`, `metric-001` etc. IDs are assigned by the variable extractor based on `extract_from` hints. This is correct — desk research documents vary in content, so IDs are extraction-time, not handler-time.
+
+---
+
+## 4. Cascade contract impact
+
+### Do downstream consumers need updates?
+
+**No.** The emitted variable shapes are unchanged. `stakeholder_synthesis` and `research_brief` consume the same `{id, title, summary, ...}` objects. The extraction pipeline (yamlProcessor → variableExtractor → studyVariables) is unchanged.
+
+### Does the extraction quality change?
+
+**Possibly improves.** The rendered document will have a cleaner structure (mechanical document list + analytical sections) which should make extraction hints more reliable. Currently the `extract_from` hints point at "Key Themes and Executive Summary" which are LLM-generated section headings — those can drift in naming. With Handlebars-rendered headings, the section names are fixed.
+
+---
+
+## 5. Risks
+
+### Risk 1: Document inventory split may lose analytical context
+
+The current `document_inventory` task generates both metadata (file name, type) and analytical assessment (relevance, summary). Splitting into mechanical metadata + AI analysis could lose the connection between "this file is called X" and "this file is relevant because Y." The AI analysis task needs to receive the mechanical document list as context.
+
+**Mitigation:** Pass `document_names` and `document_types` to the AI task prompt so it can reference specific files by name.
+
+### Risk 2: Handler field extraction changes modal contract
+
+The handler currently ignores `description` and `research_topic` modal fields. Fixing this is correct but changes behavior — studies that were analyzed with `description = studyName` will now have `description = ""` (researcher's actual input, which is often blank for the optional field). The rendered document's `{{description}}` conditional will behave differently.
+
+**Mitigation:** Fall back to `studyName` when fields are blank, matching current behavior as the default.
+
+### Risk 3: Smaller restructure than brief — less opportunity to validate pattern
+
+The brief restructure was comprehensive (monolithic body → 7 tasks, pre-render JSON, ID assignment). The desk research restructure is smaller (handler fixes + document inventory split + cascade summary). This means less opportunity to validate that the v7.0 pattern generalizes. The real validation comes with the next template that has a substantially different architecture.
+
+**Mitigation:** Accept this. The desk research restructure is genuinely simpler — don't inflate it to match the brief's scope.
+
+---
+
+## 6. Implementation sequence
+
+1. Fix handler: extract modal fields, pass `topic`, add document inventory data
+2. Split `document_inventory` task: mechanical file list via Handlebars, AI analysis for summaries/relevance
+3. Standardize masthead (remove centered `<div>`, match brief/plan pattern)
+4. Add cascade summary section
+5. Test: typecheck, unit tests, manual generation with uploaded documents
+6. Verify: variable extraction produces same shapes as before
+
+**Estimated effort:** 1 session (smaller than brief restructure).
+
+---
+
+## 7. What this document does NOT cover
+
+- Discovery workspace changes (`_discovery/` folder structure) — already decided, not changing
+- Survey synthesis or stakeholder synthesis restructures — each gets its own delta
+- The `source_artifacts` orphaned variable — tracked in v1.1 followups, not addressed here


### PR DESCRIPTION
## Summary

- Desk research template restructured to v7.0 interleaved Handlebars/AI (ADR 0005/0016 pattern)
- 3 pre-existing handler bugs fixed: modal fields silently ignored, topic variable never set, minimal template input
- Document inventory split: mechanical file list via Handlebars + AI analytical summaries
- Masthead standardized, cascade summary added, OUTPUT BOUNDARIES on all tasks
- Delta document included for audit trail

## Test plan

- [x] Typecheck clean
- [x] 76/76 unit tests passing
- [ ] Run desk research with uploaded documents — verify mechanical document table + AI analysis
- [ ] Verify description and research_topic modal fields appear in rendered output
- [ ] Check cascade variable shapes unchanged (discovered_barriers, discovered_metrics, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)