### PR TITLE
fix: participant tracker date format, session IDs, and observer roles

### DIFF
--- a/backend/src/helpers/participantYamlProcessor.ts
+++ b/backend/src/helpers/participantYamlProcessor.ts
@@ -160,7 +160,55 @@ const LOCATION_TYPE_MAPPINGS: Record<string, string> = {
   'prefer_not_to_say': 'Prefer not to say',
 };
 
+const OBSERVER_ROLE_LABELS: Record<string, string> = {
+  'note_taker': '📝 Note-taker',
+  'silent_observer': '👁️ Silent Observer',
+  'pm_observer': '📊 PM Observer',
+  'stakeholder': '🏛️ Stakeholder',
+  'observer': '👁️ Observer',
+};
+
 // ─── Helper functions ────────────────────────────────────────────────
+
+/** Format a date+time pair into "Mon, May 27 · 10:00 AM". Omits year if current year. */
+function formatScheduleDisplay(dateStr: string | null, timeStr?: string | null): string {
+  if (!dateStr) return '';
+  try {
+    const datePart = dateStr.split('T')[0]; // handle ISO strings
+    const [year, month, day] = datePart.split('-').map(Number);
+    const date = new Date(year, month - 1, day);
+    const currentYear = new Date().getFullYear();
+    const dayOfWeek = format(date, 'EEE');
+    const monthDay = format(date, 'MMM d');
+    const yearSuffix = year !== currentYear ? `, ${year}` : '';
+    let timeDisplay = '';
+    if (timeStr) {
+      const [hours, minutes] = timeStr.split(':').map(Number);
+      const ampm = hours >= 12 ? 'PM' : 'AM';
+      const h = hours % 12 || 12;
+      timeDisplay = ` · ${h}:${String(minutes).padStart(2, '0')} ${ampm}`;
+    }
+    return `${dayOfWeek}, ${monthDay}${yearSuffix}${timeDisplay}`;
+  } catch {
+    return `${dateStr}${timeStr ? ' ' + timeStr : ''}`;
+  }
+}
+
+/** Normalize session ID to PT-XXX format with dash. */
+function normalizeSessionId(sessionId: string): string {
+  if (!sessionId) return sessionId;
+  // Already has dash in right place (PT-001)
+  if (/^PT-\d+$/i.test(sessionId)) return sessionId;
+  // Has letters then digits without dash (PT001, PT003)
+  const match = sessionId.match(/^(PT)(\d+)$/i);
+  if (match) return `${match[1]}-${match[2].padStart(3, '0')}`;
+  return sessionId;
+}
+
+/** Format observer role enum to display label with emoji. */
+function getObserverRoleDisplay(role: string): string {
+  return OBSERVER_ROLE_LABELS[role] || role;
+}
 
 function getRecruitmentSourceDisplay(source: string): string {
   return SOURCE_MAPPINGS[source] || source;
@@ -568,7 +616,7 @@ export async function processParticipantYamlTemplate(
         participant_name: p.participant_name,
         contact_details: p.contact_details,
         recruitment_source: p.recruitment_source,
-        scheduled_date: p.scheduled_date,
+        scheduled_date: formatScheduleDisplay(p.scheduled_date, p.scheduled_time),
         scheduled_time: p.scheduled_time,
         status_select: PARTICIPANT_STATUS_LABELS[p.status_select as ParticipantStatus] || p.status_select,
         notes_field: p.notes_field,
@@ -589,15 +637,28 @@ export async function processParticipantYamlTemplate(
         try {
           if (!inputValues.study_id) return [];
           const observers = await SessionObserverService.getObserverRequestsByStudy(inputValues.study_id);
-          return (observers as Array<{ session_id: string; requester_name: string | string[]; role?: string; status?: string }>).map(obs => {
-            const names = Array.isArray(obs.requester_name) ? obs.requester_name : [obs.requester_name];
-            return {
-              session_id: obs.session_id,
-              observer_names: names.join(', '),
-              observer_role: obs.role || 'observer',
-              status: obs.status || 'confirmed',
-            };
-          });
+          // Group observers by session_id to combine multiple observers per session
+          const observersBySession = new Map<string, { names: string[]; roles: string[]; participant?: { scheduled_date?: string; scheduled_time?: string } }>();
+          for (const obs of observers as Array<{ session_id: string; requester_name: string | string[]; role?: string; status?: string; participant?: { scheduled_date?: string; scheduled_time?: string } }>) {
+            const sessionId = normalizeSessionId(obs.session_id);
+            const existing = observersBySession.get(sessionId) || { names: [], roles: [], participant: obs.participant };
+            const obsNames = Array.isArray(obs.requester_name) ? obs.requester_name : [obs.requester_name];
+            const roleLabel = getObserverRoleDisplay(obs.role || 'observer');
+            for (const name of obsNames) {
+              existing.names.push(`${name} (${roleLabel})`);
+            }
+            existing.roles.push(obs.role || 'observer');
+            observersBySession.set(sessionId, existing);
+          }
+          return Array.from(observersBySession.entries()).map(([sessionId, data]) => ({
+            session_id: sessionId,
+            date_time: formatScheduleDisplay(data.participant?.scheduled_date || null, data.participant?.scheduled_time),
+            observer_names: data.names.length > 0 ? data.names.join(', ') : 'None',
+            capacity: data.names.length,
+            pending_count: 0,
+            observer_role: data.roles[0] || 'observer',
+            status: 'confirmed',
+          }));
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
           console.warn('⚠️ Could not fetch observer data for tracker:', message);

--- a/config/prompts/participant_tracker.yaml
+++ b/config/prompts/participant_tracker.yaml
@@ -153,7 +153,7 @@ output_template: |
   | ID | Alias | Recruited Via | Scheduled | Status | Notes & Accommodations |
   |----|-------|---------------|-----------|--------|------------------------|
   {{#each participants}}
-  | {{id}} | {{participant_name}} | {{recruitment_source}} | {{scheduled_date}} {{scheduled_time}} | {{status_select}} | {{notes_field}} |
+  | {{id}} | {{participant_name}} | {{recruitment_source}} | {{scheduled_date}} | {{status_select}} | {{notes_field}} |
   {{/each}}
 
   ---


### PR DESCRIPTION
## Summary

Three rendering improvements from production testing:

1. **Date format**: `2026-05-27 10:00` → `Tue, May 27 · 10:00 AM`. Adds day of week (useful for scheduling), AM/PM, drops year when current year. Applied to Participant Details and Observer Management.

2. **Session ID normalization**: `PT003` and `PT-022` → consistent `PT-003` and `PT-022` format. `normalizeSessionId()` adds dash and pads to 3 digits.

3. **Observer role labels with emoji**: `observer` → `👁️ Observer`, `note_taker` → `📝 Note-taker`, `stakeholder` → `🏛️ Stakeholder`, etc. `OBSERVER_ROLE_LABELS` mapping applied to all observer name displays. Observers also grouped by session so multiple observers per session render on one row.

## Test plan

- [x] TypeScript typecheck passes
- [x] 76/76 unit tests pass
- [ ] **Regenerate tracker** — verify dates show "Tue, May 27 · 10:00 AM" format, session IDs normalized with dashes, all observer roles show emoji labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)