### PR TITLE
fix: handle Date objects in discovery variable source.date

### DIFF
--- a/backend/src/helpers/discoveryLoader.ts
+++ b/backend/src/helpers/discoveryLoader.ts
@@ -69,7 +69,11 @@ export async function loadDiscoveryArtifacts(projectId: number): Promise<Discove
         } else {
           const firstVar = variables[variableKeys[0]];
           if (firstVar?.source?.date) {
-            date = firstVar.source.date.split('T')[0];
+            // source.date may be a Date object (from Sequelize) or string at runtime
+            // despite the type saying string — Sequelize returns Date for date columns
+            const dateValue = firstVar.source.date as unknown;
+            const dateStr = dateValue instanceof Date ? dateValue.toISOString() : String(dateValue);
+            date = dateStr.split('T')[0];
           }
         }
 


### PR DESCRIPTION
## Summary

Sequelize returns `Date` objects for date columns, but the code assumed strings when calling `.split('T')`. Now handles both at runtime.

This fixes the `source.date.split is not a function` error that caused `loadDiscoveryArtifacts` to fail even though variables were written successfully to Postgres.

## Root Cause

```
✅ Discovery variables written to Postgres for project:35
Discovery: no variables for project 35, type desk-research (firstVar.source.date.split is not a function)
```

Postgres write succeeded, but the read crashed because `source.date` was a `Date` object, not a string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)