### PR TITLE
fix: add confirmation message to PII test command

### DIFF
--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -295,7 +295,7 @@ slackExpressRouter.post('/commands', (req: any, res: any) => {
 // handler's withScope creates an isolated context. Extras set before throwing
 // don't flow into that scope — they're lost. Direct capture ensures context
 // is attached to the event that reaches beforeSend.
-slackApp.command('/qori-test-pii', async ({ ack }) => {
+slackApp.command('/qori-test-pii', async ({ ack, client, command }) => {
   await ack();
 
   // Error message with interpolated PII (BAD PATTERN, but scrubber should catch)
@@ -305,7 +305,7 @@ slackApp.command('/qori-test-pii', async ({ ack }) => {
   );
 
   // Capture directly with context attached — this is how beforeSend receives it
-  Sentry.captureException(err, {
+  const eventId = Sentry.captureException(err, {
     tags: {
       test_participant: 'PT-123',
       slack_error: 'true',
@@ -331,6 +331,15 @@ slackApp.command('/qori-test-pii', async ({ ack }) => {
         action: 'form_submit',
       },
     },
+  });
+
+  // Confirm to user that the test ran
+  await client.chat.postEphemeral({
+    channel: command.channel_id,
+    user: command.user_id,
+    text: eventId
+      ? `PII test event sent to Sentry.\nEvent ID: \`${eventId}\`\n\nCheck Sentry for an event with tag \`error_type: PII_TEST\`. The exception message should show \`[REDACTED_PII]\` instead of "John Smith" and the verbatim quote.`
+      : `Sentry capture returned no event ID. Check if SENTRY_DSN is set and NODE_ENV is not "development".`,
   });
 });
 


### PR DESCRIPTION
## Summary

- Shows the Sentry event ID after capturing (or a warning if Sentry isn't configured)
- Helps verify the capture actually happened and provides the event ID to look up in Sentry

## Test plan

- [ ] Deploy to Railway
- [ ] Run `/qori-test-pii` in Slack
- [ ] Should see confirmation message with event ID (or warning about Sentry config)
- [ ] Look up event ID in Sentry to verify PII scrubbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)