### PR TITLE
fix: filter discovery variables by type when reading

### DIFF
--- a/backend/src/helpers/studyVariables.ts
+++ b/backend/src/helpers/studyVariables.ts
@@ -21,6 +21,13 @@ const TEMPLATE_TO_DISCOVERY_TYPE: Record<string, string> = {
   'survey_synthesis': 'survey-synthesis',
 };
 
+// Reverse mapping: discovery type → source_template for filtering queries
+const DISCOVERY_TYPE_TO_TEMPLATE: Record<string, string> = {
+  'desk-research': 'desk_research',
+  'stakeholder-interviews': 'stakeholder_synthesis',
+  'survey-synthesis': 'survey_synthesis',
+};
+
 // ═══════════════════════════════════════════════════════════
 // TYPE DEFINITIONS
 // ═══════════════════════════════════════════════════════════
@@ -534,11 +541,20 @@ export async function readDiscoveryVariablesByProject(projectId: number, discove
 
   if (StudyVariable) {
     try {
+      // Map discovery type to source_template for filtering
+      // e.g., 'desk-research' → 'desk_research'
+      const sourceTemplate = DISCOVERY_TYPE_TO_TEMPLATE[discoveryType];
+      if (!sourceTemplate) {
+        console.warn(`⚠️ Unknown discovery type "${discoveryType}", returning empty`);
+        return createEmptyDiscoveryVariablesFile(`project-${projectId}`, discoveryType);
+      }
+
       const rows = await StudyVariable.findAll({
         where: {
           project_id: projectId,
           study_id: null,
           scope: 'discovery',
+          source_template: sourceTemplate,
         },
       });
 


### PR DESCRIPTION
## Summary

`readDiscoveryVariablesByProject` was returning ALL discovery variables for the project, regardless of type. This caused the brief modal to show all three discovery types (desk research, stakeholder, survey) even when only one was run.

Now filters by `source_template` to only return variables for the requested discovery type.

## Before
- Run desk research only
- Brief modal shows 3 discovery sources (desk, stakeholder, survey) — all with same data

## After  
- Run desk research only
- Brief modal shows 1 discovery source (desk research)

🤖 Generated with [Claude Code](https://claude.com/claude-code)