### PR TITLE
feat: leadership_readout + accessibility_readout v7.0 — all readouts complete

### DIFF
--- a/config/prompts/leadership_readout.yaml
+++ b/config/prompts/leadership_readout.yaml
@@ -4,16 +4,17 @@
 id: leadership_readout
 name: run_leadership_readout
 label: "👔 Leadership Brief"
-version: "v1.0"
+version: "v7.0"
 
 description: |
   Executive brief translating research findings into leadership-level decisions.
   BLUF-style, 2-3 pages max. Document only — no tickets. Emits exec_summary_points.
-  Consumes from research_readout v6.0.
+  v7.0: Interleaved Handlebars/AI — mechanical content rendered by template,
+  LLM writes bounded analytical sections. Per ADR 0005/0016.
 
 author: Qori R&D
 created: 2026-05-07
-last_updated: 2026-05-07
+last_updated: 2026-05-20
 
 # ═══════════════════════════════════════════════════════════
 # CONFIGURATION
@@ -79,24 +80,54 @@ emits:
     extract_from: "Key findings, recommended actions, decision points, and risks sections"
 
 # ═══════════════════════════════════════════════════════════
-# AI GENERATION
+# AI GENERATION — focused, bounded tasks
 # ═══════════════════════════════════════════════════════════
 ai_generation_tasks:
-  - task_id: "leadership_readout_complete"
-    prompt: |
-      You are creating an executive brief for senior leadership. Audience: product
-      owners, directors, stakeholders who funded the study. They have 5-10 minutes
-      to read this.
 
-      IMPORTANT: This document is SHORT — 2-3 pages maximum. Brevity over
-      completeness. Detail goes in appendix.
+  # Main analytical body — bottom line, key findings, recommended actions,
+  # decisions required, business impact, risks if inaction, methodology
+  # summary, detailed findings for appendix.
+  # Document-only — no tickets. BLUF-style, 2-3 pages max.
+  # exec_summary_points (7 fields) extracted from output — no downstream
+  # consumers, document-only variable.
+  - task_id: "analysis_body"
+    prompt: |
+      You are creating an executive brief for senior leadership. Audience:
+      product owners, directors, stakeholders who funded the study.
+      They have 5-10 minutes to read this.
+
+      THIS DOCUMENT IS SHORT — 2-3 pages maximum. Brevity over completeness.
+
+      ============================================================
+      CRITICAL RULES
+      ============================================================
+
+      RULE 1: BOTTOM LINE UP FRONT. First sentence states what they need
+      to know. No methodology preamble.
+
+      RULE 2: DECISIONS, NOT DATA. Leadership wants to know what to decide,
+      not how findings were extracted.
+
+      RULE 3: BUSINESS IMPACT IN THEIR LANGUAGE. Tie findings to strategy,
+      user metrics, compliance risk, budget. Not "users abandon tasks" but
+      connect to business outcomes from upstream business_context.
+
+      RULE 4: BREVITY OVER COMPLETENESS. Top 3-5 findings only. Detail
+      goes in appendix.
+
+      RULE 5: ANTI-FABRICATION. Don't invent business metrics, financial
+      implications, or strategic priorities not in upstream variables.
+      If business_context mentions specific pressures, reference them.
+      Otherwise stay descriptive.
+
+      RULE 6: PRIVACY. PT-XXX only, but aggregate where possible.
+      Leadership rarely needs individual participant citations.
+
+      RULE 7: NO RAW JSON. Format all upstream data as readable text.
 
       ============================================================
       UPSTREAM DATA (from research readout)
       ============================================================
-
-      NOTE: The data below may be in JSON format. Extract human-readable content
-      and format as clean markdown. NEVER copy JSON syntax into the output.
 
       PRIORITIZED FINDINGS:
       {{upstream_prioritized_findings}}
@@ -115,35 +146,6 @@ ai_generation_tasks:
       {% endif %}
 
       ============================================================
-      CASCADE-AWARE LEADERSHIP READOUT GENERATION
-      ============================================================
-
-      1. **Bottom Line Up Front.** First sentence states what they need to know.
-         No methodology preamble.
-
-      2. **Decisions, not data.** Leadership wants to know what to decide, not how
-         findings were extracted. Findings are evidence; decisions are the artifact.
-
-      3. **Business impact in their language.** Tie findings to strategy, user metrics,
-         compliance risk, budget. Not "users abandon tasks" but connect to business
-         outcomes mentioned in upstream business_context.
-
-      4. **Brevity over completeness.** If there are 5+ findings, surface the top 3-5.
-         Detail goes in appendix.
-
-      5. **Decision points explicit.** When a decision is required, state it:
-         "Leadership decision required: [Question]. Recommendation: [Path]."
-
-      6. **Anti-fabrication.** Don't invent business metrics, financial implications, or
-         strategic priorities not in upstream variables. If business_context from brief
-         mentions specific business pressures, reference them. Otherwise stay descriptive.
-
-      7. **Privacy preserved.** PT-XXX codes only, but leadership doc rarely needs to
-         cite individual participants. Aggregate where possible.
-
-      8. **No raw JSON in output.** Format all upstream data as readable text.
-
-      ============================================================
       INPUT
       ============================================================
 
@@ -151,36 +153,19 @@ ai_generation_tasks:
       **Researcher:** {{researcher_contact}}
 
       ============================================================
-      OUTPUT FORMAT — FOLLOW EXACTLY
+      GENERATE THESE SECTIONS
       ============================================================
 
-      # Leadership Brief: {{study_name}}
-
-      **Study:** {{selected_study}} &nbsp; | &nbsp; **Audience:** Leadership &nbsp; | &nbsp; **Date:** {{current_date}} &nbsp; | &nbsp; **Status:** Draft
-
-      ---
-
-      ## Cascade summary
-
-      | Source | Count |
-      |--------|-------|
-      | Research findings | [count] |
-      | Recommendations | [count] |
-      | Decision inputs | [count or "Not available"] |
-
-      ---
+      Output ALL sections below. Use ## headings. Do not stop early.
 
       ## Bottom line
 
-      [2-3 sentences maximum. What leadership needs to know. Lead with the most
-      consequential finding. Frame in business terms.]
+      [2-3 sentences maximum. What leadership needs to know. Lead with the
+      most consequential finding. Frame in business terms.]
 
       ---
 
       ## Key findings
-
-      [Top 3-5 findings, bulleted. Each finding is 1-2 sentences in leadership
-      language. Reference finding IDs for traceability but don't dwell on methodology.]
 
       - **[Finding title]** — [Business-level impact statement] _(finding-XX)_
       - **[Finding title]** — [Business-level impact statement] _(finding-XX)_
@@ -190,44 +175,31 @@ ai_generation_tasks:
 
       ## Recommended actions
 
-      [Top 3-5 actions, prioritized. Each action includes owner and effort level.
-      Frame as decisions, not research recommendations.]
-
       | Priority | Action | Owner | Effort |
       |:--------:|--------|-------|:------:|
       | 1 | [Action in leadership language] | [Team] | [H/M/L] |
       | 2 | [Action] | [Team] | [H/M/L] |
-      | 3 | [Action] | [Team] | [H/M/L] |
 
       ---
 
-      [If any decisions require leadership input, include this section.
-      If no decisions required, omit it.]
-
+      {% if upstream_decision_inputs %}
       ## Decisions required
-
-      [State each decision clearly with recommended path.]
 
       **Decision:** [Question that needs leadership input]
       **Recommendation:** [Recommended path with rationale]
       **Impact of delay:** [What happens if decision is deferred]
+      {% endif %}
 
       ---
 
       ## Business impact
 
       [Connect findings to business outcomes. Use upstream business_context
-      if available. Frame in terms leadership tracks: user metrics, compliance
-      risk, operational costs, strategic alignment.]
-
-      [2-3 paragraphs maximum. No methodology details.]
+      if available. 2-3 paragraphs maximum. No methodology details.]
 
       ---
 
       ## Risks if inaction
-
-      [What happens if these findings are not addressed. Frame as business risk,
-      compliance risk, or user impact at scale. 3-4 bullet points.]
 
       - [Risk statement with consequence]
       - [Risk statement with consequence]
@@ -238,59 +210,72 @@ ai_generation_tasks:
       ## Methodology summary
 
       [1 paragraph. Just enough for leadership to understand how conclusions
-      were reached. No academic detail.]
+      were reached.]
 
       ---
-
-      ## Appendix
 
       <details>
       <summary><strong>Detailed findings</strong></summary>
 
       [For each finding, provide the full detail: evidence quotes, severity,
-      participant count affected. This is for leadership who want to dig deeper.]
-
-      [Format each as a brief paragraph with the finding title, evidence summary,
-      and severity. Reference finding IDs.]
+      participant count affected. Reference finding IDs.]
 
       </details>
 
-      <details>
-      <summary><strong>Upstream context</strong></summary>
-
-      This leadership brief was generated from:
-
-      | Variable | Source | Status |
-      |----------|--------|--------|
-      | prioritized_findings | research_readout | [Available/Missing] |
-      | prioritized_recommendations | research_readout | [Available/Missing] |
-      | decision_inputs | research_readout | [Available/Missing] |
-      | business_context | research_brief | [Available/Missing] |
-
-      </details>
-
-      ============================================================
-      QUALITY CHECKS (do not include in output)
-      ============================================================
-
-      Before outputting, verify:
-      - Document is 2-3 pages maximum (brevity is critical)
-      - Bottom line leads with most consequential finding
-      - Findings framed in business language, not research language
-      - Recommended actions have clear owners
-      - No raw JSON anywhere in output
-      - Decision points are explicit when present
-      - No methodology detail in main body (appendix only)
-      - Privacy: no real names, aggregate where possible
-      - Finding IDs traceable to upstream prioritized_findings
-
-      Do NOT output a footer or "Generated by Qori" line — that is added automatically.
+      OUTPUT BOUNDARIES: Do not generate the document title, masthead,
+      cascade summary, upstream context, or any footer. The template
+      handles those. USE ## headings for each section.
 
 # ═══════════════════════════════════════════════════════════
-# OUTPUT
+# OUTPUT — interleaved Handlebars + AI prose
 # ═══════════════════════════════════════════════════════════
 output_template: |
-  {{ai_generated.leadership_readout_complete}}
+  # Leadership Brief: {{selected_study}}
+
+  **Study:** {{selected_study}} &nbsp; | &nbsp; **Audience:** Leadership &nbsp; | &nbsp; **Researcher:** {{researcher_contact}} &nbsp; | &nbsp; **Date:** {{current_date}}
+
+  ---
+
+  {{ai_generated.analysis_body}}
+
+  ---
+
+  <details>
+  <summary><strong>Upstream context</strong></summary>
+
+  This leadership brief was generated from:
+
+  | Variable | Source | Role |
+  |----------|--------|------|
+  | prioritized_findings | research_readout | Top-level impact |
+  | prioritized_recommendations | research_readout | Resource allocation decisions |
+  {{#if upstream_decision_inputs}}| decision_inputs | research_readout | Decision frame |
+  {{/if}}{{#if upstream_business_context}}| business_context | research_brief | Business pressures |
+  {{/if}}
+
+  </details>
+
+  ---
+
+  ---
+
+  ## Cascade summary
+
+  This leadership brief emits variables for potential downstream consumption.
+
+  | Variable | Description |
+  |----------|-------------|
+  | exec_summary_points | Executive-level statements with business implications and recommended actions |
+
+  **Consumed from upstream:**
+
+  | Variable | Source | Role |
+  |----------|--------|------|
+  | prioritized_findings | research_readout | Top-level impact |
+  | prioritized_recommendations | research_readout | Resource allocation |
+  | decision_inputs | research_readout | Decision frame |
+  | business_context | research_brief | Business pressures |
+  | methodology_selection | research_brief | Study methodology context |
 
 output_options:
   path: "05-reports/"
@@ -302,7 +287,7 @@ output_options:
 processing_workflow:
   1. validate_inputs
   2. read_upstream_variables
-  3. execute_leadership_readout_complete_task
+  3. execute_analysis_body_task
   4. render_output_template
   5. save_to_reports_folder
 
@@ -313,15 +298,22 @@ notify:
     message: "Leadership brief for {{study_name}} is ready for review."
 
 notes: |
+  v7.0: Interleaved Handlebars/AI architecture (ADR 0005/0016 pattern).
+  - Monolithic leadership_readout_complete task replaced by analysis_body task.
+  - Handlebars renders: masthead, upstream context (toggle), cascade summary
+    (always present).
+  - No validity checklist (intentional — document too short for checklist
+    to add value; anti-fabrication guards serve same purpose).
+  - Cascade summary changed from LLM-generated count table to standard v7.0
+    emits/consumes format.
+  - OUTPUT BOUNDARIES with ## heading instruction added.
+  - Internal quality checklist removed.
+  - Document-only: no tickets, no ticketHandler integration.
+    exec_summary_points (7 fields) has no downstream consumers.
+  - Detailed findings appendix toggle content generated by AI task
+    (leadership wants depth available but not in main body).
+
   v1.0: Initial leadership readout template.
-  - Single-task architecture (leadership_readout_complete)
-  - Consumes: prioritized_findings, prioritized_recommendations (required, grounding),
-    decision_inputs (optional, grounding), business_context (optional, context),
-    methodology_selection (optional, context)
-  - Emits: exec_summary_points (array of exec_summary_point schema) — document only, no tickets
-  - BLUF-style: 2-3 pages max, decisions over data, business language
-  - Shorter than other audience templates by design
-  - Detailed findings in collapsible appendix for leadership who want depth
 
 output_use: |
   Executive brief translating research findings into leadership-level decisions.

--- a/docs/leadership-readout-restructure-delta.md
+++ b/docs/leadership-readout-restructure-delta.md
@@ -1,0 +1,193 @@
+# Leadership Readout Restructure Delta: v1.0 to v7.0 Conformance
+
+**Date:** 2026-05-20
+**Status:** Proposed (awaiting approval before implementation)
+**Reference:** `designer_readout.yaml` v7.0 (structural), `research_readout.yaml` v7.0 (synthesis pattern), ADR 0005/0016
+
+---
+
+## 1. Current state of leadership_readout
+
+Same "single LLM" pattern:
+
+```handlebars
+{{ai_generated.leadership_readout_complete}}
+```
+
+One task generates the entire document — title, masthead, cascade summary (count table), bottom line (BLUF), key findings (bulleted), recommended actions table, decisions required (conditional), business impact, risks if inaction, methodology summary, appendix (detailed findings toggle, upstream context toggle).
+
+### Architecture
+
+One AI task: `leadership_readout_complete` (~200 lines of prompt — the shortest readout). Same `readoutHandler.ts` routing. Both "Executive Leadership" and "Product Leadership" checkbox options map to `leadership_readout.yaml`.
+
+### Cascade contract — consumes
+
+| Variable | Source | Required | inject_as |
+|----------|--------|----------|-----------|
+| `prioritized_findings` | research_readout | Yes | grounding |
+| `prioritized_recommendations` | research_readout | Yes | grounding |
+| `decision_inputs` | research_readout | No | grounding |
+| `business_context` | research_brief | No | context |
+| `methodology_selection` | research_brief | No | context |
+
+5 upstream variables, 2 required. **Does consume `decision_inputs`** — unique among readouts. This is the only readout that uses the decision frame extracted by research_readout (decision questions with recommended paths and evidence summaries).
+
+### Cascade contract — emits
+
+| Variable | Schema | Model | Downstream consumers |
+|----------|--------|-------|---------------------|
+| `exec_summary_points` | `$ref: schemas/exec_summary_point.yaml` (7 fields) | Sonnet | **None** (document-only) |
+
+**No downstream consumers.** The schema explicitly states "Consumed by: none (document-only, no downstream tickets)". `ticketHandler.ts` has no leadership audience config — the Step 1 modal explicitly says "Leadership readouts are document-only — no tickets."
+
+### exec_summary_points schema — 7 fields
+
+**Required (3):**
+- `id` — Format: exec-point-001, exec-point-002
+- `point` — Executive-level statement (1-2 sentences)
+- `supporting_findings` — Finding IDs (finding-XX)
+
+**Optional (4):**
+- `category` — Enum: risk, opportunity, decision_required, validation, recommendation
+- `business_implication` — Why this matters at executive level
+- `recommended_action` — What leadership should do
+- `effort_summary` — Resource implication summary
+
+**Assessment:** The schema is lightweight and appropriate for its purpose. 7 fields is intentionally minimal — executive summary points don't need the depth of ticket schemas. The `category` enum effectively sorts points for leadership scanning. No alignment needed — this is a different pattern from tickets entirely.
+
+### What the LLM controls that it shouldn't
+
+| Value | Current | Should be |
+|-------|---------|-----------|
+| Document title + masthead | LLM generates | Handlebars |
+| Cascade summary (count table) | LLM computes counts | Handlebars (mechanical) |
+| Methodology summary | LLM generates 1 paragraph | Keep in LLM — leadership-appropriate synthesis |
+| Upstream context table | LLM generates with Available/Missing | Handlebars (conditional) |
+
+**Note:** Leadership readout intentionally keeps methodology in the main body (1 paragraph) rather than a toggle — leadership wants to see how conclusions were reached, but briefly. This stays in the AI task.
+
+### Anti-fabrication guards
+
+**Present and leadership-appropriate.** 8 numbered rules:
+
+1. Bottom Line Up Front
+2. Decisions, not data
+3. Business impact in leadership language
+4. Brevity over completeness
+5. Decision points explicit
+6. **Anti-fabrication: Don't invent business metrics, financial implications, or strategic priorities not in upstream.** If business_context mentions specific pressures, reference them. Otherwise stay descriptive.
+7. Privacy — PT-XXX only, aggregate where possible
+8. No raw JSON
+
+**Assessment:** Rule 6 is critical for leadership audiences — LLMs commonly invent ROI figures, strategic priorities, and budget implications. The guard correctly instructs: reference upstream business_context when available, otherwise stay descriptive. Preserved as-is.
+
+### Cascade summary status
+
+**LLM-generated, wrong format.** Same as other readouts — count table instead of v7.0 contract format.
+
+### Notable structural differences from other readouts
+
+1. **BLUF-style architecture.** Bottom Line section leads — no methodology preamble. 2-3 pages max.
+2. **No tickets.** Document-only. No ticket candidates section, no sequencing, no dependency graph.
+3. **"Decisions required" section** (conditional). Explicit decision questions with recommended paths and "impact of delay." Unique to leadership.
+4. **"Risks if inaction" section.** Frames consequences of not acting on findings. Business risk, compliance risk, user impact at scale.
+5. **"Business impact" section.** Connects findings to business outcomes from upstream business_context. Strategic language.
+6. **Methodology in main body** (1 paragraph, not toggle). Leadership sees how conclusions were reached but briefly.
+7. **Detailed findings in appendix toggle.** Inverse of other readouts where findings are in the main body.
+8. **Shortest prompt** (~200 lines vs designer's ~300, engineering's ~300, accessibility's ~310).
+
+### Handler concerns
+
+Same `readoutHandler.ts`. `selected_study` already fixed. No changes needed.
+
+---
+
+## 2. Target state
+
+Same pattern: single `analysis_body` task + Handlebars for structure.
+
+### Task split
+
+Leadership readout has cross-section coherence — bottom line references key findings, recommended actions reference finding IDs, decisions required trace to findings, business impact references findings. One task preserves coherence.
+
+**Recommended split:**
+1. `analysis_body` — Bottom line (BLUF), key findings (bulleted with finding IDs), recommended actions table, decisions required (conditional), business impact, risks if inaction, methodology summary (1 paragraph), detailed findings appendix content. One task.
+2. Handlebars — masthead, cascade summary (standard v7.0 format), upstream context (toggle, conditional), validity-level checklist not needed for leadership (document is too short for a checklist to add value — omit).
+
+**Decision: omit validity checklist for leadership.** The other readouts have validity checklists because they generate structured data (tickets) where verification matters. Leadership brief is a narrative document — a validity checklist adds noise for no value. The anti-fabrication guards in the prompt serve the same purpose.
+
+---
+
+## 3. Specific changes required
+
+### 3a. YAML changes
+
+**Split into 1 AI task + Handlebars structure:**
+
+1. `analysis_body` — Bottom line, key findings, recommended actions, decisions required (conditional), business impact, risks if inaction, methodology summary (1 paragraph), detailed findings (for appendix toggle content). USE `##` headings.
+
+**Handlebars renders:**
+
+- **Masthead:** `# Leadership Brief: {{selected_study}}`
+  - Study, audience, researcher, date
+- **Cascade summary** (standard v7.0 format):
+  - Emits table: `exec_summary_points`
+  - Consumes table: all 5 upstream variables
+- **Upstream context** (in `<details>` toggle, conditional):
+  - Variable table with source and role
+- **No validity checklist** (intentional — document too short for checklist to add value)
+
+**Clean up:**
+- OUTPUT BOUNDARIES with `##` heading instruction
+- Remove quality checklist
+- Move detailed findings appendix content into the AI task output, wrapped by Handlebars `<details>` toggle
+- Fix version to v7.0
+
+### 3b. Handler changes
+
+None. Same `readoutHandler.ts`. `selected_study` already in place.
+
+### 3c. Cascade contract changes
+
+None. `exec_summary_points` emit schema unchanged (7 fields). No downstream consumers to affect.
+
+---
+
+## 4. Risks
+
+### Risk 1: exec_summary_points extraction (7 fields, Sonnet)
+
+Smallest schema of any readout emit. Low extraction risk. The `category` enum and `supporting_findings` array are straightforward.
+
+**Mitigation:** Schema unchanged. Verify after restructure.
+
+### Risk 2: document length after restructure
+
+Leadership brief is intentionally short (2-3 pages). Moving structural elements to Handlebars might make the AI output feel disconnected from the frame. The BLUF pattern requires tight integration between bottom line → findings → actions → decisions.
+
+**Mitigation:** The AI task generates all analytical content in one pass. Handlebars only wraps with masthead and appendix toggles. The analytical flow is unbroken.
+
+---
+
+## 5. Implementation sequence
+
+1. Handlebars skeleton (masthead, cascade summary, upstream context toggle — no validity checklist)
+2. Split AI task (single `analysis_body` replacing `leadership_readout_complete`)
+3. Add OUTPUT BOUNDARIES with `##` heading instruction
+4. Remove internal quality checklist
+5. Verify extraction: `exec_summary_points` (7 fields, Sonnet)
+
+**Estimated effort:** 1 session. Smaller than other readouts due to shorter prompt.
+
+---
+
+## 6. Ticket alignment assessment
+
+**Not applicable.** Leadership readout does not emit tickets. The `exec_summary_points` schema is intentionally different from ticket schemas:
+
+- 7 fields vs designer's 15 / engineering's 21 / accessibility's 18
+- No acceptance criteria, no affected components, no testing approach
+- Purpose is executive distillation, not work item generation
+- `ticketHandler.ts` explicitly excludes leadership: "Leadership readouts are document-only — no tickets"
+
+The v1.1-followups ticket alignment item is now fully resolved — all 3 ticket-generating readouts confirmed production-ready, and leadership confirmed as a different pattern entirely. The followup can be closed.

--- a/docs/product-backlog.md
+++ b/docs/product-backlog.md
@@ -28,10 +28,11 @@ The migration paused template standardization. The plan template (v7.0) and brie
 - **research_readout** v7.0 (upstream of all 4 audience readouts — emits prioritized_findings + prioritized_recommendations)
 - **engineering_readout** v7.0 (21-field ticket schema, already production-ready)
 - **accessibility_readout** v7.0 (18-field compliance/AT schema, P0_legal/P0_severe priority)
+- **leadership_readout** v7.0 (document-only, BLUF-style, exec_summary_points)
 
 ### Remaining
 
-- **Readout templates:** leadership_readout. Emits exec_summary_points (different pattern from ticket-generating readouts).
+- All readout templates complete.
 - **Discussion guide, session_summary, participant_tracker.** Discussion guide has cascade gaps (75-minute partially addressed). Participant tracker has status label mismatch (audit finding).
 - **Other downstream templates:** journey_mapping, jobs_to_be_done, usability_issues, design_opportunities, service_blueprint. Each consumes specific cascade variables and produces specific outputs.
 

--- a/docs/v1.1-followups.md
+++ b/docs/v1.1-followups.md
@@ -18,8 +18,8 @@ Only `research_plan` has template-level tests. The remaining 26 templates have z
 **Effort:** M (1–2 days). Migration + backfill + service updates to write `study_id` alongside `study_name`.
 **Source:** Architecture audit Section 4.1, every audit since Q2.
 
-### 8 templates using single-LLM pattern
-The interleaved Handlebars + bounded LLM slots pattern (ADR 0005) is the target. 11 templates now on v7.0 (research_plan, research_brief, desk_research, stakeholder_synthesis, survey_synthesis, affinity_mapping, persona_generator, designer_readout, research_readout, engineering_readout, accessibility_readout). 8 remain on the older "minimal static + single LLM" pattern. These are harder to structurally test and more likely to produce inconsistent output.
+### 7 templates using single-LLM pattern
+The interleaved Handlebars + bounded LLM slots pattern (ADR 0005) is the target. 12 templates now on v7.0 (research_plan, research_brief, desk_research, stakeholder_synthesis, survey_synthesis, affinity_mapping, persona_generator, research_readout, designer_readout, engineering_readout, accessibility_readout, leadership_readout). 7 remain on the older "minimal static + single LLM" pattern. These are harder to structurally test and more likely to produce inconsistent output.
 
 **Why deferred:** Template restructuring is content work, not migration work. Each template needs a design reference document and a YAML rewrite.
 **Effort:** L (1–2 days per template, 12 templates). Can be done incrementally.
@@ -92,12 +92,8 @@ All v7.0 templates render a validity checklist in a `<details>` toggle, but the 
 **Effort:** S (option a: 0.5 day for a Handlebars helper) or M (option b: 1–2 days for programmatic validation).
 **Source:** Persona generator v7.0 output review.
 
-### Readout ticket body alignment
-Designer_readout (15 fields), engineering_readout (21 fields), and accessibility_readout (18 fields) are all production-ready references with appropriately specialized schemas. Leadership_readout emits `exec_summary_points` (different pattern entirely) and may need its own audit during v7.0 restructure.
-
-**Why deferred:** All 3 ticket-generating readouts confirmed production-grade during v7.0 restructures. Leadership uses a different emit pattern (summary points, not tickets).
-**Effort:** S (0.5 day). Leadership audit only — during its restructure.
-**Source:** Designer v7.0 delta Section 6, engineering v7.0 delta Section 6, accessibility v7.0 delta Section 6.
+### ~~Readout ticket body alignment~~ (RESOLVED 2026-05-20)
+All 3 ticket-generating readouts confirmed production-ready: designer (15 fields), engineering (21 fields), accessibility (18 fields). Leadership confirmed as different pattern (document-only, emits `exec_summary_points`, no tickets). No further work needed.
 
 ### Orphaned cascade variables
 7 variables emitted by producers but never consumed: `source_artifacts`, `backstage_observations`, `system_failure_modes`, `study_methodology`, `unexpected_patterns`, `persona_design_implications`, `sample_demographics`. These accumulate in the variable store with no downstream purpose.


### PR DESCRIPTION
## Summary

- **leadership_readout v7.0:** BLUF-style document-only pattern. No validity checklist (intentional). exec_summary_points (7 fields) with no downstream consumers. Consumes decision_inputs (unique among readouts).
- **accessibility_readout v7.0:** (included in branch) 18-field compliance/AT schema with P0_legal/P0_severe priority. No ticket alignment needed.
- v1.1-followups ticket alignment item fully resolved and marked complete.
- **All 5 readout templates now on v7.0:** research_readout, designer_readout, engineering_readout, accessibility_readout, leadership_readout.

## Test plan

- [ ] Generate leadership brief on Railway — verify BLUF structure renders (2-3 pages)
- [ ] Check extraction: `exec_summary_points` (7 fields, Sonnet) stored in Postgres
- [ ] Verify study name in title and masthead
- [ ] No cross-template verification needed (exec_summary_points has no downstream consumers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)