### PR TITLE
fix: hard-fail discovery on Postgres write + relabel next-steps buttons

### DIFF
--- a/backend/src/helpers/slack/ui/projectCreatedNextStepsModal.ts
+++ b/backend/src/helpers/slack/ui/projectCreatedNextStepsModal.ts
@@ -90,21 +90,12 @@ export function projectCreatedNextStepsModal(options: ProjectNextStepsModalOptio
           type: "button",
           text: {
             type: "plain_text",
-            text: "Coming soon",
+            text: "Run discovery",
           },
           action_id: "project_action_discovery",
           value: projectSlug,
           style: "primary",
         },
-      },
-      {
-        type: "context",
-        elements: [
-          {
-            type: "mrkdwn",
-            text: "_Wiring in progress — discovery will flow into briefs automatically._",
-          },
-        ],
       },
       {
         type: "section",
@@ -116,20 +107,11 @@ export function projectCreatedNextStepsModal(options: ProjectNextStepsModalOptio
           type: "button",
           text: {
             type: "plain_text",
-            text: "Coming soon",
+            text: "Create brief",
           },
           action_id: "project_action_brief",
           value: projectSlug,
         },
-      },
-      {
-        type: "context",
-        elements: [
-          {
-            type: "mrkdwn",
-            text: "_Briefs will auto-connect to this project once wiring is complete._",
-          },
-        ],
       },
       {
         type: "section",
@@ -164,7 +146,7 @@ export function projectCreatedNextStepsModal(options: ProjectNextStepsModalOptio
         elements: [
           {
             type: "mrkdwn",
-            text: `Project: \`${projectSlug}\` — these workflows connect to projects in the next update.`,
+            text: `Project: \`${projectSlug}\``,
           },
         ],
       },

--- a/backend/src/helpers/studyVariables.ts
+++ b/backend/src/helpers/studyVariables.ts
@@ -568,7 +568,12 @@ export async function readDiscoveryVariables(_team: string, _discoveryType: stri
 
 /**
  * Write discovery variables by project ID.
- * Preferred method for new code.
+ *
+ * Architecture (Phase 2D):
+ * - Postgres is authoritative for cascade variables (what brief modal reads)
+ * - GitHub is a readable backup/debugging artifact
+ * - Postgres write failure = hard fail (cascade would break invisibly)
+ * - GitHub write failure = soft warning (Postgres is authoritative)
  */
 export async function writeDiscoveryVariablesByProject(
   projectId: number,
@@ -578,17 +583,19 @@ export async function writeDiscoveryVariablesByProject(
 ): Promise<void> {
   const StudyVariable = getStudyVariableModel();
 
-  if (StudyVariable) {
-    try {
-      await writeDiscoveryToPostgresByProject(StudyVariable, projectId, variablesData);
-      console.log(`✅ Discovery variables written to Postgres for project:${projectId}`);
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.error('❌ Postgres discovery write failed:', message);
-    }
+  // Hard-fail if database unavailable — discovery without cascade is broken
+  if (!StudyVariable) {
+    throw new Error(
+      'Database unavailable — cannot persist discovery variables. ' +
+      'Discovery requires database connection for cascade to work.'
+    );
   }
 
-  // Also write GitHub artifact if path provided
+  // Postgres write — let exceptions propagate (hard-fail)
+  await writeDiscoveryToPostgresByProject(StudyVariable, projectId, variablesData);
+  console.log(`✅ Discovery variables written to Postgres for project:${projectId}`);
+
+  // GitHub artifact — only write if Postgres succeeded (soft warning on failure)
   // Note: discoveryType is used for Postgres queries but NOT for file paths
   // All discovery variables go to a single flat .variables/ folder
   if (projectPath) {


### PR DESCRIPTION
## Summary

Two fixes from modal audit:

**1. Relabel /qori-start next-steps buttons**
- "Coming soon" → "Run discovery" / "Create brief" (these are wired and working)
- Remove false "Wiring in progress" help text
- Library button keeps honest placeholder

**2. Hard-fail discovery on Postgres write failure**
- Postgres is authoritative for cascade variables (what brief modal reads)
- GitHub is a readable backup/debugging artifact
- Previously: Postgres failure silently swallowed, GitHub still wrote → invisible cascade break
- Now: Postgres failure propagates to user-visible error; GitHub only writes if Postgres succeeds

This fixes the bug where discovery "succeeded" (GitHub artifact exists) but brief modal showed "no discovery available" (Postgres was empty).

## Verification

- Local typecheck ✅
- 114 unit tests ✅  
- 92 integration tests ✅

## Live Re-Test Required

1. `/qori-start` → new project
2. Click "Run discovery" → complete desk research
3. Click "Create brief" → brief modal should show the discovery (not "No discovery available")

🤖 Generated with [Claude Code](https://claude.com/claude-code)