### PR TITLE
feat: optional alias field with code preview in modal

### DIFF
--- a/backend/src/__tests__/type-verification.test.ts
+++ b/backend/src/__tests__/type-verification.test.ts
@@ -18,7 +18,7 @@ import type { ResearchStudy } from '../database/models/research_study';
 function verifyParticipantTypes(participant: StudyParticipant) {
   // These should compile with their correct types:
   const id: number = participant.id;
-  const name: string = participant.participant_name;
+  const name: string | null = participant.participant_name;
   const status: string | null = participant.status_select;
   const compensation: number | null = participant.compensation_amount;
   const outreachMethod: 'email' | 'slack' | 'phone' | 'other' | null = participant.outreach_method;

--- a/backend/src/database/migrations/20260602100000-make-participant-name-optional.js
+++ b/backend/src/database/migrations/20260602100000-make-participant-name-optional.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+ * Migration: Make participant_name (alias) optional
+ *
+ * The participant_code is now the identity. The participant_name field
+ * becomes an optional alias / memory aid for researchers.
+ *
+ * See ADR 0020: System-Assigned Per-Study Participant Codes
+ */
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.changeColumn('study_participants', 'participant_name', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Backfill any NULLs with the participant_code before making NOT NULL
+    await queryInterface.sequelize.query(`
+      UPDATE study_participants
+      SET participant_name = participant_code
+      WHERE participant_name IS NULL
+    `);
+
+    await queryInterface.changeColumn('study_participants', 'participant_name', {
+      type: Sequelize.STRING,
+      allowNull: false,
+    });
+  },
+};

--- a/backend/src/database/models/study_participant.ts
+++ b/backend/src/database/models/study_participant.ts
@@ -27,7 +27,7 @@ class StudyParticipant extends Model<
   declare id: CreationOptional<number>;
   declare study_id: ForeignKey<number>;
   declare participant_code: string;
-  declare participant_name: string;
+  declare participant_name: string | null;
   declare recruitment_source: string | null;
   declare scheduled_date: string | null;
   declare scheduled_time: string | null;
@@ -93,7 +93,7 @@ export default (sequelize: Sequelize) => {
       },
       participant_name: {
         type: DataTypes.STRING,
-        allowNull: false,
+        allowNull: true,
       },
       recruitment_source: {
         type: DataTypes.STRING,

--- a/backend/src/helpers/slack/commands/participantHandler.ts
+++ b/backend/src/helpers/slack/commands/participantHandler.ts
@@ -53,6 +53,23 @@ async function participantHandler({ ack, body, client, command }: SlackCommandMi
 
       // Store first study ID in metadata for default
       const studyId = studies[0].id;
+
+      // Preview the next participant code for the initially selected study
+      const nextCode = await studyParticipantService.previewNextParticipantCode(studyId);
+      const codePreviewBlockIndex = blocks.findIndex((block: any) => block.block_id === 'code_preview_block');
+      if (codePreviewBlockIndex !== -1) {
+        blocks[codePreviewBlockIndex] = {
+          type: "context",
+          block_id: "code_preview_block",
+          elements: [
+            {
+              type: "mrkdwn",
+              text: `🏷️ *Will be assigned:* \`${nextCode}\``
+            }
+          ]
+        };
+      }
+
       await client.views.open({
         trigger_id: body.trigger_id,
         view: {
@@ -191,10 +208,16 @@ async function handleLoadParticipantsButton({ ack, body, client }: SlackActionMi
     }
 
     // Transform participants to the format expected by the modal
-    const participantOptions = participants.map((participant: any) => ({
-      text: { type: 'plain_text', text: participant.participant_name },
-      value: participant.id.toString()
-    }));
+    // Display format: PT-001 (alias) or just PT-001 if no alias
+    const participantOptions = participants.map((participant: any) => {
+      const code = participant.participant_code || `PT-${String(participant.id).padStart(3, '0')}`;
+      const alias = participant.participant_name;
+      const displayText = alias ? `${code} (${alias})` : code;
+      return {
+        text: { type: 'plain_text', text: displayText },
+        value: participant.id.toString()
+      };
+    });
 
     // Get the studies list to pass back to the modal
     const studies = await getStudiesByUser(body.user.id);
@@ -388,10 +411,62 @@ async function handleUpdateParticipantSubmission({ ack, body, view, client }: Sl
   }
 }
 
+/**
+ * Handle study selection change in Add Participant modal.
+ * Updates the code preview block to show the next code for the selected study.
+ */
+async function handleAddParticipantStudySelect({ ack, body, client }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs): Promise<void> {
+  await ack();
+
+  try {
+    const view = body.view;
+    if (!view) return;
+
+    // Get the selected study ID from the action
+    const action = body.actions[0];
+    if (action.type !== 'static_select' || !action.selected_option) return;
+
+    const studyId = parseInt(action.selected_option.value, 10);
+    if (isNaN(studyId)) return;
+
+    // Preview the next participant code
+    const nextCode = await studyParticipantService.previewNextParticipantCode(studyId);
+
+    // Update the code preview block
+    const blocks = JSON.parse(JSON.stringify(view.blocks));
+    const codePreviewBlockIndex = blocks.findIndex((block: any) => block.block_id === 'code_preview_block');
+    if (codePreviewBlockIndex !== -1) {
+      blocks[codePreviewBlockIndex] = {
+        type: "context",
+        block_id: "code_preview_block",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `🏷️ *Will be assigned:* \`${nextCode}\``
+          }
+        ]
+      };
+    }
+
+    // Update the modal with the new code preview
+    await client.views.update({
+      view_id: view.id,
+      view: {
+        ...addParticipantModal,
+        blocks,
+        private_metadata: view.private_metadata || "{}",
+      } as View,
+    });
+  } catch (error) {
+    console.error("Error updating code preview:", error);
+  }
+}
+
 export {
   participantHandler,
   participantHandler as handleAddParticipantSubmit,
   updateParticipantHandler,
   handleLoadParticipantsButton,
   handleUpdateParticipantSubmission,
+  handleAddParticipantStudySelect,
 };

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -50,7 +50,7 @@ import { discoverHandler, openDiscoverTypeModal, handleDiscoverSubmission } from
 
 // Fieldwork
 import { fieldworkHandler, handleFieldworkStudyPickerSubmit, handleFieldworkAddParticipant, handleFieldworkUpdateStatus, handleFieldworkObserve, handleFieldworkOutreach, handleFieldworkUploadNotes } from './commands/fieldworkHandler';
-import { handleUpdateParticipantSubmission, handleLoadParticipantsButton } from './commands/participantHandler';
+import { handleUpdateParticipantSubmission, handleLoadParticipantsButton, handleAddParticipantStudySelect } from './commands/participantHandler';
 import { handleParticipantOutreachSubmit, handleInitialRecruitmentSubmit, handleReschedulingRequestSubmit, handleSessionConfirmationSubmit, handleThankYouSubmit, handleFollowUpSubmit, handleSessionReminderSubmit, handleAddParticipantSubmit, handleObserverModalButton } from './commands/participantOutreachHandler';
 import { handleAddObserverSubmission, handleSelfJoinObserver, handleSelfJoinSubmission } from './commands/addObserverHandler';
 
@@ -406,6 +406,7 @@ slackApp.action('fieldwork_observe', handleFieldworkObserve);
 slackApp.action('fieldwork_outreach', handleFieldworkOutreach);
 slackApp.action('fieldwork_upload_notes', handleFieldworkUploadNotes);
 slackApp.action('load_participants_button', handleLoadParticipantsButton);
+slackApp.action('add_participant_study_select', handleAddParticipantStudySelect);
 slackApp.view('add-participant-modal', handleAddParticipantSubmit);
 slackApp.view('update-participant-status', handleUpdateParticipantSubmission);
 

--- a/backend/src/helpers/slack/ui/addParticipantModal.ts
+++ b/backend/src/helpers/slack/ui/addParticipantModal.ts
@@ -28,28 +28,42 @@ const addParticipantModal = {
       label: { type: "plain_text", text: "Research study *" },
       element: {
         type: "static_select",
-        action_id: "study_select",
+        action_id: "add_participant_study_select",
         placeholder: { type: "plain_text", text: "Select a study..." },
         options: [ { text: { type: "plain_text", text: "Loading studies..." }, value: "loading" } ],
       },
+      dispatch_action: true,
+    },
+
+    // Code assignment preview (populated dynamically after study selection)
+    {
+      type: "context",
+      block_id: "code_preview_block",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "_Select a study to see the code that will be assigned_"
+        }
+      ]
     },
 
     { type: "divider" },
 
     // Participant Information
     { type: "section", text: { type: "mrkdwn", text: "📝 *Participant Information*" } },
-    // Participant name
+    // Participant alias (optional memory aid)
     {
       type: "input",
       block_id: "participant_name_block",
-      label: { type: "plain_text", text: "Participant name or alias *" },
+      label: { type: "plain_text", text: "Private alias (optional)" },
       element: {
         type: "plain_text_input",
         action_id: "participant_name",
         max_length: 100,
-        placeholder: { type: "plain_text", text: "e.g., Veteran 5, Alice, or P-04" },
+        placeholder: { type: "plain_text", text: "e.g., 'screen-reader user', 'Veteran A'" },
       },
-      hint: { type: "plain_text", text: "Human-readable name or alias (e.g., 'Veteran 5', 'Alice'). A code (PT-001, etc.) is assigned automatically." },
+      hint: { type: "plain_text", text: "Optional private label to help YOU remember this participant. Do NOT enter real names — use the system code for identity." },
+      optional: true,
     },
     // Recruitment method
     {

--- a/backend/src/helpers/slack/ui/sessionNotesModal.ts
+++ b/backend/src/helpers/slack/ui/sessionNotesModal.ts
@@ -86,13 +86,18 @@ export const buildSessionNotesView = (state: SessionNotesState = {}) => {
           action_id: 'session_select_change',
           placeholder: { type: 'plain_text', text: 'Choose the session you observed…' },
           options: (state.sessions && state.sessions.length > 0)
-            ? state.sessions.map(session => ({
-              text: {
-                type: 'plain_text',
-                text: `${session.study?.name || 'Unknown Study'} - ${session.participant?.participant_name || 'Unknown Participant'} (${session.session_id || 'Unknown Session'})`
-              },
-              value: session.id.toString()
-            }))
+            ? state.sessions.map(session => {
+              const code = session.session_id || 'Unknown';
+              const alias = session.participant?.participant_name;
+              const displayName = alias ? `${code} (${alias})` : code;
+              return {
+                text: {
+                  type: 'plain_text',
+                  text: `${session.study?.name || 'Unknown Study'} - ${displayName}`
+                },
+                value: session.id.toString()
+              };
+            })
             : [{
               text: {
                 type: 'plain_text',
@@ -101,13 +106,18 @@ export const buildSessionNotesView = (state: SessionNotesState = {}) => {
               value: 'no_sessions'
             }],
           initial_option: state.session
-            ? {
-              text: {
-                type: 'plain_text',
-                text: state.session.displayName || `${state.session.study?.name || 'Unknown Study'} - ${state.session.participant?.participant_name || 'Unknown Participant'} (${state.session.session_id || 'Unknown Session'})`
-              },
-              value: state.session.id.toString()
-            }
+            ? (() => {
+              const code = state.session.session_id || 'Unknown';
+              const alias = state.session.participant?.participant_name;
+              const displayName = alias ? `${code} (${alias})` : code;
+              return {
+                text: {
+                  type: 'plain_text',
+                  text: state.session.displayName || `${state.session.study?.name || 'Unknown Study'} - ${displayName}`
+                },
+                value: state.session.id.toString()
+              };
+            })()
             : undefined
         }
       },

--- a/backend/src/services/session_observer.service.ts
+++ b/backend/src/services/session_observer.service.ts
@@ -281,7 +281,7 @@ class SessionObserverService {
           {
             model: StudyParticipantModel,
             as: 'participant',
-            attributes: ['id', 'participant_name', 'scheduled_date', 'scheduled_time', 'status_select']
+            attributes: ['id', 'participant_code', 'participant_name', 'scheduled_date', 'scheduled_time', 'status_select']
           }
         ],
         order: [['created_at', 'DESC']]
@@ -359,7 +359,7 @@ class SessionObserverService {
           {
             model: StudyParticipantModel,
             as: 'participant',
-            attributes: ['id', 'participant_name', 'scheduled_date', 'scheduled_time']
+            attributes: ['id', 'participant_code', 'participant_name', 'scheduled_date', 'scheduled_time']
           }
         ],
         order: [['created_at', 'DESC']]
@@ -387,7 +387,7 @@ class SessionObserverService {
           {
             model: StudyParticipantModel,
             as: 'participant',
-            attributes: ['id', 'participant_name', 'scheduled_date', 'scheduled_time']
+            attributes: ['id', 'participant_code', 'participant_name', 'scheduled_date', 'scheduled_time']
           }
         ],
         order: [['created_at', 'DESC']]
@@ -418,7 +418,7 @@ class SessionObserverService {
           {
             model: StudyParticipantModel,
             as: 'participant',
-            attributes: ['id', 'participant_name', 'scheduled_date', 'scheduled_time']
+            attributes: ['id', 'participant_code', 'participant_name', 'scheduled_date', 'scheduled_time']
           }
         ],
         order: [['created_at', 'DESC']]
@@ -518,7 +518,7 @@ class SessionObserverService {
         },
         include: [
           { model: ResearchStudyModel, as: 'study', attributes: ['id', 'name', 'path', 'researcher_name'] },
-          { model: StudyParticipantModel, as: 'participant', attributes: ['id', 'participant_name', 'scheduled_date', 'scheduled_time'] },
+          { model: StudyParticipantModel, as: 'participant', attributes: ['id', 'participant_code', 'participant_name', 'scheduled_date', 'scheduled_time'] },
         ],
         order: [['created_at', 'DESC']],
       });

--- a/backend/src/services/study_participant.service.ts
+++ b/backend/src/services/study_participant.service.ts
@@ -48,6 +48,24 @@ interface AggregateWithCount extends StudyParticipant {
 
 class StudyParticipantService {
   /**
+   * Preview the next participant code for a study (no lock, read-only).
+   * Use this for modal display; actual assignment uses getNextParticipantCode with transaction.
+   */
+  async previewNextParticipantCode(studyId: number): Promise<string> {
+    const [result] = (await StudyParticipantModel.sequelize!.query(
+      `SELECT COALESCE(
+         MAX(CAST(SUBSTRING(participant_code FROM 4) AS INTEGER)),
+         0
+       ) + 1 AS next_code
+       FROM study_participants
+       WHERE study_id = $1`,
+      { bind: [studyId], type: QueryTypes.SELECT },
+    )) as [{ next_code: number }];
+
+    return `PT-${String(result.next_code).padStart(3, '0')}`;
+  }
+
+  /**
    * Generate the next participant code for a study.
    * Uses MAX+1 logic (delete-safe) with advisory lock for race condition prevention.
    * Returns PT-001, PT-002, etc. — each study starts at 001.

--- a/backend/src/types/models.ts
+++ b/backend/src/types/models.ts
@@ -146,7 +146,7 @@ export interface StudyParticipantAttributes {
   id: number;
   study_id: number;
   participant_code: string;
-  participant_name: string;
+  participant_name: string | null;
   contact_details: string | null;
   recruitment_source: string | null;
   scheduled_date: string | null;

--- a/docs/workstreams/pii-handling-architecture.md
+++ b/docs/workstreams/pii-handling-architecture.md
@@ -1,0 +1,78 @@
+# Workstream: PII-Handling Architecture / Zero-PII Design
+
+**Status:** Not started — requires audit before design
+**Filed:** 2026-06-02
+**Relates to:** ADR 0020 (system-assigned participant codes)
+
+## Problem Statement
+
+The participant code fix (ADR 0020) addresses one PII entry path — the participant name field. But there's another path: **outreach messages**. If Qori stores real names/emails to send recruitment/scheduling messages, PII enters the system regardless of what's in the participant field.
+
+## Target Principle
+
+**Qori holds ZERO participant PII.** Real names and contact info live in the researcher's own email/recruiting tools. Qori holds only:
+- System-assigned code (PT-001)
+- Optional alias (non-PII memory aid like "screen-reader user")
+- Research data (findings, nuggets, analysis)
+
+## Required Audit (Before Design)
+
+### Questions to Answer
+
+1. **How does outreach get participant name/email today?**
+   - Does the outreach handler read from a contact_details field?
+   - Are emails/names stored in the database?
+   - Where do the outreach templates get personalization data?
+
+2. **Does Qori SEND messages or DRAFT them?**
+   - If Qori sends directly (via Slack DM, email API), it must have PII
+   - If Qori drafts for the researcher to copy/paste, PII stays external
+
+3. **What does the outreach flow actually do?**
+   - Trace through `participantOutreachHandler.ts` and related files
+   - Map data flow from modal input to message output
+   - Identify all PII touchpoints
+
+### Lapedra's Insight
+
+Messages could instruct the researcher to add the real name/email in THEIR email system. Qori's tracker adds a column linking the outgoing message to the participant CODE (not storing the PII). This keeps:
+- Real names → researcher's email client
+- Contact info → researcher's recruiting tool
+- Qori → codes + research data only
+
+## Design Considerations (After Audit)
+
+1. **Outreach message drafts** — Generate template text with `{{participant_code}}` placeholder; researcher fills in real name/email in their own system
+
+2. **Tracker linkage** — Record that "outreach sent to PT-003 on 2026-06-02" without storing what name/email was used
+
+3. **Modal changes** — Remove any PII input fields from outreach modals; reference participants by code only
+
+4. **Data model changes** — If `contact_details` column exists, decide whether to deprecate it
+
+5. **Migration path** — Handle existing studies that may have stored PII
+
+## Federal Defensibility Angle
+
+This is a federal-defensibility piece: "We store no participant PII." For VA research context, this matters for:
+- Privacy Act compliance
+- HIPAA considerations (if health data involved)
+- IRB approval language
+- Data breach risk reduction
+
+Worth doing deliberately as a standalone design, not bolted onto the current participant code fix.
+
+## Files to Audit
+
+- `backend/src/helpers/slack/commands/participantOutreachHandler.ts`
+- `backend/src/helpers/slack/ui/outreach/*.ts`
+- `backend/src/database/models/study_participant.ts` (contact_details field?)
+- Outreach-related YAML templates in `config/prompts/`
+
+## Next Steps
+
+1. Complete audit (answer the three questions above)
+2. Document current PII touchpoints
+3. Design zero-PII architecture
+4. Write ADR for the approach
+5. Implement changes


### PR DESCRIPTION
## Summary

ADR 0020 follow-up: reframe `participant_name` as an **optional alias** (private memory aid), not identity.

### Changes

**Modal UX:**
- Shows "🏷️ Will be assigned: `PT-005`" before submission (updates on study change)
- Alias field label: "Private alias (optional)"
- Hint: "Optional private label to help YOU remember this participant. Do NOT enter real names — use the system code for identity."

**Data model:**
- `participant_name` is now nullable (migration included)
- Session/participant dropdowns show: `PT-001 (alias)` or just `PT-001` when no alias

**Display format:**
- Code is primary identifier, always shown
- Alias is supplementary, shown in parentheses when present

### Separate Filing

Also filed `docs/workstreams/pii-handling-architecture.md`:
- Audit for outreach message PII paths (another entry point)
- Target principle: Qori holds ZERO participant PII
- Needs audit before design (not built now)

## Test plan

- [ ] Add participant without alias — should work, shows only PT-XXX
- [ ] Add participant with alias — shows `PT-XXX (alias)` in dropdowns
- [ ] Change study selection — code preview updates to show next code for that study
- [ ] Session dropdowns show code-first format

🤖 Generated with [Claude Code](https://claude.com/claude-code)