### PR TITLE
feat: cascade-aware transcript selection in /qori-analyze

### DIFF
--- a/backend/src/helpers/slack/commands/analyzeNotesHandler.ts
+++ b/backend/src/helpers/slack/commands/analyzeNotesHandler.ts
@@ -9,7 +9,7 @@
 import type { AllMiddlewareArgs, SlackCommandMiddlewareArgs, SlackActionMiddlewareArgs, SlackViewMiddlewareArgs, BlockAction, ViewSubmitAction } from '@slack/bolt';
 import type { ResearchQuestion, TargetBarrier } from '../../../types/cascade';
 
-import { analyzeNotesModal } from "../ui/analyzeNotesModal";
+import { analyzeNotesModal, type AnalyzeNotesModalMetadata } from "../ui/analyzeNotesModal";
 import { getStudiesByUser, resolveStudyFromName } from "../../../services/research_study.service";
 import { getActiveStudy, setActiveStudy } from "../../../services/slack-user-state.service";
 import { studyNotesService } from "../../../services";
@@ -131,6 +131,28 @@ const mapParticipantsToSessions = (participants: ParticipantRecord[]): MappedSes
   }));
 };
 
+// ─── Dynamic block_id helpers ────────────────────────────────────
+// Session block_id is dynamic (includes study ID) to reset Slack's view state on study change.
+// These helpers find the session selection regardless of which study's block_id is in use.
+
+type ViewStateValues = Record<string, Record<string, { selected_option?: { value?: string; text?: { text?: string } } }>>;
+
+const findSessionSelection = (values: ViewStateValues): { value?: string; text?: string } | null => {
+  // Search all blocks for the session action_id
+  for (const blockId of Object.keys(values)) {
+    if (blockId.startsWith('session_select_block')) {
+      const action = values[blockId]?.analyze_notes_session_select;
+      if (action?.selected_option) {
+        return {
+          value: action.selected_option.value,
+          text: action.selected_option.text?.text,
+        };
+      }
+    }
+  }
+  return null;
+};
+
 // ─── Command handler ────────────────────────────────────────────
 
 const analyzeNotesHandler = async ({ ack, body, client }: SlackCommandMiddlewareArgs & AllMiddlewareArgs): Promise<void> => {
@@ -197,18 +219,31 @@ const analyzeNotesHandler = async ({ ack, body, client }: SlackCommandMiddleware
 const handleAnalyzeNotesSubmission = async ({ ack, body, view, client }: SlackViewMiddlewareArgs<ViewSubmitAction> & AllMiddlewareArgs): Promise<void> => {
   const values = view.state.values;
 
+  // Parse metadata for auto-selected transcript (when exactly 1 transcript exists)
+  let metadata: AnalyzeNotesModalMetadata = { source: 'slack' };
+  try {
+    metadata = JSON.parse(view.private_metadata || '{}');
+  } catch {
+    // Default to empty metadata if parsing fails
+  }
+
   const studyId = values.study_select_block?.study_select_test?.selected_option?.value as string | undefined;
-  const sessionId = values.session_select_block?.analyze_notes_session_select?.selected_option?.value as string | undefined;
-  const selectedTranscriptId = values.transcript_select_block?.transcript_select?.selected_option?.value as string | undefined;
+  const sessionSelection = findSessionSelection(values as ViewStateValues);
+  const sessionId = sessionSelection?.value;
   const selectedNotes = values.notes_select_block?.notes_select?.selected_options || [];
 
+  // Transcript: check form value first (>1 transcripts), fall back to auto-selected (1 transcript)
+  const selectedTranscriptId =
+    values.transcript_select_block?.transcript_select?.selected_option?.value ||
+    metadata.autoSelectedTranscriptId;
+
   // Transcript is required
-  const transcriptBlock = values.transcript_select_block;
-  if (!transcriptBlock || !selectedTranscriptId) {
+  if (!selectedTranscriptId) {
+    // This only happens if 0 transcripts (submit should be disabled, but defensive)
     await (ack as Function)({
       response_action: "errors",
       errors: {
-        transcript_select_block: "Please select a session transcript to analyze."
+        transcript_selection_header: "No transcript available. Upload one via /qori-notes first."
       }
     });
     return;
@@ -237,7 +272,7 @@ const handleAnalyzeNotesSubmission = async ({ ack, body, view, client }: SlackVi
     }
 
     const studyName: string = values.study_select_block?.study_select_test?.selected_option?.text?.text || "Unknown Study";
-    const sessionName: string | null = values.session_select_block?.analyze_notes_session_select?.selected_option?.text?.text || null;
+    const sessionName: string | null = sessionSelection?.text || null;
 
     // Fetch the transcript (required)
     const noteDetails: NoteDetail[] = [];
@@ -524,7 +559,7 @@ const handleSessionSelectionChange = async ({ ack, body, client }: SlackActionMi
     }
 
     const selectedStudyOption = view.state.values.study_select_block?.study_select_test?.selected_option;
-    const selectedSessionOption = view.state.values.session_select_block?.analyze_notes_session_select?.selected_option;
+    const sessionSelection = findSessionSelection(view.state.values as ViewStateValues);
 
     if (!selectedStudyOption || selectedStudyOption.value === "no_studies") {
       console.log("🚀 ~ No study selected");
@@ -546,7 +581,7 @@ const handleSessionSelectionChange = async ({ ack, body, client }: SlackActionMi
     ]);
     const sessions = mapParticipantsToSessions(participantsResult as ParticipantRecord[]);
 
-    if (!selectedSessionOption || selectedSessionOption.value === "no_sessions") {
+    if (!sessionSelection || sessionSelection.value === "no_sessions") {
       console.log("🚀 ~ No session selected, showing sessions only");
       await client.views.update({
         view_id: view.id,
@@ -562,14 +597,14 @@ const handleSessionSelectionChange = async ({ ack, body, client }: SlackActionMi
       return;
     }
 
-    const sessionId = parseInt(selectedSessionOption.value);
-    const sessionName: string = selectedSessionOption.text.text;
+    const sessionId = parseInt(sessionSelection.value!);
+    const sessionName: string = sessionSelection.text || 'Unknown Session';
 
     // Get the participant to extract participant_name
     let participantName: string | null = null;
     try {
       const allParticipants = await studyParticipantService.getParticipantsByStudy(studyId);
-      const participant = allParticipants.find((p) => p.id.toString() === selectedSessionOption.value);
+      const participant = allParticipants.find((p) => p.id.toString() === sessionSelection.value);
       participantName = participant?.participant_name || null;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/backend/src/helpers/slack/ui/analyzeNotesModal.ts
+++ b/backend/src/helpers/slack/ui/analyzeNotesModal.ts
@@ -6,6 +6,7 @@ import { generateFileCheckboxOptions } from "../../generateFileCheckboxOptions";
 /** The shape of private_metadata for the analyze-notes-modal. */
 export interface AnalyzeNotesModalMetadata {
   source: 'slack';
+  autoSelectedTranscriptId?: string;  // Populated when exactly 1 transcript exists
 }
 
 interface ResearchStudy {
@@ -240,9 +241,16 @@ export const analyzeNotesModal = (
       sessionSelectElement.initial_option = selectedSessionOption;
     }
 
+    // Dynamic block_id incorporates study ID so Slack resets state when study changes.
+    // Without this, Slack preserves the old session selection in view.state.values
+    // even after we rebuild the modal with new options.
+    const sessionBlockId = selectedStudy
+      ? `session_select_block_${selectedStudy}`
+      : "session_select_block";
+
     blocks.push({
       type: "input",
-      block_id: "session_select_block",
+      block_id: sessionBlockId,
       dispatch_action: true,
       label: {
         type: "plain_text",
@@ -252,7 +260,19 @@ export const analyzeNotesModal = (
       element: sessionSelectElement,
     });
 
-    if (sessions.length > 10) {
+    if (sessions.length === 0) {
+      // No sessions — actionable hint (same pattern as no-transcripts)
+      blocks.push({
+        type: "context",
+        block_id: "no_sessions_hint",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "No sessions yet — run `/qori-notes` to upload a session transcript first.",
+          },
+        ],
+      });
+    } else if (sessions.length > 10) {
       blocks.push({
         type: "context",
         block_id: "sessions_limit_warning",
@@ -273,16 +293,61 @@ export const analyzeNotesModal = (
     });
 
     // Section 3a: Session Transcript (required)
-    blocks.push({
-      type: "section",
-      block_id: "transcript_selection_header",
-      text: {
-        type: "mrkdwn",
-        text: `*Session Transcript*\n${transcriptFiles.length > 0 ? 'Select the session transcript to analyze. This is the primary source for the summary.' : 'No transcripts available for this session.'}`,
-      },
-    });
+    // Three states: 0 transcripts (warning, no submit), 1 transcript (auto-select), >1 transcripts (picker)
+    const transcriptCount = transcriptFiles.length;
 
-    if (transcriptOptions.length > 0) {
+    if (transcriptCount === 0) {
+      // State: 0 transcripts — hard fail, no submit
+      blocks.push({
+        type: "section",
+        block_id: "transcript_selection_header",
+        text: {
+          type: "mrkdwn",
+          text: "*Session Transcript*\n:warning: No transcript uploaded for this session.",
+        },
+      });
+      blocks.push({
+        type: "context",
+        block_id: "no_transcripts_warning",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "Upload a session transcript first via `/qori-notes`, then re-open this modal.",
+          },
+        ],
+      });
+    } else if (transcriptCount === 1) {
+      // State: 1 transcript — auto-select, read-only display
+      const transcript = transcriptFiles[0];
+      blocks.push({
+        type: "section",
+        block_id: "transcript_selection_header",
+        text: {
+          type: "mrkdwn",
+          text: "*Session Transcript*",
+        },
+      });
+      blocks.push({
+        type: "context",
+        block_id: "transcript_auto_selected",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `📄 *Analyzing:* \`${transcript.filename || 'Unknown'}\``,
+          },
+        ],
+      });
+      // autoSelectedTranscriptId will be stored in private_metadata
+    } else {
+      // State: >1 transcripts — picker (legacy/edge case)
+      blocks.push({
+        type: "section",
+        block_id: "transcript_selection_header",
+        text: {
+          type: "mrkdwn",
+          text: "*Session Transcript*\nSelect the transcript to analyze.",
+        },
+      });
       blocks.push({
         type: "input",
         block_id: "transcript_select_block",
@@ -300,17 +365,6 @@ export const analyzeNotesModal = (
           },
           options: transcriptOptions,
         },
-      });
-    } else {
-      blocks.push({
-        type: "context",
-        block_id: "no_transcripts_warning",
-        elements: [
-          {
-            type: "mrkdwn",
-            text: "No transcripts available. Upload a session transcript first via `/qori-notes`.",
-          },
-        ],
       });
     }
 
@@ -358,12 +412,20 @@ export const analyzeNotesModal = (
     }
   }
 
+  // Determine if submission is allowed
+  // When showNotes is true, we need at least 1 transcript to enable submit
+  const canSubmit = !showNotes || transcriptFiles.length > 0;
+
   // Submit button text based on state
-  const submitButtonText = showNotes && (transcriptOptions.length > 0)
+  const submitButtonText = showNotes && transcriptFiles.length > 0
     ? "Analyze"
-    : showSession
-      ? "Continue"
-      : "Continue";
+    : "Continue";
+
+  // Build metadata — include autoSelectedTranscriptId when exactly 1 transcript
+  const metadata: AnalyzeNotesModalMetadata = {
+    source: 'slack',
+    ...(transcriptFiles.length === 1 && { autoSelectedTranscriptId: transcriptFiles[0].id.toString() }),
+  };
 
   return {
     type: "modal",
@@ -378,12 +440,15 @@ export const analyzeNotesModal = (
       text: "Cancel",
       emoji: false,
     },
-    submit: {
-      type: "plain_text",
-      text: submitButtonText,
-      emoji: false,
-    },
-    private_metadata: JSON.stringify({ source: 'slack' } satisfies AnalyzeNotesModalMetadata),
+    // No submit button when 0 transcripts (canSubmit = false)
+    ...(canSubmit && {
+      submit: {
+        type: "plain_text",
+        text: submitButtonText,
+        emoji: false,
+      },
+    }),
+    private_metadata: JSON.stringify(metadata),
     blocks,
   } as unknown as View;
 };


### PR DESCRIPTION
## Summary

- Auto-select transcript when session has exactly 1 (read-only "Analyzing: [filename]" display, no picker)
- Radio picker fallback when >1 transcript (legacy/edge case)
- Graceful "no transcript" and "no sessions" states with `/qori-notes` hints, Analyze button omitted when nothing to analyze
- Fix stale session selection on study switch: dynamic session `block_id` per study + `findSessionSelection` helper so changing study resets the session field (display + submission), preventing cross-study session mismatch
- No-brief Cascade Context block correctly hidden when no approved brief

## Test plan

All states verified live:
- [x] 1-transcript auto-select (read-only display, Analyze runs correctly)
- [x] >1 transcripts picker (PT003 with legacy coded-transcript artifact)
- [x] 0-transcript state (warning + no Analyze button)
- [x] No-sessions state (hint + Continue blocked)
- [x] Study-switch reset (session field clears, no cross-study mismatch)
- [x] No-brief Cascade Context block hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)