### PR TITLE
fix: desk research derived variables + theme numbering

### DIFF
--- a/backend/src/helpers/slack/commands/discovery/deskResearchHandler.ts
+++ b/backend/src/helpers/slack/commands/discovery/deskResearchHandler.ts
@@ -37,6 +37,8 @@ interface MutableBlock {
 interface DeskResearchTemplateInput {
   selected_study: string;
   topic: string;
+  effective_topic: string;
+  topic_slug: string;
   research_topic: string;
   description: string;
   document_content: string;
@@ -197,9 +199,16 @@ async function handleDeskResearchSubmission({ ack, body, view, client }: SlackVi
     const documentNames = processedFiles.map((f: any) => f.name as string);
     const documentTypes = processedFiles.map((f: any) => f.type as string);
 
+    // derived_variables in YAML is documentation-only (not processed by yamlProcessor),
+    // so the handler must compute these for Handlebars rendering and discovery scoping.
+    const effectiveTopic = researchTopic || topic;
+    const topicSlug = topic.toLowerCase().replace(/[\s_]+/g, '-').replace(/[^a-z0-9-]/g, '').replace(/-+/g, '-').replace(/^-|-$/g, '');
+
     const deskResearchData: DeskResearchTemplateInput = {
       selected_study: studyName,
       topic,
+      effective_topic: effectiveTopic,
+      topic_slug: topicSlug,
       research_topic: researchTopic,
       description,
       document_content: formattedDocumentContent,
@@ -208,7 +217,7 @@ async function handleDeskResearchSubmission({ ack, body, view, client }: SlackVi
       document_types: documentTypes,
     };
 
-    console.log(`📚 Assembled desk research data: ${deskResearchData.document_count} documents, topic: "${topic}", study: ${studyName}`);
+    console.log(`📚 Assembled desk research data: ${deskResearchData.document_count} documents, topic: "${effectiveTopic}", names: [${documentNames.join(', ')}], study: ${studyName}`);
 
     const study = await getResearchStudyWithRoles(studyName);
 

--- a/config/prompts/desk_research.yaml
+++ b/config/prompts/desk_research.yaml
@@ -197,6 +197,7 @@ ai_generation_tasks:
       Requirements:
       - Only include themes with at least 2 pieces of direct evidence
       - Maximum 5 themes
+      - Number themes sequentially starting at 1 with no gaps (1, 2, 3... not 1, 2, 4)
       - Each theme must have clear implications stated
 
       OUTPUT BOUNDARIES: Do not generate section headings, sub-headings,


### PR DESCRIPTION
## Summary

- Handler now computes `effective_topic` and `topic_slug` explicitly (YAML `derived_variables` is documentation-only, never processed by yamlProcessor)
- Theme numbering rule added to prevent LLM skipping numbers
- Enhanced logging for document inventory debugging

## Test plan

- [x] Typecheck clean
- [x] 76/76 unit tests passing
- [ ] Re-run desk research on same study — verify title, topic, document_count, document table all render
- [ ] Verify themes numbered sequentially without gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)