### PR TITLE
fix: desk research mechanical values — correct handler + dual path followup

### DIFF
--- a/backend/src/helpers/slack/commands/discoverHandler.ts
+++ b/backend/src/helpers/slack/commands/discoverHandler.ts
@@ -65,6 +65,7 @@ interface UploadedFile {
 /** Data shape passed to discovery YAML templates. */
 interface DiscoveryTemplateInput {
   topic: string;
+  effective_topic: string;
   topic_slug: string;
   team: string;
   description: string;
@@ -74,6 +75,10 @@ interface DiscoveryTemplateInput {
   _discovery_team: string;
   selected_study: string;
   study_name: string;
+  // Mechanical document inventory (handler-assembled for Handlebars)
+  document_count: number;
+  document_names: string[];
+  document_types: string[];
   // Survey-specific
   survey_name?: string;
   question_focus?: string;
@@ -312,8 +317,13 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
     const parsedDocuments: ParsedDocuments = parseDocuments(documents);
     const formattedDocumentContent: string = parsedDocuments.structured_format;
 
+    // Mechanical document inventory for Handlebars rendering
+    const documentNames = processedFiles.map((f: ProcessedFile) => f.name);
+    const documentTypes = processedFiles.map((f: ProcessedFile) => f.type);
+
     const data: DiscoveryTemplateInput = {
       topic,
+      effective_topic: topic,
       topic_slug: topicSlug,
       team,
       description: description || topic,
@@ -323,6 +333,9 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
       _discovery_team: team,
       selected_study: `discovery-${topicSlug}`,
       study_name: topic,
+      document_count: processedFiles.length,
+      document_names: documentNames,
+      document_types: documentTypes,
     };
 
     // Survey-specific fields

--- a/docs/v1.1-followups.md
+++ b/docs/v1.1-followups.md
@@ -124,3 +124,11 @@ The cascade context display in plan modal (and other modals) is hardcoded agains
 **Why deferred:** `desk_research` (the most-used discovery template) is now fixed. The other two are next in the restructure queue. If a production study triggers the bug before restructure, apply option (c).
 **Effort:** S (option c: 10 minutes per handler) or M (option b: 1 day to implement yamlProcessor processing).
 **Source:** Desk research restructure delta audit.
+
+### Dual handler paths for desk research
+
+`deskResearchHandler.ts` handles standalone desk research uploads via `upload_desk_research` action / `upload_desk_research_modal` callback. `discoverHandler.ts` handles `/qori-discover` which routes all three discovery types (desk research, stakeholder, survey) through a unified flow. Both handlers call `processYamlTemplate` with `desk_research.yaml` but assemble their data objects independently with different interfaces (`DeskResearchTemplateInput` vs `DiscoveryTemplateInput`). Bug fixes must be applied to both handlers — the desk research restructure initially fixed only `deskResearchHandler` while production used `discoverHandler`. Consider consolidating: either `deskResearchHandler` calls into `discoverHandler` for the desk research path, or both import a shared data assembly function.
+
+**Why deferred:** Both handlers now produce consistent data. The duplication is a maintenance risk, not a current bug.
+**Effort:** S (0.5 day). Extract shared desk research data assembly into a utility, or have deskResearchHandler delegate to discoverHandler.
+**Source:** Desk research v7.0 restructure — wrong handler debugged via Railway logs.

--- a/docs/v1.1-followups.md
+++ b/docs/v1.1-followups.md
@@ -112,3 +112,15 @@ The cascade context display in plan modal (and other modals) is hardcoded agains
 **Why deferred:** Works correctly once updated. The drift risk is low when template restructures happen infrequently.
 **Effort:** M (1–2 days). Parse YAML `consumes` blocks at startup or build time, generate `TEMPLATE_CONSUMES` automatically.
 **Source:** Brief restructure Stream B field audit.
+
+### derived_variables in YAML is documentation-only — handlers must compute explicitly
+
+`yamlProcessor` does not process `derived_variables` blocks. All three discovery templates (`desk_research`, `survey_synthesis`, `stakeholder_synthesis`) declare `derived_variables` with `topic_slug`; only `desk_research`'s handler now computes it (fixed during v7.0 restructure). `survey_synthesis` and `stakeholder_synthesis` have the same bug — `topic_slug` renders empty, affecting filename (loses topic prefix) and discovery variable scoping.
+
+**Production impact:** When `topic_slug` is falsy, `yamlProcessor` line 363 skips the discovery-scope write path and falls through to the study-level variable store. This means `survey_synthesis` and `stakeholder_synthesis` cascade variables are written to `study-variables.json` instead of `_discovery/`. The brief handler's `loadDiscoveryArtifacts` reads from `_discovery/`, so it would miss these variables entirely. Bug is latent if no production studies have run survey or stakeholder synthesis yet.
+
+**Resolution options:** (a) Fix each handler during its v7.0 restructure (next in queue). (b) Implement `derived_variables` processing in `yamlProcessor` so the YAML blocks actually work. (c) Quick interim fix: add `topic_slug` computation to survey and stakeholder handlers now. Option (a) is planned; option (c) is warranted if production studies are running those templates.
+
+**Why deferred:** `desk_research` (the most-used discovery template) is now fixed. The other two are next in the restructure queue. If a production study triggers the bug before restructure, apply option (c).
+**Effort:** S (option c: 10 minutes per handler) or M (option b: 1 day to implement yamlProcessor processing).
+**Source:** Desk research restructure delta audit.


### PR DESCRIPTION
## Summary

- Root cause found: `/qori-discover` routes through `discoverHandler.ts`, not `deskResearchHandler.ts`. Previous fix targeted the wrong handler.
- Added `effective_topic`, `document_count`, `document_names`, `document_types` to `discoverHandler.ts`'s `DiscoveryTemplateInput`
- Both handlers now produce consistent data (verified field-by-field)
- Filed dual handler path as v1.1 followup — both are live (different entry points), duplication is a maintenance risk

## Test plan

- [x] Typecheck clean
- [x] 76/76 unit tests passing
- [ ] Re-run `/qori-discover` desk research — verify title, topic, document count, document table all render
- [ ] Verify cascade summary "Documents analyzed" count renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)