### PR TITLE
Add PII scrubbing verification test

### DIFF
--- a/backend/src/config/sentry.js
+++ b/backend/src/config/sentry.js
@@ -148,6 +148,26 @@ function scrubPII(data, visited = new Set(), depth = 0) {
  * @returns {import('@sentry/node').Event | null} - Scrubbed event or null to drop
  */
 function beforeSend(event) {
+  // Debug mode: log before/after for PII verification
+  // Set SENTRY_DEBUG_SCRUBBING=true to enable
+  const debugScrubbing = process.env.SENTRY_DEBUG_SCRUBBING === 'true';
+
+  if (debugScrubbing) {
+    console.log('\n========== SENTRY BEFORE SCRUBBING ==========');
+    console.log(JSON.stringify({
+      exception_message: event.exception?.values?.[0]?.value,
+      exception_stack_vars: event.exception?.values?.[0]?.stacktrace?.frames?.slice(-3).map(f => ({
+        function: f.function,
+        vars: f.vars
+      })),
+      extra: event.extra,
+      contexts: event.contexts,
+      tags: event.tags,
+      breadcrumbs: event.breadcrumbs?.slice(-3),
+      request_data: event.request?.data,
+    }, null, 2));
+  }
+
   try {
     // Scrub exception values (error messages)
     if (event.exception?.values) {
@@ -194,6 +214,23 @@ function beforeSend(event) {
     // Scrub request body if present
     if (event.request?.data) {
       event.request.data = scrubPII(event.request.data);
+    }
+
+    if (debugScrubbing) {
+      console.log('\n========== SENTRY AFTER SCRUBBING ==========');
+      console.log(JSON.stringify({
+        exception_message: event.exception?.values?.[0]?.value,
+        exception_stack_vars: event.exception?.values?.[0]?.stacktrace?.frames?.slice(-3).map(f => ({
+          function: f.function,
+          vars: f.vars
+        })),
+        extra: event.extra,
+        contexts: event.contexts,
+        tags: event.tags,
+        breadcrumbs: event.breadcrumbs?.slice(-3),
+        request_data: event.request?.data,
+      }, null, 2));
+      console.log('==============================================\n');
     }
 
     return event;

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -282,23 +282,6 @@ slackExpressRouter.post('/commands', (req: any, res: any) => {
 
 // ─── Slash commands (entry points) ──────────────────────────────
 
-// ─── Temporary test command (remove after verifying Sentry) ──────
-slackApp.command('/qori-test-error', async ({ ack }) => {
-  await ack();
-  interface TestError extends Error {
-    context?: Record<string, unknown>;
-  }
-  const testError: TestError = new Error('Test error: Participant PT-007 reported login issues');
-  testError.context = {
-    participant_id: 'PT-007',
-    participant_name: 'John Smith',
-    nugget_text: 'Veteran said the login flow is confusing and takes too long',
-    email: 'john.smith@example.com',
-    variables: { theme: 'usability', severity: 'high' },
-  };
-  throw testError;
-});
-
 slackApp.command('/qori', qoriMainCommand);
 slackApp.command('/qori-start', projectStartCommand);
 slackApp.command('/qori-brief', async ({ ack, client, command }) => {

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -282,6 +282,41 @@ slackExpressRouter.post('/commands', (req: any, res: any) => {
 
 // ─── Slash commands (entry points) ──────────────────────────────
 
+// ─── Temporary PII scrubbing verification command ──────
+// Remove after verifying Sentry scrubbing covers all PII hiding places
+slackApp.command('/qori-test-pii', async ({ ack, client, command }) => {
+  await ack();
+
+  // Add a breadcrumb with PII (will be captured by Sentry)
+  Sentry.addBreadcrumb({
+    message: 'User PT-042 clicked submit button',
+    category: 'ui',
+    data: {
+      participant_name: 'Jane Doe',
+      action: 'form_submit',
+    },
+  });
+
+  // Set extra context with PII
+  Sentry.setExtra('participant_data', {
+    participant_id: 'PT-099',
+    name: 'Robert Johnson',
+    quote: 'The veteran mentioned that the VA website is hard to navigate',
+    verbatim: 'I just want to check my appointments without calling',
+  });
+
+  // Set tags (shouldn't have PII but testing defense in depth)
+  Sentry.setTag('test_participant', 'PT-123');
+
+  // Error message contains PII
+  const err = new Error(
+    'Extraction failed for participant PT-007 (John Smith): ' +
+    'nugget "The login process takes forever and I give up" could not be parsed'
+  );
+
+  throw err;
+});
+
 slackApp.command('/qori', qoriMainCommand);
 slackApp.command('/qori-start', projectStartCommand);
 slackApp.command('/qori-brief', async ({ ack, client, command }) => {


### PR DESCRIPTION
## Summary

Adds tools to verify PII scrubbing is working correctly before trusting it with real participant data.

**Temporary changes (remove after verification):**
- `SENTRY_DEBUG_SCRUBBING=true` env var logs before/after payloads
- `/qori-test-pii` command tests PII in all hiding places

## Verification steps

1. Set `SENTRY_DEBUG_SCRUBBING=true` in Railway
2. Register `/qori-test-pii` in Slack app
3. Run the command
4. Check Railway logs for before/after output
5. Verify all PII is scrubbed:
   - Exception message: PT-XXX, names, quotes
   - Extra context: participant_id, name, verbatim
   - Breadcrumbs: user actions with participant IDs
   - Tags: defense in depth

## Test plan

- [ ] Deploy with debug flag
- [ ] Run /qori-test-pii
- [ ] Verify BEFORE shows raw PII
- [ ] Verify AFTER shows [REDACTED_*] markers
- [ ] Remove test command and debug flag after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)