### PR TITLE
fix: participant tracker status labels and added_by display name

### DIFF
--- a/backend/src/helpers/participantYamlProcessor.ts
+++ b/backend/src/helpers/participantYamlProcessor.ts
@@ -558,7 +558,7 @@ export async function processParticipantYamlTemplate(
         recruitment_source: p.recruitment_source,
         scheduled_date: p.scheduled_date,
         scheduled_time: p.scheduled_time,
-        status_select: p.status_select,
+        status_select: PARTICIPANT_STATUS_LABELS[p.status_select as ParticipantStatus] || p.status_select,
         notes_field: p.notes_field,
         demographics_info: p.demographics_info,
       })),

--- a/backend/src/helpers/slack/commands/participantHandler.ts
+++ b/backend/src/helpers/slack/commands/participantHandler.ts
@@ -9,6 +9,16 @@ import { getConfigRepo, YAML_TEMPLATE_PATH, fetchFileFromRepo } from "../../gith
 import { refreshDashboardAfterAction } from './fieldworkHandler';
 import type { View } from '@slack/types';
 
+/** Resolve Slack user ID to display name. Falls back to username, never to raw ID. */
+async function resolveDisplayName(client: AllMiddlewareArgs['client'], userId: string, fallbackName?: string): Promise<string> {
+  try {
+    const result = await client.users.info({ user: userId });
+    return result.user?.profile?.display_name || result.user?.real_name || fallbackName || 'Unknown';
+  } catch {
+    return fallbackName || 'Unknown';
+  }
+}
+
 async function participantHandler({ ack, body, client, command }: SlackCommandMiddlewareArgs & AllMiddlewareArgs): Promise<void> {
   try {
     console.log("🚀 ~ participantHandler ~ body:", body);
@@ -330,6 +340,7 @@ async function handleUpdateParticipantSubmission({ ack, body, view, client }: Sl
         const yamlTemplateFile = await fetchFileFromRepo(getConfigRepo(), YAML_TEMPLATE_PATH, "participant_tracker.yaml");
 
         if (yamlTemplateFile && yamlTemplateFile.content) {
+          const displayName = await resolveDisplayName(client, body.user.id, body.user.name);
           const templateData = {
             study_id: studyId,
             study_name: study.name,
@@ -337,7 +348,7 @@ async function handleUpdateParticipantSubmission({ ack, body, view, client }: Sl
             status_select: newStatus,
             notes_field: updateNotes,
             current_date: new Date().toISOString().split('T')[0],
-            added_by: body.user.name || body.user.id
+            added_by: displayName
           };
 
           // @ts-expect-error — pre-existing type mismatch from require() → import migration

--- a/docs/participant-tracker-audit.md
+++ b/docs/participant-tracker-audit.md
@@ -1,0 +1,182 @@
+# Participant Tracker Production Audit
+
+**Date:** 2026-05-21
+**Scope:** Production-quality assessment of participant_tracker.yaml + handler + processor
+
+---
+
+## 1. What the rendered tracker looks like
+
+The tracker renders as a GitHub Markdown document at `{study}/primary-research/02-participants/{study_name}_participant_tracker.md`. Sections:
+
+1. **Header** — "Participant Tracker: {study}" + recruitment summary table (total, confirmed, pending, completed counts) + last updated timestamp
+2. **Participant Details** — Roster table: ID, name, recruitment source, date/time, status (emoji + label), notes
+3. **Recruitment Progress** — Breakdown by method (e.g., "Internal VA Panel: 5 (50%)")
+4. **Observer Management** — Session observer assignments with role distribution
+5. **Demographics Overview** (collapsible) — 4 breakdown tables: race/ethnicity, age range, education, location
+6. **Accessibility & Accommodations** — Participant accommodation notes
+7. **Next Steps** — Auto-generated recommendations (follow-up reminders, recruitment targets)
+
+The document is **regenerated on every participant add or status update** — not a one-time generation. Each mutation triggers `processParticipantYamlTemplate()` which fetches all participants from Postgres and re-renders the complete tracker to GitHub.
+
+---
+
+## 2. Handler contract assessment
+
+### What the processor computes
+
+`participantYamlProcessor.ts` computes ALL template variables server-side from the `allParticipants` array. No variable is left to the template — this is the opposite of the "undefined variable" problem flagged in the initial scan.
+
+| Computed variable | Source | Method |
+|---|---|---|
+| `total_participants_count` | `allParticipants.length` | Direct count |
+| `confirmed_sessions_count` | Filter by `CONFIRMED` status | Status filter |
+| `pending_responses_count` | Filter by `CONTACTED` status | Status filter |
+| `completed_sessions_count` | Filter by `COMPLETED` status | Status filter |
+| `participants` | Map with id, name, source, date, time, status, notes | Array map |
+| `recruitment_breakdown` | Group by `recruitment_source`, compute % | `calculateRecruitmentBreakdown()` |
+| `race_ethnicity_breakdown` | Parse `demographics_info.race_ethnicity` | `generateDemographicBreakdowns()` |
+| `age_range_breakdown` | Parse `demographics_info.age_range` | `generateDemographicBreakdowns()` |
+| `education_breakdown` | Parse `demographics_info.education_level` | `generateDemographicBreakdowns()` |
+| `location_breakdown` | Parse `demographics_info.location_type` | `generateDemographicBreakdowns()` |
+| `immediate_actions` | Logic: pending follow-ups, reschedules, recruiting gaps | `generateImmediateActions()` |
+| `followup_needed` | Per-participant action items | `generateFollowupNeeded()` |
+| `session_observers` | `SessionObserverService.getObserverRequestsByStudy()` | Service call |
+| `accommodations` | Filter participants with `notes_field` containing accommodation keywords | Heuristic |
+| `demographics_summary` | "Demographics collected for X of Y participants" | Computed string |
+| `recruitment_analysis` | Conversion rate: confirmed / total | `generateRecruitmentAnalysis()` |
+| `next_steps_recommendations` | Recruiting targets, follow-up reminders | `generateNextStepsRecommendations()` |
+
+**Verdict:** The handler-template contract is complete. The processor computes every variable the template references. The initial scan flagged "undefined variables" incorrectly — the YAML `input_variables` section lists modal form inputs, not template variables. The processor bridges the gap.
+
+---
+
+## 3. Common failure modes
+
+### 0 participants
+
+**What happens:** Processor checks `allParticipants.length > 0` at line 536. If empty, falls through to file-based mode which attempts to parse an existing GitHub file. If no file exists, creates a new file with the single participant being added.
+
+**Risk:** Low. The tracker is only triggered by adding or updating a participant, so there's always at least 1. A study with 0 participants simply has no tracker file yet.
+
+### No observers assigned
+
+**What happens:** Processor calls `SessionObserverService.getObserverRequestsByStudy(study_id)` wrapped in try/catch. If it fails or returns empty, `session_observers` is set to an empty array. The Observer Management section renders with an empty table.
+
+**Risk:** Low. Empty observer table is correct — observers are optional.
+
+### Sparse demographic data
+
+**What happens:** `generateDemographicBreakdowns()` handles nulls — if `demographics_info` is null or fields are missing, participants are counted under "Not specified" / "Unknown" / "Not disclosed" categories. `generateDemographicsSummary()` reports "Demographics collected for X of Y" showing the gap.
+
+**Risk:** Low. Graceful degradation — shows what's available, flags what's missing.
+
+### Status enum mismatch
+
+**This is a real issue.** See Section 5 below.
+
+---
+
+## 4. Workflow integration
+
+### When it's generated/updated
+
+The tracker is **event-driven**, not scheduled or on-demand:
+
+| Trigger | Action | Regenerates tracker? |
+|---------|--------|:---:|
+| `/qori` → Fieldwork → Add Participant → submit | Creates participant in DB | Yes |
+| `/qori` → Fieldwork → Update Status → submit | Updates participant status | Yes (optionally) |
+| `participantOutreachHandler` sends outreach | Records outreach, advances status | No |
+
+The tracker file on GitHub is regenerated from scratch on each participant add. Status updates optionally regenerate it (the handler has the call but it may fail silently without blocking the status update).
+
+### Who reads it
+
+Researchers and study leads. The tracker lives in the study's `02-participants/` folder on GitHub alongside other study documentation. It's a living document that reflects current recruitment state.
+
+### Is the trigger pattern right?
+
+**Mostly.** Regenerating on every add is correct. The status update regeneration is optional/fragile — if it fails, the GitHub tracker goes stale until the next participant add. A more robust pattern would regenerate on every mutation, with retry.
+
+---
+
+## 5. Known issues — verified
+
+### Issue 1: Slack user ID instead of human-readable name
+
+**Verified.** `added_by` is set from `body.user.name || body.user.id` (participantHandler.ts:340). The `body.user.name` field in Slack Bolt is the Slack username (e.g., "lapedra"), not the display name. If `body.user.name` is falsy, it falls back to the raw user ID (e.g., "U07XXXXXXXX").
+
+**Location:** participantHandler.ts line 340, rendered in template at line 147: `**Last Updated:** {{current_date}} by {{added_by}}`
+
+**Fix:** Use `body.user.real_name` or resolve via `client.users.info({ user: body.user.id })` for display name.
+
+### Issue 2: Status labels don't match canonical enum
+
+**Verified.** The YAML template defines 8 status labels:
+
+| YAML template (status_mappings) | Canonical enum (participantStatus.ts) |
+|---|---|
+| `recruited` | `not_contacted` / `contacted` |
+| `confirmed` | `confirmed` |
+| `completed` | `completed` |
+| `pending` | -- (no canonical match) |
+| `rescheduling` | `needs_reschedule` |
+| `backup` | -- (no canonical match) |
+| `canceled` | `canceled` |
+| `disqualified` | -- (no canonical match) |
+
+Missing from YAML: `not_contacted`, `contacted`, `scheduled`, `declined`, `no_response`
+Extra in YAML: `recruited`, `pending`, `backup`, `disqualified`
+
+**Impact:** The `status_mappings` in the YAML are **documentation-only** — never read by the processor. The processor passes raw `status_select` values from the database (canonical enum) directly to the template. The Handlebars template renders `{{status_select}}` as-is, so the rendered tracker shows canonical values like `confirmed`, `needs_reschedule`, `no_response` — not the display-friendly emoji labels defined in `status_mappings`.
+
+**Fix:** Either (a) map canonical enum to display labels in the processor before template injection, or (b) remove the dead `status_mappings` from the YAML.
+
+---
+
+## 6. Additional findings
+
+### Observer management metadata is aspirational
+
+Lines 314-411 of the YAML describe sophisticated observer management rules (capacity limits, role limits, auto-approve logic, workflow triggers). None of this is read by the processor — the processor simply fetches observer records from the database and passes them through. The metadata describes intended behavior that lives in handler code, not in the YAML.
+
+**Recommendation:** Remove or move to handler documentation. Dead config in the YAML creates false expectations.
+
+### Notification config is dead
+
+Lines 271-308 describe Slack notifications (researcher tags, team messages, observer DMs). The processor doesn't read these — notifications are handled by handler code.
+
+**Recommendation:** Remove. Same as observer management metadata.
+
+### File-based fallback (legacy mode)
+
+The processor has a legacy code path (Mode 2 in the audit) that parses existing GitHub files via regex to extract participant rows when `allParticipants` is not provided. This path exists for backward compatibility but is fragile — regex parsing of markdown tables is error-prone.
+
+**Recommendation:** Low priority. The database-driven path (Mode 1) is always used when triggered from the handler. The fallback only activates if someone calls the processor without providing the participant array.
+
+---
+
+## 7. Recommendations for production quality
+
+### Blocking (should fix before broader use)
+
+| # | Issue | Effort | Description |
+|:-:|-------|:------:|-------------|
+| 1 | Status display labels | S | Map canonical enum to display-friendly labels (with emoji) in processor before template injection. Use `PARTICIPANT_STATUS_LABELS` from participantStatus.ts. |
+| 2 | `added_by` shows username not display name | S | Resolve Slack user ID to display name via `client.users.info()` or use `body.user.real_name`. |
+
+### Nice-to-have (improves quality but not blocking)
+
+| # | Issue | Effort | Description |
+|:-:|-------|:------:|-------------|
+| 3 | Remove dead YAML sections | S | Delete `status_mappings`, `observer_management`, `workflow_integration`, `capacity_management`, `notify` — all documentation-only, never read. |
+| 4 | Status update should always regenerate tracker | S | Make GitHub tracker regeneration non-optional on status update. Currently optional/silently-failing. |
+| 5 | TypeScript data contract | M | Add interface for `ParticipantTrackerTemplateData` that the processor produces and the template consumes. Currently implicit. |
+
+### File for later
+
+| # | Issue | Effort | Description |
+|:-:|-------|:------:|-------------|
+| 6 | Remove legacy file-based fallback | S | Dead code path. Only used if processor called without `allParticipants`. |
+| 7 | Consider AI-assisted recruitment analysis | L | The `next_steps_recommendations` and `recruitment_analysis` functions use simple heuristics. An AI task could provide richer analysis. Not necessary now. |

--- a/docs/template-inventory.md
+++ b/docs/template-inventory.md
@@ -1,0 +1,142 @@
+# Template Inventory: Close-out Audit
+
+**Date:** 2026-05-21
+**Purpose:** Complete picture of every YAML template — what it does, where it stands, what (if anything) remains.
+
+---
+
+## Summary
+
+**27 total YAML files** in `config/prompts/`. Breakdown:
+
+| Category | Count | Status |
+|----------|:-----:|--------|
+| v7.0 restructured (synthesis + readouts + fieldwork) | 17 | Done |
+| Utility templates (not v7.0 candidates) | 7 | Intentionally non-conformant |
+| Needs work (structural issues) | 2 | Tracked |
+| Data-only (non-AI) | 1 | Separate pattern |
+
+---
+
+## Tier 1: v7.0 Restructured (17 templates)
+
+All have: interleaved Handlebars output_template, analysis_body task, cascade summary, OUTPUT BOUNDARIES, anti-fabrication guards, emit schemas.
+
+| Template | Version | Emits | Cascade role |
+|----------|:-------:|-------|--------------|
+| session_summary | v7.0 | atomic_nugget_core/detail, participant_metadata, task_completion_records, barrier_validations (5 pool) | Origin — fieldwork |
+| affinity_mapping | v7.0 | validated_themes, unexpected_patterns | Mid-cascade synthesis |
+| persona_generator | v7.0 | personas, persona_design_implications | Behavioral synthesis |
+| journey_mapping | v7.0 | journey_stages, journey_pain_points | Stage synthesis |
+| usability_issues_extractor | v7.0 | prioritized_issues | Lateral analysis → research_readout |
+| jobs_to_be_done | v7.0 | validated_jobs | Lateral analysis → design_opportunities |
+| design_opportunity_generator | v7.0 | design_hmw_opportunities | Terminal lateral analysis |
+| research_readout | v7.0 | prioritized_findings, prioritized_recommendations, decision_inputs, study_methodology | Terminal synthesis |
+| designer_readout | v7.0 | design_ticket_candidates | Audience readout |
+| engineering_readout | v7.0 | engineering_ticket_candidates | Audience readout |
+| accessibility_readout | v7.0 | accessibility_ticket_candidates | Audience readout |
+| leadership_readout | v7.0 | exec_summary_points | Audience readout |
+| research_brief | v7.0 | target_barriers, research_questions, etc. | Planning — approval gate |
+| research_plan | v7.0 | study_timeline, study_deliverables, etc. | Planning — execution doc |
+| discussion_guide | v7.0 | task_scenarios, probes | Planning — session guide |
+| desk_research | v7.0 | desk_research_themes, etc. | Discovery |
+| stakeholder_synthesis | v7.0 | stakeholder_constraints, alignment_gaps, etc. | Discovery |
+| survey_synthesis | v7.0 | survey_themes, survey_findings, etc. | Discovery |
+
+---
+
+## Tier 2: Utility Templates — Intentionally Non-Conformant (7 templates)
+
+These are lightweight AI templates that serve specific operational purposes. They don't participate in the cascade (no consumes/emits) and don't generate analytical documents. v7.0 restructure does not apply.
+
+| Template | Version | What it does | AI tasks | Disposition |
+|----------|:-------:|--------------|:--------:|-------------|
+| participant_outreach | v4.1 | Generates recruitment/reminder/thank-you emails | 2 (subject + body) | **Acceptable.** Operational utility, no cascade role. |
+| session_notes | v2.1 | Structures raw session observations into organized sections | 1 (structure_notes) | **Acceptable.** Data entry helper, no cascade role. |
+| transcript_upload | v2.4 | Uploads transcripts with PII redaction + research coding | 2 (coding + filename) | **Acceptable.** Fieldwork data entry. 7 enforcement rules are appropriate. |
+| stakeholder_interview_guide | v2.1 | Generates interview guides for internal stakeholders | 1 (guide_complete) | **Acceptable.** Planning utility, no cascade role. |
+| research_request | v1.1 | Accepts stakeholder research requests, suggests methodology | 4 (formatting tasks) | **Acceptable.** Entry-point template, light AI. Note: references GPT-4o in llm_config (dead config). |
+| github_issues_generator | v4.0 | Converts readout findings into GitHub issues | 1 (issues_complete) | **Acceptable.** Output utility. Should eventually consume readout emits (prioritized_findings → issues), but works without cascade wiring. |
+| targeted_readouts | v4.1 | Generates audience-specific reports (Congressional, leadership, team) | 1 (monolithic prompt) | **Needs attention.** Monolithic prompt with 5+ format branches is hard to maintain. No cascade wiring. Low priority — works but fragile. |
+
+---
+
+## Tier 3: Needs Work (2 templates)
+
+| Template | Version | Issue | Priority | Recommended action |
+|----------|:-------:|-------|:--------:|-------------------|
+| service_blueprint | v1.2 | Single-LLM blob, has cascade consumes but no emits, no v7.0 structure | Low | v7.0 restructure when service blueprints are used in production. Currently low-traffic — only 1 study has stakeholder data to feed it. |
+| targeted_readouts | v4.1 | Monolithic prompt with 5+ format branches, no cascade wiring, maintenance-fragile | Low | Refactor into separate templates per audience type, or add format-switching logic to handler. Not blocking. |
+
+---
+
+## Tier 4: Data-Only Template (1 template)
+
+### participant_tracker.yaml (v1.1)
+
+**What it produces:** A markdown recruitment tracking sheet with participant roster, recruitment breakdown, observer assignments, demographics, and accommodations.
+
+**Is it AI-generated?** **No.** Zero `ai_generation_tasks`. It's a pure Handlebars data template — the handler computes all values and injects them into the template.
+
+**Does it have consumes/emits?** No.
+
+**Current state assessment:**
+
+| Aspect | Status |
+|--------|--------|
+| Template structure | Functional but fragile |
+| Variable references | Many computed variables (`total_participants_count`, `recruitment_analysis`, `next_steps_recommendations`) not listed in input_variables — handler must provide |
+| `{{#each}}` blocks | Reference arrays (`participants`, `session_observers`, `race_ethnicity_breakdown`, etc.) that handler must assemble |
+| Observer management | Sophisticated capacity/role logic but all computation is handler-side |
+| Demographics | 4 breakdown arrays expected; handler must compute distribution |
+
+**Production-acceptable?** Yes, with caveats. The template works when the handler provides all computed variables. The fragility is that there's no contract between template and handler — if handler changes, template silently breaks with empty sections.
+
+**Recommended disposition:** **Intentionally non-conformant.** v7.0 does not apply (no AI generation). If the tracker needs improvement:
+1. Add a data contract (TypeScript interface for required template input)
+2. Remove unreferenced computed variables or add handler computation
+3. Consider whether AI-assisted recruitment analysis would add value (upgrade to AI template)
+
+None of these are blocking. The tracker works for its current purpose.
+
+---
+
+## Complete File Listing
+
+| # | File | Tier | Version | v7.0? |
+|:-:|------|:----:|:-------:|:-----:|
+| 1 | accessibility_readout.yaml | 1 | v7.0 | Yes |
+| 2 | affinity_mapping.yaml | 1 | v7.0 | Yes |
+| 3 | design_opportunity_generator.yaml | 1 | v7.0 | Yes |
+| 4 | designer_readout.yaml | 1 | v7.0 | Yes |
+| 5 | desk_research.yaml | 1 | v7.0 | Yes |
+| 6 | discussion_guide.yaml | 1 | v7.0 | Yes |
+| 7 | engineering_readout.yaml | 1 | v7.0 | Yes |
+| 8 | github_issues_generator.yaml | 2 | v4.0 | N/A |
+| 9 | jobs_to_be_done.yaml | 1 | v7.0 | Yes |
+| 10 | journey_mapping.yaml | 1 | v7.0 | Yes |
+| 11 | leadership_readout.yaml | 1 | v7.0 | Yes |
+| 12 | participant_outreach.yaml | 2 | v4.1 | N/A |
+| 13 | participant_tracker.yaml | 4 | v1.1 | N/A (non-AI) |
+| 14 | persona_generator.yaml | 1 | v7.0 | Yes |
+| 15 | research_brief.yaml | 1 | v7.0 | Yes |
+| 16 | research_plan.yaml | 1 | v7.0 | Yes |
+| 17 | research_readout.yaml | 1 | v7.0 | Yes |
+| 18 | research_request.yaml | 2 | v1.1 | N/A |
+| 19 | service_blueprint.yaml | 3 | v1.2 | Deferred |
+| 20 | session_notes.yaml | 2 | v2.1 | N/A |
+| 21 | session_summary.yaml | 1 | v7.0 | Yes |
+| 22 | stakeholder_interview_guide.yaml | 2 | v2.1 | N/A |
+| 23 | stakeholder_synthesis.yaml | 1 | v7.0 | Yes |
+| 24 | survey_synthesis.yaml | 1 | v7.0 | Yes |
+| 25 | targeted_readouts.yaml | 3 | v4.1 | Deferred |
+| 26 | transcript_upload.yaml | 2 | v2.4 | N/A |
+| 27 | usability_issues_extractor.yaml | 1 | v7.0 | Yes |
+
+---
+
+## Conclusion
+
+The v7.0 template restructure workstream is complete. 17 of 27 templates are v7.0 conformant with interleaved Handlebars/AI, cascade emit schemas, and structural consistency. The remaining 10 are either utility templates (7, intentionally non-conformant), low-priority deferred work (2), or a non-AI data template (1).
+
+No templates were missed. The earlier count of "19 templates" referred to the 17 AI analysis/synthesis templates + discussion_guide + journey_mapping (which were already conformant). The gap to 27 is the 8 utility/data templates that were correctly excluded from v7.0 scope.


### PR DESCRIPTION
## Summary

Two bugs in participant tracker rendering, discovered during production audit:

1. **Status display labels**: `participantYamlProcessor.ts` passed raw canonical enum values (`not_contacted`, `needs_reschedule`, `no_response`) to the Handlebars template. Researchers saw database enum strings instead of friendly labels. Now maps through `PARTICIPANT_STATUS_LABELS` before template injection.

2. **added_by display name**: `participantHandler.ts` used `body.user.name` (Slack username like "lapedra") or fell back to raw user ID (`U07XXXXXXXX`). Now resolves via `client.users.info()` to get `display_name` or `real_name`. Falls back to username only if API fails. Never falls back to user ID.

Also includes:
- `docs/template-inventory.md` — complete inventory of all 27 YAML templates with disposition
- `docs/participant-tracker-audit.md` — production quality assessment with data flow analysis

## Test plan

- [x] TypeScript typecheck passes
- [x] 76/76 unit tests pass
- [ ] **Generate tracker on test study** — verify status shows "Confirmed" not "confirmed", "Needs reschedule" not "needs_reschedule"
- [ ] **Verify added_by** — should show display name (e.g., "Lapedra Tolson") not username

## Follow-on (not in this PR)

Dead YAML cleanup: ~100 lines of documentation-only config (`status_mappings`, `observer_management`, `workflow_integration`, `capacity_management`, `notify`) can be removed from `participant_tracker.yaml` in a separate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)