### PR TITLE
fix: pass selected_study to readout templates

### DIFF
--- a/backend/src/helpers/slack/commands/readoutHandler.ts
+++ b/backend/src/helpers/slack/commands/readoutHandler.ts
@@ -60,6 +60,7 @@ interface ModalState {
 
 /** Data shape passed to readout YAML templates. */
 interface ReadoutTemplateInput {
+  selected_study: string;
   research_folder_path: string;
   study_name: string;
   researcher_contact: string;
@@ -480,6 +481,7 @@ const handleReadoutModalSubmission = async ({ ack, body, view, client }: SlackVi
       : 'No files detected';
 
     const reportData: ReadoutTemplateInput = {
+      selected_study: selectedStudyName,
       research_folder_path: folderPath,
       study_name: selectedStudyName,
       researcher_contact: selectedStudy?.researcher_name || selectedStudy?.researcher_email || 'Unknown Researcher',

--- a/config/prompts/designer_readout.yaml
+++ b/config/prompts/designer_readout.yaml
@@ -263,7 +263,7 @@ ai_generation_tasks:
 
       **Dependencies:**
       - Blocked by: [Other ticket IDs, or "None"]
-      - Related engineering work: [Leave empty for now — cross-template linking is a future enhancement]
+      - Related engineering work: — None at this time
 
       ---
 


### PR DESCRIPTION
## Summary

- Fix empty study name in designer_readout masthead and document title — `readoutHandler.ts` wasn't passing `selected_study` to the template input
- Fix dependency placeholder rendering literally in ticket candidates — bracketed prompt instruction was being treated as content

## Test plan

- [ ] Regenerate designer readout on Railway — verify study name appears in title and masthead
- [ ] Verify ticket candidates show "— None at this time" for related engineering work, not bracketed instruction text

🤖 Generated with [Claude Code](https://claude.com/claude-code)