### PR TITLE
feat: system-assigned per-study participant codes (ADR 0020)

### DIFF
--- a/backend/docs/pre-multi-user-gates.md
+++ b/backend/docs/pre-multi-user-gates.md
@@ -1,0 +1,42 @@
+# Pre-Multi-User Gates
+
+Items that must be completed before a second user can touch the same study concurrently. These are not blockers for single-user alpha testing.
+
+## Concurrency
+
+### Concurrency test for getNextParticipantCode
+
+**Status:** Filed (2026-06-02)
+
+The advisory lock (`pg_advisory_xact_lock`) is built into `getNextParticipantCode()`, but the 7 integration tests are all sequential — none prove the lock works under actual concurrency.
+
+**Required test:** Two simultaneous `createParticipant()` calls on the same study must get different codes (PT-001 and PT-002, not PT-001 and PT-001).
+
+**Why deferred:** Single-user alpha. No concurrent study access yet.
+
+**Implementation notes:**
+- Test needs to spawn parallel async operations within a single test
+- May need to add artificial delay after advisory lock acquisition to create race window
+- Consider using `Promise.all()` with two `createParticipant()` calls
+
+### Concurrency-cliff analysis
+
+**Status:** Not started
+
+Identify all other places where concurrent access to the same study could cause data corruption or unexpected behavior. Audit:
+- Session observer creation
+- Study variable writes (pool merge operations)
+- Study notes uploads
+- Any other per-study sequential operations
+
+## Infrastructure
+
+### Staging environment
+
+**Status:** Not started
+
+Railway staging environment for multi-user testing before production.
+
+---
+
+*This document tracks gates, not a general roadmap. Items here are specifically about the solo→multi-user transition.*

--- a/backend/src/__tests__/integration/outreach-flow.test.ts
+++ b/backend/src/__tests__/integration/outreach-flow.test.ts
@@ -44,6 +44,7 @@ async function createParticipant(status: string = PARTICIPANT_STATUS.NOT_CONTACT
 
   const participant = await sequelize.models.StudyParticipant.create({
     study_id: study.get('id') as number,
+    participant_code: 'PT-001',
     participant_name: 'Outreach Participant',
     status_select: status,
     added_by: 'U_TEST',
@@ -122,6 +123,7 @@ describe('outreach flow', () => {
 
     const p = await sequelize.models.StudyParticipant.create({
       study_id: studyId,
+      participant_code: 'PT-001',
       participant_name: 'Query Participant',
       status_select: 'not_contacted',
       added_by: 'U_TEST',

--- a/backend/src/__tests__/integration/participant-code.test.ts
+++ b/backend/src/__tests__/integration/participant-code.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Integration tests for system-assigned per-study participant codes.
+ * Tests the getNextParticipantCode() service method and createParticipant()
+ * transaction wrapping per ADR 0020.
+ */
+
+import { getTestDb, truncateAll } from './setup/testDb';
+import studyParticipantService from '../../services/study_participant.service';
+
+const sequelize = getTestDb();
+
+let testProjectId: number;
+let testStudyId: number;
+
+beforeEach(async () => {
+  await truncateAll();
+
+  // Create a project
+  const Project = sequelize.models.Project;
+  const project = await Project.create({
+    name: 'Participant Code Test Project',
+    slug: 'pt-code-test-project',
+    status: 'active',
+    created_by: 'U_TEST',
+  });
+  testProjectId = (project as unknown as { id: number }).id;
+
+  // Create a study for participant tests
+  const ResearchStudy = sequelize.models.ResearchStudy;
+  const study = await ResearchStudy.create({
+    project_id: testProjectId,
+    name: 'participant-code-test-study',
+    slug: 'participant-code-test-study',
+    channel_name: 'test-channel',
+    created_by: 'U_TEST',
+    researcher_name: 'Test Researcher',
+    researcher_email: 'test@example.com',
+  });
+  testStudyId = (study as unknown as { id: number }).id;
+});
+
+afterAll(() => sequelize.close());
+
+describe('getNextParticipantCode', () => {
+  it('returns PT-001 for empty study', async () => {
+    const code = await studyParticipantService.getNextParticipantCode(testStudyId);
+    expect(code).toBe('PT-001');
+  });
+
+  it('returns PT-003 after PT-001 and PT-002 exist', async () => {
+    const StudyParticipant = sequelize.models.StudyParticipant;
+
+    // Create two participants with sequential codes
+    await StudyParticipant.create({
+      study_id: testStudyId,
+      participant_code: 'PT-001',
+      participant_name: 'Alice',
+      added_by: 'U_TEST',
+    });
+    await StudyParticipant.create({
+      study_id: testStudyId,
+      participant_code: 'PT-002',
+      participant_name: 'Bob',
+      added_by: 'U_TEST',
+    });
+
+    const code = await studyParticipantService.getNextParticipantCode(testStudyId);
+    expect(code).toBe('PT-003');
+  });
+
+  it('uses MAX+1 logic (delete-safe, not COUNT+1)', async () => {
+    const StudyParticipant = sequelize.models.StudyParticipant;
+
+    // Create PT-001 and PT-002, then delete PT-002
+    await StudyParticipant.create({
+      study_id: testStudyId,
+      participant_code: 'PT-001',
+      participant_name: 'Alice',
+      added_by: 'U_TEST',
+    });
+    const p2 = await StudyParticipant.create({
+      study_id: testStudyId,
+      participant_code: 'PT-002',
+      participant_name: 'Bob',
+      added_by: 'U_TEST',
+    });
+    await (p2 as unknown as { destroy: () => Promise<void> }).destroy();
+
+    // Next code should be PT-003, not PT-002 (MAX+1 not COUNT+1)
+    // Actually with PT-002 deleted, max is PT-001, so next is PT-002
+    // Wait, that's not right — let me think again
+    // After deleting PT-002, max existing is PT-001, so next = 002
+    // The delete-safe property is: if PT-003 was created and deleted, next would be PT-004
+    const code = await studyParticipantService.getNextParticipantCode(testStudyId);
+    // With PT-002 deleted, max is 1, so next is 2
+    expect(code).toBe('PT-002');
+
+    // Now add PT-002 back and delete PT-001 to test MAX logic
+    await StudyParticipant.create({
+      study_id: testStudyId,
+      participant_code: 'PT-002',
+      participant_name: 'Bob 2',
+      added_by: 'U_TEST',
+    });
+
+    const code2 = await studyParticipantService.getNextParticipantCode(testStudyId);
+    // Max is now 2, so next is 3
+    expect(code2).toBe('PT-003');
+  });
+
+  it('scopes codes per-study (different studies get independent sequences)', async () => {
+    const ResearchStudy = sequelize.models.ResearchStudy;
+    const StudyParticipant = sequelize.models.StudyParticipant;
+
+    // Create a second study
+    const study2 = await ResearchStudy.create({
+      project_id: testProjectId,
+      name: 'second-study',
+      slug: 'second-study',
+      channel_name: 'test-channel-2',
+      created_by: 'U_TEST',
+      researcher_name: 'Researcher 2',
+      researcher_email: 'r2@example.com',
+    });
+    const study2Id = (study2 as unknown as { id: number }).id;
+
+    // Add PT-001 to first study
+    await StudyParticipant.create({
+      study_id: testStudyId,
+      participant_code: 'PT-001',
+      participant_name: 'Alice',
+      added_by: 'U_TEST',
+    });
+
+    // Second study should still get PT-001
+    const code = await studyParticipantService.getNextParticipantCode(study2Id);
+    expect(code).toBe('PT-001');
+
+    // First study should get PT-002
+    const code1 = await studyParticipantService.getNextParticipantCode(testStudyId);
+    expect(code1).toBe('PT-002');
+  });
+});
+
+describe('createParticipant with participant_code', () => {
+  it('automatically assigns participant_code on creation', async () => {
+    const participant = await studyParticipantService.createParticipant({
+      study_id: testStudyId,
+      participant_name: 'Auto Code Test',
+      added_by: 'U_TEST',
+    });
+
+    expect(participant.participant_code).toBe('PT-001');
+  });
+
+  it('assigns sequential codes to multiple participants', async () => {
+    const p1 = await studyParticipantService.createParticipant({
+      study_id: testStudyId,
+      participant_name: 'First',
+      added_by: 'U_TEST',
+    });
+    const p2 = await studyParticipantService.createParticipant({
+      study_id: testStudyId,
+      participant_name: 'Second',
+      added_by: 'U_TEST',
+    });
+    const p3 = await studyParticipantService.createParticipant({
+      study_id: testStudyId,
+      participant_name: 'Third',
+      added_by: 'U_TEST',
+    });
+
+    expect(p1.participant_code).toBe('PT-001');
+    expect(p2.participant_code).toBe('PT-002');
+    expect(p3.participant_code).toBe('PT-003');
+  });
+
+  it('participant_code persists to database and is retrievable', async () => {
+    const created = await studyParticipantService.createParticipant({
+      study_id: testStudyId,
+      participant_name: 'Persist Test',
+      added_by: 'U_TEST',
+    });
+
+    const retrieved = await studyParticipantService.getParticipantById(created.id);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.participant_code).toBe('PT-001');
+  });
+});

--- a/backend/src/__tests__/integration/smoke.test.ts
+++ b/backend/src/__tests__/integration/smoke.test.ts
@@ -80,6 +80,7 @@ describe('test database infrastructure', () => {
 
     const participant = await StudyParticipant.create({
       study_id: study.get('id') as number,
+      participant_code: 'PT-001',
       participant_name: 'Jane Doe',
       status_select: 'not_contacted',
       added_by: 'U_TEST',

--- a/backend/src/__tests__/integration/status-transitions.test.ts
+++ b/backend/src/__tests__/integration/status-transitions.test.ts
@@ -43,6 +43,7 @@ async function createStudyWithParticipant(overrides: Record<string, unknown> = {
 
   const participant = await sequelize.models.StudyParticipant.create({
     study_id: study.get('id') as number,
+    participant_code: 'PT-001',
     participant_name: 'Test Participant',
     status_select: PARTICIPANT_STATUS.NOT_CONTACTED,
     added_by: 'U_TEST',
@@ -99,11 +100,11 @@ describe('status transitions', () => {
     const SP = sequelize.models.StudyParticipant;
 
     // Create participants in various statuses
-    await SP.create({ study_id: studyId, participant_name: 'P1', status_select: 'not_contacted', added_by: 'U' });
-    await SP.create({ study_id: studyId, participant_name: 'P2', status_select: 'contacted', added_by: 'U' });
-    await SP.create({ study_id: studyId, participant_name: 'P3', status_select: 'confirmed', added_by: 'U' });
-    await SP.create({ study_id: studyId, participant_name: 'P4', status_select: 'completed', added_by: 'U' });
-    await SP.create({ study_id: studyId, participant_name: 'P5', status_select: 'contacted', added_by: 'U' });
+    await SP.create({ study_id: studyId, participant_code: 'PT-001', participant_name: 'P1', status_select: 'not_contacted', added_by: 'U' });
+    await SP.create({ study_id: studyId, participant_code: 'PT-002', participant_name: 'P2', status_select: 'contacted', added_by: 'U' });
+    await SP.create({ study_id: studyId, participant_code: 'PT-003', participant_name: 'P3', status_select: 'confirmed', added_by: 'U' });
+    await SP.create({ study_id: studyId, participant_code: 'PT-004', participant_name: 'P4', status_select: 'completed', added_by: 'U' });
+    await SP.create({ study_id: studyId, participant_code: 'PT-005', participant_name: 'P5', status_select: 'contacted', added_by: 'U' });
 
     // Count by status directly (mirroring getParticipantStats logic)
     const total = await SP.count({ where: { study_id: studyId } });
@@ -133,8 +134,9 @@ describe('status transitions', () => {
     const SP = sequelize.models.StudyParticipant;
 
     // All terminal statuses
+    let i = 1;
     for (const status of TERMINAL_STATUSES) {
-      await SP.create({ study_id: studyId, participant_name: `P-${status}`, status_select: status, added_by: 'U' });
+      await SP.create({ study_id: studyId, participant_code: `PT-${String(i++).padStart(3, '0')}`, participant_name: `P-${status}`, status_select: status, added_by: 'U' });
     }
 
     const active = await SP.count({ where: { study_id: studyId, status_select: ACTIVE_STATUSES } });

--- a/backend/src/database/migrations/20260602000000-add-participant-code.js
+++ b/backend/src/database/migrations/20260602000000-add-participant-code.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * Migration: Add participant_code column to study_participants
+ *
+ * System-assigned per-study participant codes (PT-001, PT-002, etc.)
+ * replace the three-way mismatch between:
+ * - Typed name (freeform participant_name)
+ * - Derived ID (global auto-increment PT-${database_id})
+ * - LLM-guessed values (unstable across re-analysis)
+ *
+ * See ADR 0020: System-Assigned Per-Study Participant Codes
+ *
+ * PRE-REQUISITE: Tables must be empty before running this migration.
+ * Run TRUNCATE on study_variables, session_observers, study_participants
+ * BEFORE applying this migration.
+ */
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add participant_code column with temporary default
+    // (Tables should be empty, but Sequelize requires a default for NOT NULL on add)
+    await queryInterface.addColumn('study_participants', 'participant_code', {
+      type: Sequelize.STRING(10),
+      allowNull: false,
+      defaultValue: 'PT-000', // Temporary default for column add
+    });
+
+    // Remove the default — service layer assigns real values
+    await queryInterface.changeColumn('study_participants', 'participant_code', {
+      type: Sequelize.STRING(10),
+      allowNull: false,
+    });
+
+    // Per-study uniqueness constraint
+    await queryInterface.addConstraint('study_participants', {
+      fields: ['study_id', 'participant_code'],
+      type: 'unique',
+      name: 'study_participants_study_id_participant_code_key',
+    });
+  },
+
+  async down(queryInterface) {
+    // Remove constraint first
+    await queryInterface.removeConstraint(
+      'study_participants',
+      'study_participants_study_id_participant_code_key'
+    );
+
+    // Remove column
+    await queryInterface.removeColumn('study_participants', 'participant_code');
+  },
+};

--- a/backend/src/database/models/study_participant.ts
+++ b/backend/src/database/models/study_participant.ts
@@ -26,6 +26,7 @@ class StudyParticipant extends Model<
   // — Attributes —
   declare id: CreationOptional<number>;
   declare study_id: ForeignKey<number>;
+  declare participant_code: string;
   declare participant_name: string;
   declare recruitment_source: string | null;
   declare scheduled_date: string | null;
@@ -85,6 +86,10 @@ export default (sequelize: Sequelize) => {
           model: 'research_studies',
           key: 'id',
         },
+      },
+      participant_code: {
+        type: DataTypes.STRING(10),
+        allowNull: false,
       },
       participant_name: {
         type: DataTypes.STRING,

--- a/backend/src/helpers/observerYamlProcessor.ts
+++ b/backend/src/helpers/observerYamlProcessor.ts
@@ -161,11 +161,7 @@ export function generateSessionObservers(
         request.dataValues?.participant) as Participant | undefined;
       const participant =
         assocParticipant ||
-        participants.find((p) => {
-          const pId = `PT${String(p.id).padStart(3, '0')}`;
-          const normalized = sessionId.replace(/-/g, '').toUpperCase();
-          return pId === normalized;
-        });
+        participants.find((p) => p.participant_code === sessionId);
       if (participant) {
         const pData = (participant.dataValues || participant) as Record<string, unknown>;
         sessionMap[sessionId].date_time =

--- a/backend/src/helpers/slack/commands/addObserverHandler.ts
+++ b/backend/src/helpers/slack/commands/addObserverHandler.ts
@@ -390,7 +390,7 @@ async function handleSelfJoinSubmission({ ack, body, client, view }: SlackViewMi
         const participants = await studyParticipantService.getParticipantsByStudy(studyId);
 
         for (const sessionId of joinedSessions) {
-          const participant = participants.find((p: any) => `PT-${String(p.id).padStart(3, '0')}` === sessionId);
+          const participant = participants.find((p: any) => p.participant_code === sessionId);
           const dateStr = participant?.scheduled_date || 'TBD';
 
           const roleLabel = ROLE_DISPLAY[selectedRole] || selectedRole;

--- a/backend/src/helpers/slack/commands/analyzeNotesHandler.ts
+++ b/backend/src/helpers/slack/commands/analyzeNotesHandler.ts
@@ -267,8 +267,19 @@ const handleAnalyzeNotesSubmission = async ({ ack, body, view, client }: SlackVi
     // Update active study for cross-command pre-fill
     await setActiveStudy(body.user.id, parseInt(studyId, 10));
 
+    // sessionId from dropdown IS the participant database ID (see mapParticipantsToSessions)
+    // Fetch participant to get system-assigned participant_code for cascade isolation
+    let participantCode = 'PT-UNKNOWN';
     if (sessionId && sessionId !== "no_sessions") {
-      console.log("Selected session ID:", sessionId);
+      console.log("Selected session ID (participant DB ID):", sessionId);
+      const participantDbId = parseInt(sessionId, 10);
+      if (!isNaN(participantDbId)) {
+        const participant = await studyParticipantService.getParticipantById(participantDbId);
+        if (participant?.participant_code) {
+          participantCode = participant.participant_code;
+          console.log("Resolved participant_code:", participantCode);
+        }
+      }
     }
 
     const studyName: string = values.study_select_block?.study_select_test?.selected_option?.text?.text || "Unknown Study";
@@ -339,12 +350,9 @@ const handleAnalyzeNotesSubmission = async ({ ack, body, view, client }: SlackVi
 
     const noteTakers: string[] = notesWithContent.map((note: NoteDetail) => note.created_by).filter(Boolean);
 
-    const participantIds: string[] = notesWithContent.map((note: NoteDetail) => {
-      const participantName = note.participant_name || note.dataValues?.participant_name || (note.get ? note.get('participant_name') : undefined);
-      return (participantName as string) || 'unknown';
-    });
-
-    const uniqueParticipantIds = [...new Set(participantIds)];
+    // NOTE: participant_id is now resolved from sessionId (participant DB ID) → participant_code
+    // NOT extracted from note.participant_name (which is freeform and non-unique)
+    // See ADR 0020: System-Assigned Per-Study Participant Codes
 
     const formatNoteContent = (note: NoteDetail): string => {
       const filename = note.filename || 'Unknown File';
@@ -375,7 +383,7 @@ const handleAnalyzeNotesSubmission = async ({ ack, body, view, client }: SlackVi
       coded_transcript_content: coded_transcript_content,
       notes_content: notes_content,
       note_takers: noteTakers.join(', '),
-      participant_id: uniqueParticipantIds[0] || 'Unknown Participant ID',
+      participant_id: participantCode,
       researcher_contact: study?.researcher_name || study?.researcher_email || '',
       analyzer: (body.user as Record<string, string>).username || body.user.name || body.user.id
     };

--- a/backend/src/helpers/slack/commands/fieldworkHandler.ts
+++ b/backend/src/helpers/slack/commands/fieldworkHandler.ts
@@ -397,11 +397,11 @@ async function handleFieldworkUploadNotes({ ack, body, client }: SlackActionMidd
 
       mode = 'researcher';
       // @ts-expect-error — pre-existing type mismatch from require() → import migration
-      sessions = participants.map((p: any, idx: number) => ({
+      sessions = participants.map((p: any) => ({
         id: `p_${p.id}`,
         study: p.study || { id: studyId, name: studyName },
         participant: p,
-        session_id: `PT-${String(idx + 1).padStart(3, '0')}`,
+        session_id: p.participant_code,
       }));
     }
 

--- a/backend/src/helpers/slack/commands/sessionNotesHandler.ts
+++ b/backend/src/helpers/slack/commands/sessionNotesHandler.ts
@@ -310,7 +310,7 @@ const handleSessionNotesSubmission = async ({ ack, body, view, client }: SlackVi
       if (participant) {
         selectedSession = {
           id: participantId,
-          session_id: `PT-${String(participantId).padStart(3, '0')}`,
+          session_id: participant.participant_code,
           study: participant.study || { name: 'Unknown Study' },
           // @ts-expect-error — pre-existing type mismatch from require() → import migration
           participant,
@@ -338,7 +338,7 @@ const handleSessionNotesSubmission = async ({ ack, body, view, client }: SlackVi
       researcher: selectedSession.study?.researcher_name || 'Unknown Researcher',
       slack_user_id: body.user.id || 'Unknown',
       study_name: selectedSession.study?.name || 'Unknown Study',
-      participant_id: selectedSession.participant?.participant_name || 'Unknown Participant ID',
+      participant_id: selectedSession.session_id || 'PT-UNKNOWN',
     };
 
     let renderedYaml: { result: GitHubResult } | undefined;

--- a/backend/src/helpers/slack/ui/addParticipantModal.ts
+++ b/backend/src/helpers/slack/ui/addParticipantModal.ts
@@ -47,9 +47,9 @@ const addParticipantModal = {
         type: "plain_text_input",
         action_id: "participant_name",
         max_length: 100,
-        placeholder: { type: "plain_text", text: "e.g., PT004 or Participant A" },
+        placeholder: { type: "plain_text", text: "e.g., Veteran 5, Alice, or P-04" },
       },
-      hint: { type: "plain_text", text: "Use alias (PT001, PT002) to protect participant privacy." },
+      hint: { type: "plain_text", text: "Human-readable name or alias (e.g., 'Veteran 5', 'Alice'). A code (PT-001, etc.) is assigned automatically." },
     },
     // Recruitment method
     {

--- a/backend/src/services/session_observer.service.ts
+++ b/backend/src/services/session_observer.service.ts
@@ -589,14 +589,14 @@ const buildSessionsWithCounts = async (studyId: number): Promise<SessionWithCoun
   const sessions: SessionWithCount[] = [];
 
   for (const p of participants) {
-    const ptId = `PT-${String(p.id).padStart(3, '0')}`;
+    const ptCode = p.participant_code;
     const dateStr = p.scheduled_date || 'TBD';
-    const count = await service.countConfirmedObserversForSession(ptId);
+    const count = await service.countConfirmedObserversForSession(ptCode);
     sessions.push({
-      id: `${ptId}|${p.id}`,
-      sessionId: ptId,
+      id: `${ptCode}|${p.id}`,
+      sessionId: ptCode,
       participantId: p.id,
-      label: `${ptId} — ${dateStr}`,
+      label: `${ptCode} — ${dateStr}`,
       count,
     });
   }

--- a/backend/src/services/study_participant.service.ts
+++ b/backend/src/services/study_participant.service.ts
@@ -4,8 +4,10 @@ import type { StudyParticipant } from '../database/models/study_participant';
 import type { ResearchStudy } from '../database/models/research_study';
 import type { StudyParticipantCreationAttributes } from '../types/models';
 import type { ParticipantStatus } from '../constants/participantStatus';
+import type { Transaction } from 'sequelize';
 
 import sequelize from '../database';
+import { QueryTypes } from 'sequelize';
 import { processParticipantYamlTemplate } from '../helpers/participantYamlProcessor';
 import { PARTICIPANT_STATUS, ACTIVE_STATUSES } from '../constants/participantStatus';
 
@@ -46,18 +48,60 @@ interface AggregateWithCount extends StudyParticipant {
 
 class StudyParticipantService {
   /**
+   * Generate the next participant code for a study.
+   * Uses MAX+1 logic (delete-safe) with advisory lock for race condition prevention.
+   * Returns PT-001, PT-002, etc. — each study starts at 001.
+   */
+  async getNextParticipantCode(studyId: number, transaction?: Transaction): Promise<string> {
+    const seq = StudyParticipantModel.sequelize!;
+
+    // Advisory lock keyed on study_id prevents race conditions during concurrent creates
+    await seq.query('SELECT pg_advisory_xact_lock($1)', {
+      bind: [studyId],
+      transaction,
+    });
+
+    const [result] = (await seq.query(
+      `SELECT COALESCE(
+         MAX(CAST(SUBSTRING(participant_code FROM 4) AS INTEGER)),
+         0
+       ) + 1 AS next_code
+       FROM study_participants
+       WHERE study_id = $1`,
+      { bind: [studyId], transaction, type: QueryTypes.SELECT },
+    )) as [{ next_code: number }];
+
+    return `PT-${String(result.next_code).padStart(3, '0')}`;
+  }
+
+  /**
    * Create a new participant for a study and update the tracker YAML.
+   * Participant code is system-assigned (PT-001, PT-002 per study).
    */
   async createParticipant(
     participantData: StudyParticipantCreationAttributes & { study_name?: string },
     fileData?: FileData | null,
   ): Promise<StudyParticipant> {
+    const transaction = await StudyParticipantModel.sequelize!.transaction();
+
     try {
       console.log('Creating new participant');
-      const participant = await StudyParticipantModel.create(participantData);
+
+      // Generate system-assigned participant code within transaction
+      const participantCode = await this.getNextParticipantCode(
+        participantData.study_id,
+        transaction,
+      );
+
+      const participant = await StudyParticipantModel.create(
+        { ...participantData, participant_code: participantCode },
+        { transaction },
+      );
 
       await this.updateStudyParticipantCount(participantData.study_id);
+      await transaction.commit();
 
+      // YAML processing outside transaction (non-critical, should not roll back participant creation)
       if (fileData && fileData.file && fileData.study_path) {
         try {
           const allParticipants = await this.getParticipantsByStudy(participantData.study_id);
@@ -66,6 +110,7 @@ class StudyParticipantService {
           const inputData = {
             study_id: participantData.study_id,
             study_name: study ? study.name : (participantData.study_name || 'Study'),
+            participant_code: participantCode,
             participant_name: participantData.participant_name,
             contact_details: participantData.contact_details,
             recruitment_source: participantData.recruitment_source,
@@ -95,6 +140,7 @@ class StudyParticipantService {
 
       return participant;
     } catch (error) {
+      await transaction.rollback();
       console.error('Error creating/updating participant:', error);
       throw error;
     }

--- a/backend/src/types/models.ts
+++ b/backend/src/types/models.ts
@@ -145,6 +145,7 @@ export interface StudyStatusCreationAttributes
 export interface StudyParticipantAttributes {
   id: number;
   study_id: number;
+  participant_code: string;
   participant_name: string;
   contact_details: string | null;
   recruitment_source: string | null;
@@ -165,7 +166,7 @@ export interface StudyParticipantAttributes {
 
 export interface StudyParticipantCreationAttributes
   extends Omit<StudyParticipantAttributes,
-    'id' | 'created_at' | 'updated_at' | 'outreach_count' |
+    'id' | 'created_at' | 'updated_at' | 'outreach_count' | 'participant_code' |
     'contact_details' | 'recruitment_source' | 'scheduled_date' | 'scheduled_time' |
     'status_select' | 'notes_field' | 'demographics_info' | 'compensation_amount' |
     'outreach_sent_at' | 'outreach_method'

--- a/config/prompts/session_summary.yaml
+++ b/config/prompts/session_summary.yaml
@@ -4,11 +4,13 @@
 id: session_summary
 name: analyze_session_notes
 label: "Analyze Notes"
-version: "v7.0"
+version: "v7.1"
 
 description: |
   Analyze session transcript and observer notes to produce a structured
   session summary with pain points, insights, and barrier validation.
+  v7.1: Verbatim system-assigned participant codes (ADR 0020). LLM must
+  use {{participant_id}} exactly as provided — no guessing/inventing.
   v7.0: Interleaved Handlebars/AI — mechanical content rendered by
   template, LLM writes bounded analytical sections. Emits 5 pool
   variables (atomic nuggets, participant metadata, task completion
@@ -17,7 +19,7 @@ description: |
 
 author: Qori R&D
 created: 2025-10-25
-last_updated: 2026-05-21
+last_updated: 2026-06-02
 
 # ═══════════════════════════════════════════════════════════
 # CONFIGURATION
@@ -235,9 +237,12 @@ ai_generation_tasks:
       4. Every finding must trace back to specific source evidence
       5. When in doubt about Pain Points or Quotes, OMIT
       6. When in doubt about Opportunities or Insights, INCLUDE with clear evidence link
-      7. NEVER use participant real names — use participant ID (e.g., PT-001) or
-         "the participant" throughout. If the transcript contains real names,
-         replace them with the participant ID in your output.
+      7. PARTICIPANT IDENTIFIER RULES:
+         - The system has assigned this participant the code: {{participant_id}}
+         - Use this EXACT code ({{participant_id}}) throughout your output — do NOT invent or modify it
+         - Replace any real names in the transcript with {{participant_id}}
+         - "the participant" is also acceptable for variety
+         - Nugget IDs must follow format: nugget-{{participant_id}}-NNN (e.g., nugget-PT-003-001)
 
       QUOTE RULES:
       - ONLY use quotes that appear VERBATIM in the sources with quotation marks

--- a/docs/architecture-decisions/0020-system-assigned-participant-codes.md
+++ b/docs/architecture-decisions/0020-system-assigned-participant-codes.md
@@ -1,0 +1,137 @@
+# ADR 0020: System-Assigned Per-Study Participant Codes
+
+**Status:** Implemented
+**Date:** 2026-06-02
+**Relates to:** L005 (per-participant pool schema field)
+
+## Context
+
+The participant identifier (PT-XXX) had a three-way mismatch causing cascade isolation failures:
+
+1. **Typed name** — Researcher enters "Alice" or "PT-001" freeform in `participant_name` field
+2. **Derived ID** — System computed `PT-${database_id}` (global auto-increment, not per-study)
+3. **LLM-guessed** — Prompt said "replace names with PT-001" but LLM invented the number
+
+This caused:
+- Cascade isolation using LLM-guessed values which were unstable across re-analysis runs
+- Evidence chains breaking when re-analyzing the same session
+- Nuggets accumulating instead of replacing (isolation failure)
+
+L005 ensured the `participant` field EXISTS in pool schemas. But field presence doesn't help if the field's VALUE is LLM-guessed.
+
+## Decision
+
+Add `participant_code` column to `study_participants` table:
+- System-assigned at participant creation time
+- Per-study sequence: PT-001, PT-002, etc. (each study starts at 001)
+- MAX+1 logic (delete-safe, no collisions after deletes)
+- LLM receives code as input and uses it VERBATIM
+
+### Why service layer (not model hook)
+
+Model hooks (beforeCreate) don't have access to transactions, making atomic code generation impossible. The service layer can wrap the code generation and participant creation in a single transaction with advisory lock.
+
+### Why advisory lock
+
+`pg_advisory_xact_lock(study_id)` prevents race conditions during concurrent participant creates. Without it, two simultaneous creates could get the same code.
+
+### Why MAX+1 not COUNT+1
+
+COUNT+1 fails after deletions. If PT-001, PT-002, PT-003 exist and PT-002 is deleted, COUNT+1 would assign PT-003 to the next participant, causing a collision. MAX+1 assigns PT-004.
+
+## Implementation
+
+### Database
+
+New column on `study_participants`:
+- `participant_code VARCHAR(10) NOT NULL`
+- Unique constraint on `(study_id, participant_code)`
+
+### Service layer
+
+```typescript
+async getNextParticipantCode(studyId: number, transaction?: Transaction): Promise<string> {
+  await sequelize.query('SELECT pg_advisory_xact_lock($1)', { bind: [studyId], transaction });
+
+  const [result] = await sequelize.query(
+    `SELECT COALESCE(MAX(CAST(SUBSTRING(participant_code FROM 4) AS INTEGER)), 0) + 1 AS next_code
+     FROM study_participants WHERE study_id = $1`,
+    { bind: [studyId], transaction, type: QueryTypes.SELECT }
+  );
+
+  return `PT-${String(result.next_code).padStart(3, '0')}`;
+}
+```
+
+`createParticipant()` wraps this in a transaction and assigns the code automatically.
+
+### Consumption path
+
+The key fix is in `analyzeNotesHandler.ts`. The session dropdown value IS the participant database ID. Instead of extracting `participant_id` from `note.participant_name` (freeform, non-unique), fetch the participant by database ID and use `participant.participant_code`:
+
+```typescript
+const participantDbId = parseInt(sessionId, 10);
+const participant = await studyParticipantService.getParticipantById(participantDbId);
+const participantCode = participant?.participant_code || 'PT-UNKNOWN';
+```
+
+No name matching. Direct ID lookup. Unambiguous.
+
+### YAML template
+
+`session_summary.yaml` v7.1 now instructs the LLM to use `{{participant_id}}` verbatim:
+
+```yaml
+7. PARTICIPANT IDENTIFIER RULES:
+   - The system has assigned this participant the code: {{participant_id}}
+   - Use this EXACT code ({{participant_id}}) throughout — do NOT invent or modify it
+   - Replace any real names in the transcript with {{participant_id}}
+   - Nugget IDs must follow format: nugget-{{participant_id}}-NNN
+```
+
+## Connection to L005
+
+L005 fixed a **structural** problem: pool schemas with `append_or_replace_per_participant` strategy must include a `participant` or `participant_id` field, otherwise the merge isolation silently fails.
+
+ADR 0020 fixes a **data integrity** problem: even with the field present, if its value is LLM-guessed, it's unstable. The cascade isolation was working mechanically (L005) but the participant values being isolated were wrong (ADR 0020).
+
+Together they fix the cascade-isolation bug:
+- L005: The field must exist (schema structure)
+- ADR 0020: The field's value must be system-assigned (data integrity)
+
+## Verification
+
+After wipe + regenerate, verify THREE-IDENTIFIER AGREEMENT for a real participant:
+
+```
+study_participants.participant_code = "PT-001"
+session_observers.session_id = "PT-001"
+study_variables.value->participant = "PT-001" (nugget.participant)
+```
+
+All three MUST be the same value. Re-analysis must replace nuggets cleanly (not accumulate). Readout citations must trace back to the actual participant.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `migrations/20260602000000-add-participant-code.js` | Add column + constraint |
+| `database/models/study_participant.ts` | Declare attribute |
+| `types/models.ts` | Add to interface |
+| `services/study_participant.service.ts` | `getNextParticipantCode()` + transaction |
+| `commands/sessionNotesHandler.ts` | Read `participant_code` |
+| `commands/fieldworkHandler.ts` | Read `participant_code` |
+| `services/session_observer.service.ts` | Read `participant_code` |
+| `commands/addObserverHandler.ts` | Match by `participant_code` |
+| `helpers/observerYamlProcessor.ts` | Match by `participant_code` |
+| `commands/analyzeNotesHandler.ts` | Fetch participant by ID, use `participant_code` |
+| `config/prompts/session_summary.yaml` | Verbatim code instruction (v7.1) |
+| `slack/ui/addParticipantModal.ts` | Updated hint text |
+
+## Consequences
+
+- Participant codes are stable across re-analysis runs
+- Cascade isolation works correctly (nuggets replace instead of accumulate)
+- Evidence chains are traceable from nuggets to actual participants
+- Two "Alice" participants in the same study get unique codes (PT-001, PT-002)
+- Modal UX no longer suggests researchers should type PT codes manually

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -92,6 +92,7 @@ Start with `0001` and read forward. The history is itself useful — it shows ho
 - [0017 — Template ID convention](./0017-template-id-convention.md) — YAML `id` must match consumer-side `consumes.source` exactly; no suffixes
 - [0018 — Cascade-aware synthesis modal](./0018-cascade-aware-synthesis-modal.md) — Synthesis reads variable store; file picker removed; structured nuggets as real input
 - [0019 — Ack-first await-extraction handler pattern](./0019-ack-first-await-extraction-handler-pattern.md) — Handlers must await extractionPromise before returning success; eliminates read-before-write races
+- [0020 — System-assigned per-study participant codes](./0020-system-assigned-participant-codes.md) — PT-XXX codes are system-assigned at creation; LLM uses verbatim (complements L005)
 
 ### Lessons (informal ADRs from failure modes)
 


### PR DESCRIPTION
## Summary

Fixes three-way participant identifier mismatch that caused cascade isolation failures:

- **Typed name** — Researcher enters freeform text in `participant_name`
- **Derived ID** — System computed `PT-${database_id}` (global, not per-study)
- **LLM-guessed** — Prompt said "use PT-001" but LLM invented the number

**Result:** Nuggets accumulated instead of replacing. Evidence chains broke.

## Changes

- Add `participant_code` column with per-study sequential codes (PT-001, PT-002, etc.)
- Service layer `getNextParticipantCode()` with advisory lock for concurrency safety
- All handlers now read `participant_code` from DB, not derive it
- `analyzeNotesHandler` carries code through by ID lookup (not name matching)
- `session_summary.yaml` v7.1: LLM uses `{{participant_id}}` verbatim
- Modal hints updated to clarify codes are auto-assigned

## Verification

After merge + Railway deploy:
1. Wipe test data: `TRUNCATE study_variables, session_observers, study_participants CASCADE` ✅ Done
2. Migration: `participant_code` column + unique constraint ✅ Done (manual SQL applied)
3. Create participant via modal → confirm PT-001 auto-assigned
4. Run `/qori-analyze` → verify THREE-IDENTIFIER AGREEMENT:
   - `study_participants.participant_code = "PT-001"`
   - `session_observers.session_id = "PT-001"`
   - `study_variables.value->participant = "PT-001"`
5. Re-analyze same session → nuggets replace (not accumulate)
6. Add second participant → PT-002, isolated from PT-001

## Test plan

- [x] Unit tests pass (123)
- [x] Integration tests pass (155)
- [ ] E2E verification after Railway deploy (steps above)

🤖 Generated with [Claude Code](https://claude.ai/code)