### PR TITLE
fix: participant tracker label mappings, ID display, and empty state

### DIFF
--- a/backend/src/helpers/participantYamlProcessor.ts
+++ b/backend/src/helpers/participantYamlProcessor.ts
@@ -113,6 +113,7 @@ const SOURCE_MAPPINGS: Record<string, string> = {
   'phone': '📞 Phone Recruitment',
   'referral': '🤝 Referral',
   'online': '🌐 Social/Website',
+  'recruitment_agency': '🏢 Recruitment Agency',
   'csv_import': '📊 CSV Import',
   'api_import': '🔗 API Import',
   'unknown': '❓ Unknown',
@@ -120,24 +121,35 @@ const SOURCE_MAPPINGS: Record<string, string> = {
 
 const RACE_ETHNICITY_MAPPINGS: Record<string, string> = {
   'american_indian_alaska_native': 'American Indian or Alaska Native',
+  'american_indian': 'American Indian or Alaska Native',
   'asian': 'Asian',
   'black_african_american': 'Black or African American',
+  'black': 'Black or African American',
   'hispanic_latino': 'Hispanic or Latino',
+  'hispanic': 'Hispanic or Latino',
   'native_hawaiian_pacific_islander': 'Native Hawaiian or Other Pacific Islander',
+  'native_hawaiian': 'Native Hawaiian or Other Pacific Islander',
   'white': 'White',
   'two_or_more_races': 'Two or More Races',
+  'two_or_more': 'Two or More Races',
   'prefer_not_to_say': 'Prefer not to say',
 };
 
 const EDUCATION_LEVEL_MAPPINGS: Record<string, string> = {
   'less_than_high_school': 'Less than high school',
   'high_school_ged': 'High school diploma/GED',
+  'high_school': 'High school diploma/GED',
   'some_college': 'Some college',
   'associate_degree': 'Associate degree',
+  'associate': 'Associate degree',
   'bachelors_degree': "Bachelor's degree",
+  'bachelor': "Bachelor's degree",
   'masters_degree': "Master's degree",
+  'master': "Master's degree",
   'professional_degree': 'Professional degree',
+  'professional': 'Professional degree',
   'doctorate_degree': 'Doctorate degree',
+  'doctorate': 'Doctorate degree',
   'prefer_not_to_say': 'Prefer not to say',
 };
 
@@ -552,7 +564,7 @@ export async function processParticipantYamlTemplate(
       completed_sessions_count: completedSessionsCount,
       total_observer_assignments: 0,
       participants: allParticipants.map(p => ({
-        id: p.id,
+        id: p.participant_name || `P${p.id}`,
         participant_name: p.participant_name,
         contact_details: p.contact_details,
         recruitment_source: p.recruitment_source,
@@ -594,7 +606,7 @@ export async function processParticipantYamlTemplate(
       })(),
       observer_action_items: [],
       accommodations: allParticipants.filter(p => p.notes_field && p.notes_field.trim() !== '').map(p => ({
-        participant_id: p.id,
+        participant_id: p.participant_name || `P${p.id}`,
         accommodation_details: p.notes_field,
       })),
       demographics_summary: generateDemographicsSummary(allParticipants),

--- a/backend/src/helpers/slack/commands/participantOutreachHandler.ts
+++ b/backend/src/helpers/slack/commands/participantOutreachHandler.ts
@@ -1019,7 +1019,13 @@ async function handleAddParticipantSubmit({ ack, body, view, client }: SlackView
     };
 
     const current_date = new Date().toISOString().split('T')[0];
-    const added_by = userId;
+    let added_by = userId;
+    try {
+      const userInfo = await client.users.info({ user: userId });
+      added_by = userInfo.user?.profile?.display_name || userInfo.user?.real_name || userId;
+    } catch {
+      // Fall through with userId if API fails
+    }
 
     const data = {
       study_id,

--- a/config/prompts/participant_tracker.yaml
+++ b/config/prompts/participant_tracker.yaml
@@ -172,12 +172,13 @@ output_template: |
 
   ## Observer Management
 
+  {{#if session_observers}}
   **Session Assignments:**
 
   | Session | Date/Time | Observers | Capacity | Pending Requests | Guidelines Sent |
   |---------|-----------|-----------|----------|------------------|-----------------|
   {{#each session_observers}}
-  | {{session_id}} | {{date_time}} | {{observers}} | {{capacity}}/3 | {{pending_count}} | ✅ Sent |
+  | {{session_id}} | {{date_time}} | {{observer_names}} | {{capacity}}/3 | {{pending_count}} | ✅ Sent |
   {{/each}}
 
   **Role Distribution:**
@@ -190,6 +191,9 @@ output_template: |
   | 🏛️ Stakeholder | {{stakeholder_count}} | {{stakeholder_sessions}} |
 
   **Guidelines:** Review session plan beforehand, stay muted, take notes without interrupting, share feedback after session.
+  {{else}}
+  *No observer assignments yet. Observers can be added via `/qori-fieldwork` → Observe Session.*
+  {{/if}}
 
   ---
 


### PR DESCRIPTION
## Summary

Fixes 6 rendering issues surfaced during production testing of participant tracker:

1. **Recruitment method**: `recruitment_agency` rendered as raw enum. Added to SOURCE_MAPPINGS → "🏢 Recruitment Agency"
2. **Demographics race/ethnicity**: `black`, `native_hawaiian` rendered as raw enum. Modal sends short keys; dictionary expected long keys. Added aliases for all modal values.
3. **Demographics education**: `bachelor`, `master` rendered as raw enum. Same modal/dictionary key mismatch. Added aliases.
4. **Participant IDs**: ID column showed database auto-increment IDs (21, 14, 13) instead of participant aliases (PT010, PT007, PT005). Fixed in participant mapping and accommodations section.
5. **Observer empty state**: Empty observer rows rendered with blank cells and "/3" capacity. Now shows "No observer assignments yet" message when no observers assigned.
6. **added_by display name**: Add participant handler (`participantOutreachHandler.ts`) passed raw Slack user ID. Now resolves via `client.users.info()`.

## Test plan

- [x] TypeScript typecheck passes
- [x] 76/76 unit tests pass
- [ ] **Regenerate tracker** — verify recruitment shows "🏢 Recruitment Agency", demographics show proper labels, IDs show aliases, observer section shows empty state message, added_by shows display name

🤖 Generated with [Claude Code](https://claude.com/claude-code)