### PR TITLE
fix: plan modal polish — conversational copy, cascade gate, users_select

### DIFF
--- a/backend/src/helpers/slack/commands/modal-openers/planModalOpener.ts
+++ b/backend/src/helpers/slack/commands/modal-openers/planModalOpener.ts
@@ -6,15 +6,19 @@
  * fallback), injects cascade readiness blocks, and opens the plan modal
  * via views.update.
  *
- * This is the most complex modal opener — it auto-populates study folder,
- * lead researcher, and cascade readiness status before showing the form.
+ * v6.1: Lead researcher changed to users_select. Pre-fills with study's
+ * created_by (Slack user ID) or falls back to the opener's user ID.
+ *
+ * v6.0: Study name displayed as non-editable context block (not text input).
+ * Cascade warning gates the form — when required vars missing, form fields
+ * are replaced with a warning-only view (no submit button).
  */
 
 import type { AllMiddlewareArgs, SlackActionMiddlewareArgs, BlockAction } from '@slack/bolt';
 import type { View } from '@slack/types';
 
-import { getResearchStudyWithRoles, getStudiesByUser } from '../../../../services/research_study.service';
-import { researchPlanGeneratorModal } from '../../ui/researchPlanGeneratorModal';
+import { getResearchStudyWithRoles } from '../../../../services/research_study.service';
+import { researchPlanGeneratorModal, STUDY_DISPLAY_BLOCK_ID } from '../../ui/researchPlanGeneratorModal';
 import { readStudyVariables } from '../../../studyVariables';
 import { buildCascadeReadiness, buildCascadeBlocks } from '../../ui/cascadeReadinessBlocks';
 
@@ -25,6 +29,7 @@ interface MutableBlock {
   type: string;
   block_id?: string;
   element?: { initial_value?: string; [key: string]: unknown };
+  elements?: Array<{ type: string; text?: string; [key: string]: unknown }>;
   [key: string]: unknown;
 }
 
@@ -57,79 +62,34 @@ async function openResearchPlanModal({ ack, body, client }: SlackActionMiddlewar
       return;
     }
 
-    // Fetch studies for the user
     const userId = body.user.id;
-    const studies = await getStudiesByUser(userId);
 
-    // Fetch lead researcher: study record -> Slack profile fallback
-    let leadResearcher: string | null = null;
+    // Fetch study for lead researcher ID and path
+    let leadResearcherUserId: string = userId; // default: whoever opened the modal
+    let studyPath: string | null = null;
     try {
       const study = await getResearchStudyWithRoles(preselectStudyName);
-      if (study && study.researcher_name) {
-        leadResearcher = study.researcher_name;
+      if (study) {
+        if (study.created_by) leadResearcherUserId = study.created_by;
+        if (study.path) studyPath = decodeURIComponent(study.path);
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      console.warn('Could not fetch study for lead researcher:', message);
-    }
-    if (!leadResearcher) {
-      try {
-        const userInfo = await client.users.info({ user: userId });
-        const user = userInfo.user as Record<string, any> | undefined;
-        leadResearcher = user?.real_name || user?.profile?.display_name || user?.name || '';
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        console.warn('Could not fetch Slack profile for lead researcher:', message);
-      }
+      console.warn('Could not fetch study record:', message);
     }
 
-    // Start with the modal's blocks
-    const blocks: MutableBlock[] = [...researchPlanGeneratorModal.blocks];
-
-    // Find the study_folder_block and lead_researcher_block input blocks
-    const studyFolderIndex = blocks.findIndex(
-      block => block.block_id === 'study_folder_block',
-    );
-    const leadResearcherIndex = blocks.findIndex(
-      block => block.block_id === 'lead_researcher_block',
-    );
-
-    // Auto-populate study folder with study name
-    if (studyFolderIndex !== -1 && preselectStudyName && blocks[studyFolderIndex].element) {
-      blocks[studyFolderIndex] = {
-        ...blocks[studyFolderIndex],
-        element: {
-          ...blocks[studyFolderIndex].element!,
-          initial_value: preselectStudyName,
-        },
-      };
-    }
-
-    // Auto-populate lead researcher
-    if (leadResearcherIndex !== -1 && leadResearcher && blocks[leadResearcherIndex].element) {
-      blocks[leadResearcherIndex] = {
-        ...blocks[leadResearcherIndex],
-        element: {
-          ...blocks[leadResearcherIndex].element!,
-          initial_value: leadResearcher,
-        },
-      };
-      console.log(`✅ Pre-populated lead researcher: ${leadResearcher}`);
-    }
-
-    // Cascade readiness — inject upstream variable status
+    // ── Cascade readiness check ──
+    // When required variables are missing, show warning-only view (no form, no submit).
+    let cascadeBlocks: MutableBlock[] = [];
+    let cascadeGate = false;
     try {
-      const studyForCascade = await getResearchStudyWithRoles(preselectStudyName);
-      if (studyForCascade?.path) {
-        const studyVars = await readStudyVariables(decodeURIComponent(studyForCascade.path));
+      if (studyPath) {
+        const studyVars = await readStudyVariables(studyPath);
         const cascadeData = buildCascadeReadiness(studyVars, 'research_plan');
-        const cascadeBlocks = buildCascadeBlocks(cascadeData);
-        if (cascadeBlocks.length > 0) {
-          const firstDivider = blocks.findIndex(b => b.type === 'divider');
-          if (firstDivider !== -1) {
-            // @ts-expect-error — pre-existing type mismatch from require() → import migration
-            blocks.splice(firstDivider, 0, ...cascadeBlocks);
-          }
+        const rawBlocks = buildCascadeBlocks(cascadeData);
+        if (rawBlocks.length > 0) {
+          cascadeBlocks = rawBlocks as MutableBlock[];
+          cascadeGate = true; // required vars missing — gate the form
         }
       }
     } catch (err) {
@@ -137,13 +97,84 @@ async function openResearchPlanModal({ ack, body, client }: SlackActionMiddlewar
       console.warn('⚠️ Cascade readiness failed for research plan:', message);
     }
 
-    // views.update does NOT take trigger_id
+    const privateMetadata = JSON.stringify({
+      ...(meta || {}),
+      studyName: preselectStudyName,
+      studyId: preselectStudyId,
+      userId,
+    });
+
+    if (cascadeGate) {
+      // ── Warning-only view: no form fields, no submit ──
+      const warningBlocks: MutableBlock[] = [
+        {
+          type: "context",
+          block_id: STUDY_DISPLAY_BLOCK_ID,
+          elements: [
+            {
+              type: "mrkdwn",
+              text: `:clipboard: *${preselectStudyName}*`,
+            },
+          ],
+        },
+        ...cascadeBlocks,
+      ];
+
+      await client.views.update({
+        view_id: body.view.id,
+        view: {
+          type: "modal",
+          callback_id: "research_plan_modal",
+          title: researchPlanGeneratorModal.title,
+          close: researchPlanGeneratorModal.close,
+          // No submit property — researcher can only close
+          blocks: warningBlocks,
+          private_metadata: privateMetadata,
+        } as View,
+      });
+      return;
+    }
+
+    // ── Normal view: study display + form fields ──
+    const blocks: MutableBlock[] = [...researchPlanGeneratorModal.blocks];
+
+    // Set study name in context display block
+    const studyDisplayIndex = blocks.findIndex(
+      block => block.block_id === STUDY_DISPLAY_BLOCK_ID,
+    );
+    if (studyDisplayIndex !== -1) {
+      blocks[studyDisplayIndex] = {
+        ...blocks[studyDisplayIndex],
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `:clipboard: *${preselectStudyName}*\nGenerating an execution plan from your approved brief.`,
+          },
+        ],
+      };
+    }
+
+    // Set initial_user on users_select to the study's lead researcher
+    const leadResearcherIndex = blocks.findIndex(
+      block => block.block_id === 'lead_researcher_block',
+    );
+    if (leadResearcherIndex !== -1 && blocks[leadResearcherIndex].element) {
+      blocks[leadResearcherIndex] = {
+        ...blocks[leadResearcherIndex],
+        element: {
+          ...blocks[leadResearcherIndex].element!,
+          initial_user: leadResearcherUserId,
+        },
+      };
+      console.log(`✅ Pre-populated lead researcher: ${leadResearcherUserId}`);
+    }
+
     await client.views.update({
       view_id: body.view.id,
       view: {
         ...researchPlanGeneratorModal,
         blocks,
-        private_metadata: JSON.stringify({ ...(meta || {}), studyName: preselectStudyName, studyId: preselectStudyId, userId }),
+        private_metadata: privateMetadata,
       } as View,
     });
   } catch (error) {

--- a/backend/src/helpers/slack/commands/planHandler.ts
+++ b/backend/src/helpers/slack/commands/planHandler.ts
@@ -55,11 +55,10 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
   await ack();
 
   const values = view.state.values;
-  const { channelId, studyName: metaStudyName, userId } = JSON.parse(view.private_metadata || '{}');
+  const { channelId, studyName, userId } = JSON.parse(view.private_metadata || '{}');
 
-  const studyName: string = values.study_folder_block?.study_folder_input?.value || metaStudyName;
   if (!studyName) {
-    throw new Error('No study selected or provided');
+    throw new Error('No study selected — private_metadata missing studyName');
   }
 
   console.log('🚀 ~ Research Plan Generator ~ studyName:', studyName);
@@ -80,7 +79,21 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
   };
 
   // ── Modal inputs ──
-  const leadResearcher = (extract('lead_researcher_block', 'lead_researcher_input') as string) || '';
+  // Lead researcher is a users_select — extract Slack user ID, resolve to display name
+  const leadResearcherUserId: string | null =
+    values.lead_researcher_block?.lead_researcher_select?.selected_user || null;
+  let leadResearcher = '';
+  if (leadResearcherUserId) {
+    try {
+      const userInfo = await client.users.info({ user: leadResearcherUserId });
+      const user = userInfo.user as Record<string, any> | undefined;
+      leadResearcher = user?.real_name || user?.profile?.display_name || user?.name || leadResearcherUserId;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn('Could not resolve lead researcher display name:', message);
+      leadResearcher = leadResearcherUserId; // fall back to raw user ID
+    }
+  }
   const operationalRisks = (extract('operational_risks_block', 'operational_risks_input') as string) || '';
 
   // ── Compensation (mechanical) ──

--- a/backend/src/helpers/slack/ui/researchPlanGeneratorModal.ts
+++ b/backend/src/helpers/slack/ui/researchPlanGeneratorModal.ts
@@ -1,13 +1,25 @@
 /**
- * Research Plan Modal v5.0
+ * Research Plan Modal v6.0
  *
  * Plan = execution doc. Consumes scope from brief via cascade.
  * Only asks for operational details the brief doesn't cover.
+ *
+ * v6.1: Lead researcher changed from plain_text_input to users_select.
+ * Captures Slack user ID; handler resolves display name at generation time.
+ *
+ * v6.0: Conversational copy per modal design principles. Study name
+ * moved to non-editable context block (set by planModalOpener).
+ * Removed section header for single-field group. Lead researcher
+ * and operational risks are the only inputs.
  *
  * v5.0: Removed recruitment_source_block (now cascade from brief),
  * note_taker_block and observer_block (dead fields — plan v7.0
  * doesn't render a team section; observers managed via /qori-fieldwork).
  */
+
+/** Block ID for the study name context display. Used by planModalOpener to inject the study name. */
+export const STUDY_DISPLAY_BLOCK_ID = 'study_display_block';
+
 export const researchPlanGeneratorModal = {
   type: "modal",
   callback_id: "research_plan_modal",
@@ -24,86 +36,63 @@ export const researchPlanGeneratorModal = {
     text: "Cancel",
   },
   blocks: [
+    // Study name — non-editable display, set by planModalOpener
     {
       type: "context",
+      block_id: STUDY_DISPLAY_BLOCK_ID,
       elements: [
         {
           type: "mrkdwn",
-          text: "Execution plan for an approved brief. Scope, method, participants, recruitment, and timeline come from the cascade.",
+          text: ":clipboard: *{{study_name}}*\nGenerating an execution plan from your approved brief.",
         },
       ],
     },
     {
       type: "divider",
     },
-    // Study (auto-populated from selection)
-    {
-      type: "input",
-      block_id: "study_folder_block",
-      label: {
-        type: "plain_text",
-        text: "Study",
-      },
-      hint: {
-        type: "plain_text",
-        text: "Auto-populated from study selection",
-      },
-      element: {
-        type: "plain_text_input",
-        action_id: "study_folder_input",
-        initial_value: "{{study_name}}",
-      },
-    },
-    {
-      type: "divider",
-    },
-    // Lead researcher (auto-filled)
+    // Lead researcher (users_select — defaults to opener, workspace-wide)
     {
       type: "input",
       block_id: "lead_researcher_block",
       label: {
         type: "plain_text",
-        text: "Lead researcher",
+        text: "Who's leading this study?",
       },
       hint: {
         type: "plain_text",
-        text: "Auto-filled from your profile",
+        text: "Auto-filled with you — change if someone else is leading",
       },
       element: {
-        type: "plain_text_input",
-        action_id: "lead_researcher_input",
-        initial_value: "{{lead_researcher}}",
+        type: "users_select",
+        action_id: "lead_researcher_select",
+        placeholder: {
+          type: "plain_text",
+          text: "Select a researcher...",
+        },
       },
     },
     {
       type: "divider",
     },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Execution Risks*",
-      },
-    },
-    // Operational risks
+    // Operational risks (optional)
     {
       type: "input",
       block_id: "operational_risks_block",
       optional: true,
       label: {
         type: "plain_text",
-        text: "Operational risks",
+        text: "Anything that could go wrong?",
       },
       hint: {
         type: "plain_text",
-        text: "Execution-specific risks (not scope risks — those are in the brief)",
+        text: "Operational risks you know about — scope risks are already captured in the brief",
       },
       element: {
         type: "plain_text_input",
         action_id: "operational_risks_input",
         placeholder: {
           type: "plain_text",
-          text: "e.g., AT user recruitment takes 2x longer, need backup participants",
+          text: "e.g., AT users take 2x longer to recruit, key team member out in June",
         },
         multiline: true,
       },

--- a/backend/src/helpers/slack/ui/studySetupModal.ts
+++ b/backend/src/helpers/slack/ui/studySetupModal.ts
@@ -13,7 +13,13 @@ interface StudyOption {
   name: string;
 }
 
-// Modal builder for /qori-plan command
+/**
+ * Study setup modal v2.0 — launcher for /qori-plan
+ *
+ * v2.0: Removed upload sections (desk research, stakeholder notes, survey data)
+ * — those live in /qori-discover now. Removed "Done" submit (modal is a launcher,
+ * not a form). Conversational copy per modal design principles.
+ */
 export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelId: string) {
   const studyOptions = studies && studies.length > 0
     ? studies.map((s) => ({
@@ -30,10 +36,6 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
       type: "plain_text",
       text: "Plan your study",
     },
-    submit: {
-      type: "plain_text",
-      text: "Done",
-    },
     close: {
       type: "plain_text",
       text: "Close",
@@ -44,7 +46,7 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
         elements: [
           {
             type: "mrkdwn",
-            text: "Select a study, then create documents or upload files. Start a new study with `/qori-brief`.",
+            text: "Pick a study, then choose what to create. New study? Start with `/qori-brief`.",
           },
         ],
       },
@@ -56,7 +58,7 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
         block_id: "study_selection",
         label: {
           type: "plain_text",
-          text: "Study",
+          text: "Which study?",
         },
         element: {
           type: "static_select",
@@ -75,14 +77,7 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
         type: "section",
         text: {
           type: "mrkdwn",
-          text: "*Create Documents*",
-        },
-      },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "*Research plan*\nTimeline, logistics, and session design",
+          text: ":clipboard: *Research plan*\nTurns your brief into a stakeholder-ready plan",
         },
         accessory: {
           type: "button",
@@ -98,7 +93,7 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
         type: "section",
         text: {
           type: "mrkdwn",
-          text: "*Discussion guide*\nConversation guide for user research sessions",
+          text: ":speech_balloon: *Discussion guide*\nSession script grounded in your objectives",
         },
         accessory: {
           type: "button",
@@ -114,7 +109,7 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
         type: "section",
         text: {
           type: "mrkdwn",
-          text: "*Stakeholder interview guide*\nQuestions for PMs, engineers, policy SMEs",
+          text: ":studio_microphone: *Stakeholder interview guide*\nQuestions for PMs, engineers, policy SMEs",
         },
         accessory: {
           type: "button",
@@ -125,76 +120,6 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
           action_id: "create_stakeholder_guide",
           value: "stakeholder_guide",
         },
-      },
-      {
-        type: "divider",
-      },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "*Upload Files*",
-        },
-      },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "*Desk research*\nReports, competitive analysis, background docs",
-        },
-        accessory: {
-          type: "button",
-          text: {
-            type: "plain_text",
-            text: "Upload",
-          },
-          action_id: "upload_desk_research",
-          value: "desk_research",
-        },
-      },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "*Stakeholder notes*\nTranscripts from internal interviews",
-        },
-        accessory: {
-          type: "button",
-          text: {
-            type: "plain_text",
-            text: "Upload",
-          },
-          action_id: "upload_stakeholder_notes",
-          value: "stakeholder_notes",
-        },
-      },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "*Survey data*\nSurvey exports (CSV, Excel) for synthesis",
-        },
-        accessory: {
-          type: "button",
-          text: {
-            type: "plain_text",
-            text: "Upload",
-          },
-          action_id: "upload_survey_data",
-          value: "survey_data",
-        },
-      },
-      {
-        type: "divider",
-      },
-      {
-        type: "context",
-        elements: [
-          {
-            type: "mrkdwn",
-            text: "Upload stakeholder notes to unlock Service Blueprint analysis.",
-          },
-        ],
       },
     ],
   };

--- a/docs/product-backlog.md
+++ b/docs/product-backlog.md
@@ -73,8 +73,10 @@ Items accumulated during pre-migration work and during migration debugging. See 
 
 ### /qori-plan
 
-- Remove desk research, stakeholder notes, and survey data sections from the plan modal — those now live in /qori-discover
-- Remove the execution risks section (consolidated elsewhere or no longer relevant)
+- ~~Remove desk research, stakeholder notes, and survey data sections from the plan modal — those now live in /qori-discover~~ **Done** (2026-05-21, study setup modal v2.0)
+- ~~Remove the execution risks section (consolidated elsewhere or no longer relevant)~~ **Reversed** (2026-05-21) — field kept with conversational label. Cascade doesn't contain researcher-known operational risks; removing would force LLM to fabricate or omit. See `docs/qori-plan-modal-audit.md` §2.
+- ~~Study name editable text input~~ **Done** (2026-05-21) — replaced with non-editable context display, handler reads from private_metadata
+- ~~Cascade warning alongside form~~ **Done** (2026-05-21) — cascade warning now gates the form; when required vars missing, form is hidden entirely
 
 ### Participant tracker
 

--- a/docs/qori-plan-modal-audit.md
+++ b/docs/qori-plan-modal-audit.md
@@ -1,0 +1,360 @@
+# /qori-plan Modal Design Audit
+
+**Date:** 2026-05-21
+**Status:** Review — no code changes until approved
+**Target:** `researchPlanGeneratorModal.ts` (v5.0) + `planModalOpener.ts` + `studySetupModal.ts`
+
+---
+
+## 1. Current state
+
+The `/qori-plan` flow is a two-step modal sequence:
+
+### Step 1: Study setup modal (`studySetupModal.ts`)
+
+The researcher runs `/qori-plan` and gets a "hub" modal listing their studies and available actions.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Plan your study                              [Close]   │
+├─────────────────────────────────────────────────────────┤
+│  Select a study, then create documents or upload files. │
+│  Start a new study with /qori-brief.                    │
+│ ─────────────────────────────────────────────────────── │
+│  Study                                                  │
+│  ┌───────────────────────────────────┐                  │
+│  │ Select a study...              ▼  │                  │
+│  └───────────────────────────────────┘                  │
+│ ─────────────────────────────────────────────────────── │
+│  *Create Documents*                                     │
+│                                                         │
+│  *Research plan*                            [Create]    │
+│  Timeline, logistics, and session design                │
+│                                                         │
+│  *Discussion guide*                         [Create]    │
+│  Conversation guide for user research sessions          │
+│                                                         │
+│  *Stakeholder interview guide*              [Create]    │
+│  Questions for PMs, engineers, policy SMEs              │
+│ ─────────────────────────────────────────────────────── │
+│  *Upload Files*                                         │
+│                                                         │
+│  *Desk research*                            [Upload]    │
+│  Reports, competitive analysis, background docs         │
+│                                                         │
+│  *Stakeholder notes*                        [Upload]    │
+│  Transcripts from internal interviews                   │
+│                                                         │
+│  *Survey data*                              [Upload]    │
+│  Survey exports (CSV, Excel) for synthesis              │
+│ ─────────────────────────────────────────────────────── │
+│  Upload stakeholder notes to unlock Service Blueprint   │
+│  analysis.                                              │
+│                                                         │
+│                                     [Done]              │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Step 2: Research plan modal (`researchPlanGeneratorModal.ts`)
+
+After selecting a study and clicking "Create" next to Research plan, the modal updates (via `views.update`) to the plan form:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Research Plan                               [Cancel]   │
+├─────────────────────────────────────────────────────────┤
+│  Execution plan for an approved brief. Scope, method,   │
+│  participants, recruitment, and timeline come from the   │
+│  cascade.                                               │
+│ ─────────────────────────────────────────────────────── │
+│                                                         │
+│  [⚠️ cascade warning blocks injected here if missing]   │
+│                                                         │
+│ ─────────────────────────────────────────────────────── │
+│  Study                                                  │
+│  ┌───────────────────────────────────┐                  │
+│  │ va-mobile-nav-2026                │                  │
+│  └───────────────────────────────────┘                  │
+│  Auto-populated from study selection                    │
+│ ─────────────────────────────────────────────────────── │
+│  Lead researcher                                        │
+│  ┌───────────────────────────────────┐                  │
+│  │ Lapedra Tolson                    │                  │
+│  └───────────────────────────────────┘                  │
+│  Auto-filled from your profile                          │
+│ ─────────────────────────────────────────────────────── │
+│  *Execution Risks*                                      │
+│                                                         │
+│  Operational risks                                      │
+│  ┌───────────────────────────────────┐                  │
+│  │ e.g., AT user recruitment takes   │                  │
+│  │ 2x longer, need backup            │                  │
+│  │ participants                       │                  │
+│  │                                    │                  │
+│  └───────────────────────────────────┘                  │
+│  Execution-specific risks (not scope risks — those      │
+│  are in the brief)                                      │
+│                                                         │
+│                              [Generate Plan]            │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Field inventory — plan modal (step 2)
+
+| # | Block ID | Label | Type | Required | Pre-filled | Conditional | Source |
+|---|----------|-------|------|----------|------------|-------------|--------|
+| 1 | — | (context) | context | — | — | — | Static copy |
+| 2 | — | (divider) | divider | — | — | — | — |
+| 3 | `study_folder_block` | Study | plain_text_input | Yes | Yes — study name from step 1 selection | No | `planModalOpener` mutates `initial_value` |
+| 4 | — | (divider) | divider | — | — | — | — |
+| 5 | `lead_researcher_block` | Lead researcher | plain_text_input | Yes | Yes — study record → Slack profile fallback | No | `planModalOpener` mutates `initial_value` |
+| 6 | — | (divider) | divider | — | — | — | — |
+| 7 | — | *Execution Risks* | section header | — | — | — | Static |
+| 8 | `operational_risks_block` | Operational risks | plain_text_input (multiline) | **No** (optional) | No | No | Researcher input |
+
+**Total researcher-entered fields: 1** (operational risks). The other two inputs are pre-filled confirmations.
+
+---
+
+## 2. Field-by-field assessment
+
+### Study (`study_folder_block`)
+
+| Criterion | Assessment |
+|-----------|------------|
+| Should it exist? | **No as a text input.** The researcher already selected the study in step 1. Showing it again as an editable text field invites confusion — the researcher can type a study name that doesn't match any DB record, and the handler just uses whatever's in the field. The study was already validated in `planModalOpener`; re-presenting it as editable text is the "form ID field" anti-pattern (Principle: avoid showing fields researchers shouldn't change). |
+| Cascade pre-fill? | Pre-filled from step 1 selection — working correctly. |
+| Conditional? | No — always shown. Correct. |
+| Label conversational? | "Study" is fine but terse. Could be a non-editable display. |
+| Help text quality | "Auto-populated from study selection" — explains the mechanism, not the purpose. Researcher doesn't need to know it's auto-populated. |
+| Required vs optional | Required. Correct — handler needs it. |
+| **Recommendation** | Replace with a **context block** (non-editable display): `"📋 *va-mobile-nav-2026*"`. The handler should read the study name from `private_metadata` (already stored there), not from form input. Eliminates an editable field that shouldn't be edited. |
+
+### Lead researcher (`lead_researcher_block`)
+
+| Criterion | Assessment |
+|-----------|------------|
+| Should it exist? | **Yes, but as editable confirmation.** Sometimes the researcher delegating is not the lead researcher. The pre-fill is right; letting them override is right. |
+| Cascade pre-fill? | Pre-filled from study record → Slack profile. Working correctly. |
+| Conditional? | No — always shown. Correct. |
+| Label conversational? | "Lead researcher" is formal. Per Principle 6: "Who's leading this study?" would be more conversational. |
+| Help text quality | "Auto-filled from your profile" — acceptable but could be more helpful: "Change if someone else is leading." |
+| Required vs optional | Required. Correct. |
+| **Recommendation** | Keep as editable input. Improve label to "Who's leading this study?" and hint to "Auto-filled from your Slack profile — change if someone else is leading." |
+
+### Execution Risks section header
+
+| Criterion | Assessment |
+|-----------|------------|
+| Should it exist? | **Debatable.** There's exactly one field underneath this header. A section header for a single field adds visual weight without adding scannability. Per Principle 5: headers are for grouping 2-4 fields. One field doesn't need a group. |
+| **Recommendation** | Remove the section header. The field's own label and hint are sufficient. |
+
+### Operational risks (`operational_risks_block`)
+
+| Criterion | Assessment |
+|-----------|------------|
+| Should it exist? | **Yes, but the backlog says to remove it.** The backlog item "Remove the execution risks section (consolidated elsewhere or no longer relevant)" suggests this field is dead weight. However, the handler does use it — it's passed to the YAML template as `operational_risks`, and the LLM's `risks` AI task can reference it. The field adds researcher-specific operational knowledge the cascade can't provide. |
+| Cascade pre-fill? | No — this is new information only the researcher knows. Correct. |
+| Conditional? | No — always shown. Could be conditional (see proposal). |
+| Label conversational? | "Operational risks" is formal. Per Principle 6: "Anything that could go wrong?" or "Execution risks you're aware of?" |
+| Help text quality | Good — "Execution-specific risks (not scope risks — those are in the brief)" clearly scopes the field. The placeholder example is also useful. |
+| Required vs optional | Optional. Correct — many studies have no special risks. |
+| **Recommendation** | Keep but reconsider. The LLM generates 3 risks from context regardless — this field adds researcher-known risks the LLM can't infer. That's valuable. But if the backlog decision is firm, remove it and let the LLM generate all risks from cascade context. **Needs your call.** |
+
+---
+
+## 3. Cascade pre-fill opportunities
+
+The plan handler already loads these from brief via `readUpstreamVariables`:
+
+| Upstream variable | Currently used by handler | Could feed a modal field? | Assessment |
+|---|---|---|---|
+| `research_objectives` | Yes — transforms to `{id, objective}` | No field needed — flows to template | Correctly invisible to researcher |
+| `research_questions` | Yes — passed through | No field needed | Correctly invisible |
+| `target_barriers` | Yes — passed through | No field needed | Correctly invisible |
+| `methodology_selection` | Yes — passed through | No field needed | Correctly invisible |
+| `participant_criteria` | Declared in YAML consumes, not loaded by handler | Could surface as context | See note below |
+| `participant_approach` | Declared in YAML consumes, not loaded by handler | Could surface as context | See note below |
+| `timeline_preference` | Yes — `standard` fallback | No field needed | Correctly invisible |
+| `start_date` | Yes — empty string fallback | No field needed | Correctly invisible |
+| `recruitment_sources` | Yes — empty string fallback | No field needed | Correctly invisible |
+| `budget` | Yes (via study record `parsed_budget_amount`) | No field needed | Correctly invisible |
+| `decision_deadline` | Declared in YAML consumes, not loaded by handler | Could surface as context | See note below |
+
+**Note:** `participant_criteria`, `participant_approach`, and `decision_deadline` are declared in the YAML's `consumes` block and in the cascade readiness spec (`cascadeReadinessBlocks.ts:103-113`) but the handler doesn't load them. The YAML may use them as AI context, or they may be vestigial. The handler's `readUpstreamVariables` call (line 90-98) doesn't include `participant_criteria`, `participant_approach`, `decision_deadline`, or `budget` — but `budget` is sourced from the study DB record instead. Worth verifying these are actually injected into the template context somehow, or are just dead consumes.
+
+**New pre-fill opportunity:** None. The modal already has almost no fields. The cascade is correctly invisible — researchers don't need to see or confirm upstream data because the brief was already approved.
+
+---
+
+## 4. Conditional logic opportunities
+
+| Opportunity | Description | Effort |
+|---|---|---|
+| **Cascade warning → disable submit** | When required cascade variables are missing, the warning blocks are injected but the "Generate Plan" submit button is still enabled. Researcher can submit and get a `TemplateContractError` DM. Instead: when the cascade readiness check finds required missing, don't show the plan form at all — show only the warning and a "Go back" close button. | S |
+| **Operational risks → hidden by default** | If keeping the field: collapse it behind a "Add execution risks" button (section with `button` accessory). Researchers who have no risks skip it entirely — zero visual noise. Those who need it click once to expand. Uses `views.update` on button click. | M |
+
+---
+
+## 5. Removal candidates
+
+### Confirmed removals (from backlog)
+
+| Item | Backlog says | Current state | Verdict |
+|---|---|---|---|
+| Desk research, stakeholder notes, survey data sections | "Remove — those now live in /qori-discover" | These are in the **step 1 study setup modal** (`studySetupModal.ts`), not the plan modal itself. The setup modal has Upload buttons for desk research, stakeholder notes, and survey data. | **Remove from study setup modal.** These belong in `/qori-discover`. The study setup modal should only show document creation actions. |
+| Execution risks section | "Remove (consolidated elsewhere or no longer relevant)" | The plan modal has one optional field: `operational_risks_block`. | **Your call.** See assessment in §2 above. The handler passes it to the template and the LLM uses it. Removing it means the LLM generates all risks from cascade context only. |
+
+### Additional removal candidates
+
+| Item | Rationale |
+|---|---|
+| `study_folder_block` (editable text) | Replace with non-editable context display. Study name in `private_metadata` is authoritative. See §2. |
+| *Execution Risks* section header | Single-field section. See §2. |
+| "Done" submit button on study setup modal | The setup modal's "Done" button submits to `plan_study_modal` callback — but the modal is a launcher, not a form. Should it have a submit at all, or just close buttons and action buttons? Currently submitting "Done" does nothing useful — the actions (Create, Upload) are individual buttons. Consider removing submit and making it close-only. |
+
+---
+
+## 6. Proposed new modal structure
+
+### Step 1: Study setup modal (revised)
+
+Remove upload sections. Keep document creation only.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Plan your study                              [Close]   │
+├─────────────────────────────────────────────────────────┤
+│  Pick a study, then choose what to create.              │
+│  New study? Start with /qori-brief.                     │
+│ ─────────────────────────────────────────────────────── │
+│  Which study?                                           │
+│  ┌───────────────────────────────────┐                  │
+│  │ Select a study...              ▼  │                  │
+│  └───────────────────────────────────┘                  │
+│ ─────────────────────────────────────────────────────── │
+│                                                         │
+│  📋 *Research plan*                         [Create]    │
+│  Turns your brief into a stakeholder-ready plan         │
+│                                                         │
+│  💬 *Discussion guide*                      [Create]    │
+│  Session script grounded in your objectives             │
+│                                                         │
+│  🎤 *Stakeholder interview guide*           [Create]    │
+│  Questions for PMs, engineers, policy SMEs              │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+Changes:
+- **Removed:** "Upload Files" section (desk research, stakeholder notes, survey data) — lives in `/qori-discover`
+- **Removed:** "Done" submit button — modal is a launcher, not a form; close button suffices
+- **Revised:** Context copy is more conversational
+- **Revised:** Study label → "Which study?"
+- **Added:** Emoji type differentiation per Principle 7 (semantic, not decorative)
+- **Revised:** Plan description → "Turns your brief into a stakeholder-ready plan" (explains cascade relationship)
+
+### Step 2: Research plan modal (revised)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Research Plan                               [Cancel]   │
+├─────────────────────────────────────────────────────────┤
+│  📋 *va-mobile-nav-2026*                                │
+│  Generating an execution plan from your approved brief. │
+│ ─────────────────────────────────────────────────────── │
+│  Who's leading this study?                              │
+│  ┌───────────────────────────────────┐                  │
+│  │ Lapedra Tolson                    │                  │
+│  └───────────────────────────────────┘                  │
+│  Auto-filled — change if someone else is leading        │
+│ ─────────────────────────────────────────────────────── │
+│  Anything that could go wrong?              (optional)  │
+│  ┌───────────────────────────────────┐                  │
+│  │ e.g., AT users take 2x longer to │                  │
+│  │ recruit, key team member out in   │                  │
+│  │ June                              │                  │
+│  │                                   │                  │
+│  └───────────────────────────────────┘                  │
+│  Operational risks you know about — scope risks         │
+│  are already captured in the brief                      │
+│                                                         │
+│                              [Generate Plan]            │
+└─────────────────────────────────────────────────────────┘
+```
+
+Changes:
+- **Removed:** `study_folder_block` editable text input → replaced with **context block** showing study name as non-editable display (handler reads from `private_metadata`)
+- **Removed:** *Execution Risks* section header — single field doesn't need a group
+- **Revised:** Lead researcher label → "Who's leading this study?" (Principle 6)
+- **Revised:** Lead researcher hint → "Auto-filled — change if someone else is leading"
+- **Revised:** Operational risks label → "Anything that could go wrong?" (Principle 6)
+- **Revised:** Operational risks hint → "Operational risks you know about — scope risks are already captured in the brief"
+- **Revised:** Context block at top → shows study name prominently + explains what the modal does in one sentence
+
+### Cascade warning state (when required variables missing)
+
+When `buildCascadeReadiness` finds required variables missing, the modal should show **only** the warning — not the form fields:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Research Plan                               [Cancel]   │
+├─────────────────────────────────────────────────────────┤
+│  📋 *va-mobile-nav-2026*                                │
+│ ─────────────────────────────────────────────────────── │
+│  ⚠️ *Can't generate yet — 3 inputs missing*            │
+│                                                         │
+│  ⚠️ *Research objectives* — Create research brief first │
+│  ⚠️ *Research questions* — Create research brief first  │
+│  ⚠️ *Methodology* — Create research brief first         │
+│                                                         │
+│  _Run /qori-brief for this study, then come back._      │
+│                                                         │
+│                                              [Cancel]   │
+└─────────────────────────────────────────────────────────┘
+```
+
+Changes:
+- Form fields hidden entirely when cascade is incomplete
+- Submit button removed (or relabeled to just "Cancel")
+- Warning is the entire content — researcher knows exactly what to do
+- No wasted time filling out a form that will fail on submit
+
+---
+
+## 7. Risks
+
+### Handler changes required
+
+| Change | Risk | Mitigation |
+|---|---|---|
+| Remove `study_folder_block` from form | Handler reads study name from `values.study_folder_block` (line 60). Must change to read from `private_metadata` only. | `private_metadata` already contains `studyName` — handler already has the fallback `metaStudyName`. Remove the `values` extraction, keep the metadata path. Low risk. |
+| Conversational labels | Block IDs and action IDs stay the same — only visible label text changes. | No handler impact. Zero risk. |
+| Remove upload sections from setup modal | Upload actions (`upload_desk_research`, `upload_stakeholder_notes`, `upload_survey_data`) are registered in `events.ts`. Removing the buttons means dead action registrations. | Remove the action registrations too, or leave them harmless. Confirm no other modal triggers these actions. Low risk. |
+| Remove "Done" submit from setup modal | `plan_study_modal` callback handler exists in `events.ts`. Removing submit means the callback never fires. | Check if the callback does anything meaningful. If it just acks, removing it is safe. If it records analytics or status, preserve that elsewhere. |
+| Cascade warning hides form | `planModalOpener` currently injects warning blocks alongside form blocks. New behavior: when required missing, replace form blocks entirely. | Requires changes to `planModalOpener.ts` branching logic. Must also remove or hide the submit button. Medium complexity. |
+
+### Cascade contract gap
+
+The handler's `readUpstreamVariables` call (planHandler.ts:90-98) doesn't include `participant_criteria`, `participant_approach`, or `decision_deadline` — but these are declared as consumed in the YAML and in `cascadeReadinessBlocks.ts`. Either:
+- The YAML template accesses them via a different injection path (e.g., `processYamlTemplate` loads all study variables automatically), or
+- They're dead consumes that should be cleaned up.
+
+**Must verify before implementation** to avoid breaking the template.
+
+### Researcher workflow disruption
+
+The current modal is minimal and works. Changes are cosmetic + structural, not behavioral. The only functional change is removing the editable study name field. Risk: a researcher who habitually corrects the study name in the plan modal (e.g., because they selected the wrong study) would lose that ability. Mitigation: they can go back to the study selector.
+
+---
+
+## 8. Implementation sequence (suggested)
+
+If approved, implement in this order to minimize blast radius:
+
+1. **Study setup modal cleanup** — remove upload sections, remove "Done" submit, conversational copy. (Isolated to `studySetupModal.ts` + `events.ts` action registrations.)
+2. **Plan modal copy polish** — conversational labels, revised hints, remove section header. (Isolated to `researchPlanGeneratorModal.ts`. No handler changes.)
+3. **Study name → context block** — replace editable input with non-editable display, update handler to read from metadata only. (Modal + handler change together.)
+4. **Cascade warning gate** — when required missing, show only warning, hide form and submit. (Modal opener logic change.)
+
+Each step is independently shippable and testable.


### PR DESCRIPTION
## Summary

- **Study setup modal**: Removed upload sections (now in /qori-discover), removed no-op "Done" submit, conversational copy with emoji type differentiation
- **Plan modal**: Study name converted to non-editable context display, lead researcher converted from text input to `users_select` (Slack user ID → display name at render time), cascade warning now gates the form entirely when required variables are missing
- **Handler**: Reads study name from `private_metadata`, resolves lead researcher user ID via `client.users.info()`
- **Backlog**: Updated /qori-plan items, reversed execution risks removal decision with rationale

## Test plan

- [ ] Run `/qori-plan` — study setup modal shows 3 document buttons, no upload section, no "Done" submit
- [ ] Select study → click Create next to Research plan — plan modal shows study name as non-editable context, `users_select` defaults to opener
- [ ] Change lead researcher to another workspace user → submit → verify generated plan shows correct display name
- [ ] Test with study missing brief variables → modal shows warning-only view (no form, no submit)
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (76/76)

🤖 Generated with [Claude Code](https://claude.com/claude-code)