### PR TITLE
hotfix: restore submit button on study setup modal

### DIFF
--- a/backend/src/helpers/slack/ui/studySetupModal.ts
+++ b/backend/src/helpers/slack/ui/studySetupModal.ts
@@ -36,6 +36,10 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
       type: "plain_text",
       text: "Plan your study",
     },
+    submit: {
+      type: "plain_text",
+      text: "Done",
+    },
     close: {
       type: "plain_text",
       text: "Close",


### PR DESCRIPTION
## Summary

- Slack requires a `submit` property when a modal contains `input` blocks
- The study selector is an `input` block — removing `submit` in #156 caused `invalid_arguments` errors on `views.open`
- Adds back `submit: { text: "Done" }` — the no-op handler (`handlePlanStudyNoop`) already exists

One-line fix. `/qori-plan` is broken on production until this merges.

## Test plan

- [ ] `/qori-plan` opens the study setup modal without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)