### PR TITLE
fix: replace typed-name inputs with users_select across remaining modals

### DIFF
--- a/backend/src/helpers/slack/commands/briefHandler.ts
+++ b/backend/src/helpers/slack/commands/briefHandler.ts
@@ -408,11 +408,27 @@ async function handleBriefSubmission({ ack, body, view, client }: SlackViewMiddl
 
   console.log(`📋 Structured data assembled: ${targetBarriers.length} barriers, ${researchQuestions.length} questions, ${researchObjectives.length} objectives`);
 
+  // ── Resolve stakeholder display name from users_select ──
+  const stakeholderUserId: string | null =
+    values.stakeholder_block?.stakeholder_select?.selected_user || null;
+  let requestorName = '';
+  if (stakeholderUserId) {
+    try {
+      const userInfo = await client.users.info({ user: stakeholderUserId });
+      const user = userInfo.user as Record<string, any> | undefined;
+      requestorName = user?.real_name || user?.profile?.display_name || user?.name || stakeholderUserId;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn('Could not resolve stakeholder display name:', message);
+      requestorName = stakeholderUserId;
+    }
+  }
+
   // ── Assemble complete data object ──
   const data: BriefTemplateInput = {
     selected_study: studyName,
     lead_researcher: leadResearcher,
-    requestor_name: (extract('stakeholder_block', 'stakeholder_input') as string) || '',
+    requestor_name: requestorName,
     problem_statement: problemStatement,
     learning_objectives: learningObjectives,
     out_of_scope: outOfScope,

--- a/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
+++ b/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
@@ -95,24 +95,17 @@ async function openDiscussionGuideModal({ ack, body, client }: SlackActionMiddle
       };
     }
 
-    // Auto-fill lead moderator from study or Slack profile
-    let leadModerator: string | null = null;
+    // Set initial_user on lead moderator users_select
+    let leadModeratorUserId: string = body.user.id;
     try {
       const study = await getResearchStudyWithRoles(studyName);
-      if (study?.researcher_name) leadModerator = study.researcher_name;
+      if (study?.created_by) leadModeratorUserId = study.created_by;
     } catch (_err) { /* ignore */ }
-    if (!leadModerator) {
-      try {
-        const userInfo = await client.users.info({ user: body.user.id });
-        const user = userInfo.user as Record<string, any> | undefined;
-        leadModerator = user?.real_name || user?.profile?.display_name || user?.name || '';
-      } catch (_err) { /* ignore */ }
-    }
     const moderatorIdx = blocks.findIndex(b => b.block_id === 'lead_moderator_block');
-    if (moderatorIdx !== -1 && leadModerator && blocks[moderatorIdx].element) {
+    if (moderatorIdx !== -1 && blocks[moderatorIdx].element) {
       blocks[moderatorIdx] = {
         ...blocks[moderatorIdx],
-        element: { ...blocks[moderatorIdx].element!, initial_value: leadModerator },
+        element: { ...blocks[moderatorIdx].element!, initial_user: leadModeratorUserId },
       };
     }
 
@@ -189,6 +182,22 @@ async function handleDiscussionGuideSubmission({ ack, body, view, client }: Slac
     return null;
   };
 
+  // Resolve lead moderator display name from users_select
+  const moderatorUserId: string | null =
+    values.lead_moderator_block?.lead_moderator_select?.selected_user || null;
+  let leadResearcherName = '';
+  if (moderatorUserId) {
+    try {
+      const userInfo = await client.users.info({ user: moderatorUserId });
+      const user = userInfo.user as Record<string, any> | undefined;
+      leadResearcherName = user?.real_name || user?.profile?.display_name || user?.name || moderatorUserId;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn('Could not resolve moderator display name:', message);
+      leadResearcherName = moderatorUserId;
+    }
+  }
+
   const guideData: DiscussionGuideTemplateInput = {
     selected_study: studyName,
     study_name: studyName,
@@ -197,7 +206,7 @@ async function handleDiscussionGuideSubmission({ ack, body, view, client }: Slac
     research_method: extract('research_method_block', 'research_method') || 'usability_testing',
     session_length: extract('session_length_block', 'session_length') || '60',
     task_count: extract('task_count_block', 'task_count') || '5',
-    lead_researcher: extract('lead_moderator_block', 'lead_moderator') || body.user?.name || '',
+    lead_researcher: leadResearcherName || body.user?.name || '',
   };
 
   const study = await getResearchStudyWithRoles(studyName);

--- a/backend/src/helpers/slack/commands/requestResearchHandler.ts
+++ b/backend/src/helpers/slack/commands/requestResearchHandler.ts
@@ -53,9 +53,10 @@ async function requestResearchHandler({ ack, command, client }: SlackCommandMidd
 
     const modalView = JSON.parse(JSON.stringify(requestResearchModal));
 
+    // Set initial_user on users_select
     const submittedByBlock = modalView.blocks.find((block: any) => block.block_id === 'submitted_by_block');
     if (submittedByBlock) {
-      submittedByBlock.element.initial_value = displayName;
+      submittedByBlock.element.initial_user = command.user_id;
     }
 
     await client.views.open({
@@ -98,6 +99,22 @@ async function handleRequestResearchSubmission({ ack, body, view, client }: Slac
     return '';
   };
 
+  // Resolve submitted-by user from users_select
+  const submittedByUserId: string | null =
+    values.submitted_by_block?.submitted_by_select?.selected_user || null;
+  let submittedByName = '';
+  if (submittedByUserId) {
+    try {
+      const subInfo = await client.users.info({ user: submittedByUserId });
+      const subUser = subInfo.user as Record<string, any> | undefined;
+      submittedByName = subUser?.real_name || subUser?.profile?.display_name || subUser?.name || submittedByUserId;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn('Could not resolve submitted-by display name:', message);
+      submittedByName = submittedByUserId;
+    }
+  }
+
   const requestData: RequestData = {
     project_title: extract('project_title_block', 'project_title_input'),
     problem_description: extract('problem_description_block', 'problem_description_input'),
@@ -106,8 +123,8 @@ async function handleRequestResearchSubmission({ ack, body, view, client }: Slac
     urgency: extract('urgency_block', 'urgency_select'),
     deadline: extract('deadline_block', 'deadline_picker'),
     existing_knowledge: extract('existing_knowledge_block', 'existing_knowledge_input'),
-    prepared_by: extract('submitted_by_block', 'submitted_by_input'),
-    requestor_name: extract('submitted_by_block', 'submitted_by_input'),
+    prepared_by: submittedByName,
+    requestor_name: submittedByName,
     requestedBy: userId,
     channelId,
     timelineNeeded: extract('urgency_block', 'urgency_select'),

--- a/backend/src/helpers/slack/ui/discussionGuideModal.ts
+++ b/backend/src/helpers/slack/ui/discussionGuideModal.ts
@@ -214,7 +214,7 @@ const discussionGuideModal = {
     {
       type: "divider",
     },
-    // Lead moderator (auto-filled)
+    // Lead moderator (users_select — defaults to opener)
     {
       type: "input",
       block_id: "lead_moderator_block",
@@ -224,12 +224,15 @@ const discussionGuideModal = {
       },
       hint: {
         type: "plain_text",
-        text: "Auto-filled from your profile. Edit if needed.",
+        text: "Auto-filled with you — change if someone else is moderating",
       },
       element: {
-        type: "plain_text_input",
-        action_id: "lead_moderator",
-        initial_value: "{{lead_researcher}}",
+        type: "users_select",
+        action_id: "lead_moderator_select",
+        placeholder: {
+          type: "plain_text",
+          text: "Select moderator...",
+        },
       },
     },
   ],

--- a/backend/src/helpers/slack/ui/outreach/basicInfoBlock.ts
+++ b/backend/src/helpers/slack/ui/outreach/basicInfoBlock.ts
@@ -1,10 +1,17 @@
 interface BasicInfoInitialValues {
   participant_name?: string;
   study_name?: string;
-  researcher_name?: string;
-  researcher_email?: string;
+  researcher_user_id?: string;
 }
 
+/**
+ * Basic info blocks for outreach modals.
+ *
+ * Researcher is a users_select — handler resolves name and email from
+ * client.users.info() or falls back to the study record. This replaces
+ * the previous researcher_name + researcher_email text inputs (which
+ * the handler was already ignoring in favor of the study DB record).
+ */
 export const createBasicInfoBlocks = (initialValues: BasicInfoInitialValues = {}) => [
   {
     type: "input",
@@ -32,58 +39,16 @@ export const createBasicInfoBlocks = (initialValues: BasicInfoInitialValues = {}
   },
   {
     type: "input",
-    block_id: "researcher_name",
-    label: { type: "plain_text", text: "Researcher Name *", emoji: true },
+    block_id: "researcher_block",
+    label: { type: "plain_text", text: "Researcher *", emoji: true },
     element: {
-      type: "plain_text_input",
-      action_id: "value",
-      placeholder: { type: "plain_text", text: "e.g. Jordan (UX Researcher)" },
-      initial_value: initialValues.researcher_name || "",
+      type: "users_select",
+      action_id: "researcher_select",
+      placeholder: { type: "plain_text", text: "Select researcher..." },
+      ...(initialValues.researcher_user_id ? { initial_user: initialValues.researcher_user_id } : {}),
     },
     optional: false,
   },
-  {
-    type: "input",
-    block_id: "researcher_email",
-    label: { type: "plain_text", text: "Researcher Email *", emoji: true },
-    element: {
-      type: "plain_text_input",
-      action_id: "value",
-      placeholder: { type: "plain_text", text: "e.g. jordan.researcher@va.gov" },
-      initial_value: initialValues.researcher_email || "",
-    },
-    optional: false,
-  },
-  // {
-  //   type: "input",
-  //   block_id: "contact_method",
-  //   label: { type: "plain_text", text: "Contact Method *", emoji: true },
-  //   element: {
-  //     type: "static_select",
-  //     action_id: "value",
-  //     options: [
-  //       { text: { type: "plain_text", text: "📧 Email", emoji: true }, value: "Email" },
-  //       { text: { type: "plain_text", text: "Recruitment Agency", emoji: true }, value: "Recruitment Agency" },
-  //       // { text: { type: "plain_text", text: "📞 Phone Call", emoji: true }, value: "Phone Call" },
-  //     ],
-  //   },
-  //   optional: false,
-  // },
-  // {
-  //   type: "input",
-  //   block_id: "tone",
-  //   label: { type: "plain_text", text: "Tone *", emoji: true },
-  //   element: {
-  //     type: "static_select",
-  //     action_id: "value",
-  //     options: [
-  //       { text: { type: "plain_text", text: "😊 Friendly", emoji: true }, value: "Friendly" },
-  //       { text: { type: "plain_text", text: "📝 Formal", emoji: true }, value: "Formal" },
-  //       { text: { type: "plain_text", text: "💬 Casual", emoji: true }, value: "Casual" },
-  //     ],
-  //   },
-  //   optional: false,
-  // },
 ];
 
 // For backward compatibility

--- a/backend/src/helpers/slack/ui/requestResearchModal.ts
+++ b/backend/src/helpers/slack/ui/requestResearchModal.ts
@@ -222,12 +222,15 @@ export const requestResearchModal = {
       },
       hint: {
         type: "plain_text",
-        text: "Auto-populated from your Slack profile",
+        text: "Auto-filled with you — change if submitting on someone's behalf",
       },
       element: {
-        type: "plain_text_input",
-        action_id: "submitted_by_input",
-        initial_value: "{{user_name}}",
+        type: "users_select",
+        action_id: "submitted_by_select",
+        placeholder: {
+          type: "plain_text",
+          text: "Select person...",
+        },
       },
     },
   ],

--- a/backend/src/helpers/slack/ui/researchBriefModal.ts
+++ b/backend/src/helpers/slack/ui/researchBriefModal.ts
@@ -53,7 +53,7 @@ export const researchBriefModal = {
         },
       },
     },
-    // Stakeholder
+    // Stakeholder (users_select — captures Slack user ID for approval routing)
     {
       type: "input",
       block_id: "stakeholder_block",
@@ -66,11 +66,11 @@ export const researchBriefModal = {
         text: "Stakeholder who will approve this brief",
       },
       element: {
-        type: "plain_text_input",
-        action_id: "stakeholder_input",
+        type: "users_select",
+        action_id: "stakeholder_select",
         placeholder: {
           type: "plain_text",
-          text: "e.g., Sarah Chen, Product",
+          text: "Select stakeholder...",
         },
       },
     },


### PR DESCRIPTION
## Summary

- **Brief modal**: "Requested by" text input → `users_select`. Captures stakeholder Slack user ID for future approval DM routing.
- **Discussion guide modal**: "Lead moderator" text input → `users_select`. Opener pre-fills with study creator or current user.
- **Request research modal**: "Submitted by" text input → `users_select`. Opener pre-fills with command invoker.
- **Outreach basicInfoBlock**: "Researcher Name" + "Researcher Email" (2 text fields, handler already ignored them) → single `users_select`. Handler continues reading from study DB record.

All 4 follow the same pattern: modal captures Slack user ID, handler resolves display name via `client.users.info()` at render time, falls back to raw user ID on failure.

Companion to #156 (plan modal polish) which converted the plan modal's lead researcher field.

Stakeholder interview guide's "Stakeholder name" intentionally left as text — interviewees may be external to the Slack workspace.

## Test plan

- [ ] `/qori-brief` → "Requested by" shows user picker defaulting to opener, generated brief shows stakeholder display name
- [ ] `/qori-plan` → select study → Create discussion guide → "Lead moderator" shows user picker, generated guide shows moderator display name
- [ ] `/request-research` → "Submitted by" shows user picker defaulting to invoker, request notification shows display name
- [ ] Outreach modal → "Researcher" shows single user picker (replaces name + email fields), outreach email still renders correctly from study record
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (76/76)

🤖 Generated with [Claude Code](https://claude.com/claude-code)