### PR TITLE
fix: normalize ## headings in stakeholder and survey synthesis

### DIFF
--- a/config/prompts/stakeholder_synthesis.yaml
+++ b/config/prompts/stakeholder_synthesis.yaml
@@ -271,10 +271,11 @@ ai_generation_tasks:
       **SECTION 07 — RECOMMENDATIONS:** Three sub-sections: Immediate (table), Near-term (table), Strategic (table). Each: Action | Constraint addressed | Owner
 
       OUTPUT BOUNDARIES: Do not generate the document title, masthead,
-      section heading markers (## 01, etc.), methodology section, appendix,
-      validity checklist, references, or cascade summary. The template
-      handles all document structure. Output only the analytical content
-      for each section, separated by --- dividers between sections.
+      methodology section, appendix, validity checklist, references, or
+      cascade summary. The template handles those sections.
+      USE ## headings for each section (e.g., ## 01 &nbsp;&nbsp; Constraints).
+      Output the analytical content with proper markdown heading hierarchy,
+      separated by --- dividers between sections.
 
   # Appendix observations — raw system/process observations for downstream
   # service blueprint. Preservation, not synthesis.

--- a/config/prompts/survey_synthesis.yaml
+++ b/config/prompts/survey_synthesis.yaml
@@ -247,8 +247,9 @@ ai_generation_tasks:
 
       OUTPUT BOUNDARIES: Do not generate the document title, masthead,
       methodology section, references, knowledge gaps section, or any
-      footer. The template handles all document structure. Output only
-      the analytical content for overview, themes, and sentiment.
+      footer. The template handles those sections.
+      USE ## headings for each section (e.g., ## Overview, ## Theme 1: [Name]).
+      Output the analytical content with proper markdown heading hierarchy.
 
   # Knowledge gaps — what the survey couldn't answer
   - task_id: "knowledge_gaps_prose"


### PR DESCRIPTION
## Summary

Both stakeholder_synthesis and survey_synthesis analysis_body tasks used **BOLD TEXT:** instead of `##` markdown headings. Caused by OUTPUT BOUNDARIES instruction prohibiting heading markers. Fix: explicitly instruct LLM to use `##` headings.

No extraction impact — extract_from hints reference section names, not heading format.

## Test plan

- [x] Typecheck clean
- [x] 76/76 unit tests passing
- [ ] Regenerate stakeholder synthesis — verify `##` headings
- [ ] Regenerate survey synthesis — verify `##` headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)