### PR TITLE
fix: show participant_code (PT-001) in tracker and success DM

### DIFF
--- a/backend/src/helpers/participantYamlProcessor.ts
+++ b/backend/src/helpers/participantYamlProcessor.ts
@@ -18,6 +18,7 @@ type DemographicsInfo = Record<string, string> | string | null | undefined;
 /** Shape of a participant record as stored in the database / passed into this module. */
 export interface ParticipantRecord {
   id: number;
+  participant_code: string;
   participant_name: string;
   contact_details: string | null;
   recruitment_source: string | null;
@@ -612,7 +613,7 @@ export async function processParticipantYamlTemplate(
       completed_sessions_count: completedSessionsCount,
       total_observer_assignments: 0,
       participants: allParticipants.map(p => ({
-        id: p.participant_name || `P${p.id}`,
+        id: p.participant_code || `PT-${String(p.id).padStart(3, '0')}`,
         participant_name: p.participant_name,
         contact_details: p.contact_details,
         recruitment_source: getRecruitmentSourceDisplay(p.recruitment_source || 'unknown'),
@@ -684,7 +685,7 @@ export async function processParticipantYamlTemplate(
       })(),
       observer_action_items: [],
       accommodations: allParticipants.filter(p => p.notes_field && p.notes_field.trim() !== '').map(p => ({
-        participant_id: p.participant_name || `P${p.id}`,
+        participant_id: p.participant_code || `PT-${String(p.id).padStart(3, '0')}`,
         accommodation_details: p.notes_field,
       })),
       demographics_summary: generateDemographicsSummary(allParticipants),

--- a/backend/src/helpers/slack/commands/participantOutreachHandler.ts
+++ b/backend/src/helpers/slack/commands/participantOutreachHandler.ts
@@ -1138,15 +1138,16 @@ async function handleAddParticipantSubmit({ ack, body, view, client }: SlackView
     }
 
     // Send message to the researcher's DM with the GitHub link to the participant tracker
+    const assignedCode = savedParticipant.participant_code;
     await client.chat.postMessage({
       channel: userId, // Use original Slack user ID for DM channel
-      text: `:busts_in_silhouette: *New Participant Added*\n\n*Participant:* ${participant_name}\n*Study:* ${study_name}\n*Status:* ${status_select}\n*Recruitment Source:* ${recruitment_source}`,
+      text: `:busts_in_silhouette: *New Participant Added*\n\n*Code:* ${assignedCode}\n*Name:* ${participant_name}\n*Study:* ${study_name}\n*Status:* ${status_select}`,
       blocks: [
         {
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `:busts_in_silhouette: *New Participant Added*\n\n*Participant:* ${participant_name}\n*Study:* ${study_name}\n*Status:* ${status_select}\n*Recruitment Source:* ${recruitment_source}`
+            text: `:busts_in_silhouette: *New Participant Added*\n\n*Code:* \`${assignedCode}\`\n*Name:* ${participant_name}\n*Study:* ${study_name}\n*Status:* ${status_select}\n*Recruitment Source:* ${recruitment_source}`
           }
         },
         {


### PR DESCRIPTION
## Summary

The participant tracker was showing `participant_name` (user-typed) in the ID column instead of the system-assigned `participant_code`. This was confusing because:
- Users were told "A code (PT-001, etc.) is assigned automatically"
- But they never saw that code anywhere!

### Changes

1. **Tracker ID column** now shows `PT-001`, `PT-002` (participant_code)
2. **Tracker Alias column** shows the human-readable name (participant_name)
3. **Success DM** explicitly shows the assigned code:
   ```
   New Participant Added
   Code: PT-001
   Name: Bob Test
   ...
   ```

This completes the ADR 0020 user experience by making the system-assigned codes visible to researchers.

## Test plan
- [ ] Add a new participant via `/qori-fieldwork` → Add Participant
- [ ] Verify success DM shows assigned code (e.g., `PT-007`)
- [ ] Check participant tracker shows codes in ID column, names in Alias column

🤖 Generated with [Claude Code](https://claude.com/claude-code)