### PR TITLE
fix: ADR 0020 post-merge fixes — verified cascade isolation

### DIFF
--- a/backend/src/helpers/participantYamlProcessor.ts
+++ b/backend/src/helpers/participantYamlProcessor.ts
@@ -613,7 +613,7 @@ export async function processParticipantYamlTemplate(
       completed_sessions_count: completedSessionsCount,
       total_observer_assignments: 0,
       participants: allParticipants.map(p => ({
-        id: p.participant_code || `PT-${String(p.id).padStart(3, '0')}`,
+        id: p.participant_code ?? 'PT-???',
         participant_name: p.participant_name,
         contact_details: p.contact_details,
         recruitment_source: getRecruitmentSourceDisplay(p.recruitment_source || 'unknown'),
@@ -685,7 +685,7 @@ export async function processParticipantYamlTemplate(
       })(),
       observer_action_items: [],
       accommodations: allParticipants.filter(p => p.notes_field && p.notes_field.trim() !== '').map(p => ({
-        participant_id: p.participant_code || `PT-${String(p.id).padStart(3, '0')}`,
+        participant_id: p.participant_code ?? 'PT-???',
         accommodation_details: p.notes_field,
       })),
       demographics_summary: generateDemographicsSummary(allParticipants),

--- a/backend/src/helpers/slack/commands/fieldworkHandler.ts
+++ b/backend/src/helpers/slack/commands/fieldworkHandler.ts
@@ -210,13 +210,27 @@ async function handleFieldworkAddParticipant({ ack, body, client }: SlackActionM
       value: s.id.toString(),
     }));
 
-    let blocks = JSON.parse(JSON.stringify(addParticipantModal.blocks));
+    const blocks = JSON.parse(JSON.stringify(addParticipantModal.blocks));
     const studyBlockIdx = blocks.findIndex((b: any) => b.block_id === 'study_select_block');
     if (studyBlockIdx !== -1 && studyOptions.length > 0) {
       const initialOption = studyOptions.find((o: any) => o.value === studyId.toString()) || studyOptions[0];
       blocks[studyBlockIdx] = {
         ...blocks[studyBlockIdx],
         element: { ...blocks[studyBlockIdx].element, options: studyOptions, initial_option: initialOption },
+      };
+    }
+
+    // Update code preview since study is pre-selected (ADR 0020)
+    const codePreviewIdx = blocks.findIndex((b: any) => b.block_id === 'code_preview_block');
+    if (codePreviewIdx !== -1 && studyId) {
+      const nextCode = await studyParticipantService.previewNextParticipantCode(studyId);
+      blocks[codePreviewIdx] = {
+        type: "context",
+        block_id: "code_preview_block",
+        elements: [{
+          type: "mrkdwn",
+          text: `✨ Will be assigned: *${nextCode}*`
+        }]
       };
     }
 
@@ -228,9 +242,17 @@ async function handleFieldworkAddParticipant({ ack, body, client }: SlackActionM
         private_metadata: JSON.stringify({ ...dashboardMeta, studyId, studyName, rootViewId: body.view?.id }),
       } as View,
     });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('handleFieldworkAddParticipant error:', message);
+  } catch (error: unknown) {
+    const errData = (error as Record<string, unknown>)?.data;
+    const messages = (errData as Record<string, unknown>)?.response_metadata as Record<string, unknown>;
+    console.error('❌ handleFieldworkAddParticipant error:');
+    console.error('Error data:', JSON.stringify(errData, null, 2));
+    if (messages?.messages) {
+      console.error('Validation errors:', JSON.stringify(messages.messages, null, 2));
+    } else {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('Error message:', message);
+    }
   }
 }
 
@@ -414,13 +436,17 @@ async function handleFieldworkUploadNotes({ ack, body, client }: SlackActionMidd
     }));
 
     const firstSession = plainSessions[0];
+    // Build displayName matching sessionNotesModal format: "Study - PT-001 (alias)" or "Study - PT-001"
+    const code = firstSession.session_id || 'Unknown';
+    const alias = firstSession.participant?.participant_name;
+    const sessionDisplayPart = alias ? `${code} (${alias})` : code;
     const initialState = {
       tab: 'upload',
       mode,
       studyId,
       session: {
         id: firstSession.id,
-        displayName: `${firstSession.study?.name || 'Unknown Study'} - ${firstSession.participant?.participant_name || 'Unknown Participant'} (${firstSession.session_id || 'Unknown Session'})`,
+        displayName: `${firstSession.study?.name || 'Unknown Study'} - ${sessionDisplayPart}`,
         study: firstSession.study,
         participant: firstSession.participant,
         session_id: firstSession.session_id,
@@ -436,10 +462,15 @@ async function handleFieldworkUploadNotes({ ack, body, client }: SlackActionMidd
       trigger_id: body.trigger_id,
       view: buildSessionNotesView(initialState as any) as View,
     });
-  } catch (error) {
+  } catch (error: unknown) {
+    const errData = (error as Record<string, unknown>)?.data;
+    const messages = (errData as Record<string, unknown>)?.response_metadata as Record<string, unknown>;
+    console.error('❌ handleFieldworkUploadNotes error:');
+    console.error('Error data:', JSON.stringify(errData, null, 2));
+    if (messages?.messages) {
+      console.error('Validation errors:', JSON.stringify(messages.messages, null, 2));
+    }
     const message = error instanceof Error ? error.message : String(error);
-    const detail = (error as Record<string, unknown>)?.data ?? '';
-    console.error('handleFieldworkUploadNotes error:', message, detail);
     await client.chat.postEphemeral({
       channel: body.user.id,
       user: body.user.id,

--- a/backend/src/helpers/slack/commands/participantHandler.ts
+++ b/backend/src/helpers/slack/commands/participantHandler.ts
@@ -210,9 +210,12 @@ async function handleLoadParticipantsButton({ ack, body, client }: SlackActionMi
     // Transform participants to the format expected by the modal
     // Display format: PT-001 (alias) or just PT-001 if no alias
     const participantOptions = participants.map((participant: any) => {
-      const code = participant.participant_code || `PT-${String(participant.id).padStart(3, '0')}`;
+      const code = participant.participant_code;
+      if (!code) {
+        console.warn(`⚠️ Participant ${participant.id} missing participant_code — this should not happen after ADR 0020`);
+      }
       const alias = participant.participant_name;
-      const displayText = alias ? `${code} (${alias})` : code;
+      const displayText = alias ? `${code || 'PT-???'} (${alias})` : (code || 'PT-???');
       return {
         text: { type: 'plain_text', text: displayText },
         value: participant.id.toString()

--- a/backend/src/helpers/slack/commands/participantOutreachHandler.ts
+++ b/backend/src/helpers/slack/commands/participantOutreachHandler.ts
@@ -1008,8 +1008,8 @@ async function handleAddParticipantSubmit({ ack, body, view, client }: SlackView
     const meta = JSON.parse(body.view.private_metadata || '{}');
     const { channelId, userId } = meta;
 
-    // Extract study from dropdown selection
-    const selectedStudyOption = state.study_select_block?.study_select?.selected_option || null;
+    // Extract study from dropdown selection (action_id: add_participant_study_select)
+    const selectedStudyOption = state.study_select_block?.add_participant_study_select?.selected_option || null;
     const study_id = selectedStudyOption?.value || "";
     const study_name = selectedStudyOption?.text?.text || "";
     const participant_name = state.participant_name_block?.participant_name?.value || "";

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -308,16 +308,31 @@ slackApp.command('/qori-brief', async ({ ack, client, command }) => {
     console.warn('Could not fetch Slack profile for brief modal:', errMessage);
   }
 
-  const modal = await buildBriefEntryModal({
-    leadResearcher,
-    channelId: command.channel_id,
-    projectId: project.id,
-    projectName: project.name,
-    projectSlug: project.slug,
-    source: 'qori_brief_command',
-  });
-  // @ts-expect-error — modal blocks are Record<string,unknown>[] from JSON.parse; structurally valid at runtime
-  await client.views.open({ trigger_id: command.trigger_id, view: modal });
+  try {
+    const modal = await buildBriefEntryModal({
+      leadResearcher,
+      channelId: command.channel_id,
+      projectId: project.id,
+      projectName: project.name,
+      projectSlug: project.slug,
+      source: 'qori_brief_command',
+    });
+    // @ts-expect-error — modal blocks are Record<string,unknown>[] from JSON.parse; structurally valid at runtime
+    await client.views.open({ trigger_id: command.trigger_id, view: modal });
+  } catch (err: unknown) {
+    const errData = (err as Record<string, unknown>)?.data;
+    const messages = (errData as Record<string, unknown>)?.response_metadata as Record<string, unknown>;
+    console.error('❌ Error opening brief modal:');
+    console.error('Error data:', JSON.stringify(errData, null, 2));
+    if (messages?.messages) {
+      console.error('Validation errors:', JSON.stringify(messages.messages, null, 2));
+    }
+    await client.chat.postEphemeral({
+      channel: command.channel_id,
+      user: command.user_id,
+      text: `❌ Error opening research brief modal. Check server logs for details.`,
+    });
+  }
 });
 slackApp.command('/qori-plan', async ({ ack, client, command }) => {
   await ack();

--- a/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
+++ b/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
@@ -197,15 +197,26 @@ export async function buildBriefEntryModal(options: BuildBriefEntryModalOptions)
       };
     } else {
       // Build checkbox options from artifacts — AUTO-SELECT ALL
+      // Note: Slack limits: checkbox text = 150 chars, value = 75 chars
       const checkboxOptions = artifacts.map(a => {
         const categories = formatVariableCategories(Object.keys(a.variables));
-        const categoryLabel = categories || `${a.variableCount} variables`;
+        const categoryLabel = categories || `${a.variableCount} vars`;
+        // Truncate slug if needed (for both display and value)
+        const maxSlugDisplay = 30;
+        const displaySlug = a.slug.length > maxSlugDisplay
+          ? a.slug.substring(0, maxSlugDisplay - 1) + '…'
+          : a.slug;
+        // Build compact display: "📊 *slug* · label · date"
+        const baseText = `${a.icon} *${displaySlug}* · ${a.label} · ${a.date}`;
+        const displayText = baseText.length > 150
+          ? baseText.substring(0, 147) + '…'
+          : baseText;
+        // Value: truncate to 75 chars
+        const rawValue = `${a.type}::${a.slug}`;
+        const value = rawValue.length > 75 ? rawValue.substring(0, 75) : rawValue;
         return {
-          text: {
-            type: "mrkdwn",
-            text: `${a.icon} *${a.slug}*\n      ${a.label} · ${categoryLabel} · ${a.date}`,
-          },
-          value: `${a.type}::${a.slug}`,
+          text: { type: "mrkdwn", text: displayText },
+          value,
         };
       });
 
@@ -288,7 +299,19 @@ export async function buildBriefEntryModal(options: BuildBriefEntryModalOptions)
         // Check for exact match first
         let matchedRadio = radioOptions[methodLower];
 
-        // If no exact match, check for combined/mixed methods indicators
+        // If no exact match, check if method string CONTAINS any known method name
+        if (!matchedRadio) {
+          // Priority order: longer matches first to avoid "interview" matching before "user interview"
+          const orderedKeys = Object.keys(radioOptions).sort((a, b) => b.length - a.length);
+          for (const key of orderedKeys) {
+            if (methodLower.includes(key)) {
+              matchedRadio = radioOptions[key];
+              break;
+            }
+          }
+        }
+
+        // If still no match, check for combined/mixed methods indicators
         if (!matchedRadio) {
           const combinedIndicators = ['followed by', 'then', ' + ', ' and ', 'combined with'];
           const isCombined = combinedIndicators.some(ind => methodLower.includes(ind));


### PR DESCRIPTION
## Summary

Post-merge fixes for ADR 0020 (System-Assigned Per-Study Participant Codes). These fixes were discovered during verification testing after PR #185 was merged.

**Three-identifier agreement VERIFIED:**
- `study_participants.participant_code` = `PT-001`
- `study_variables.value->>'participant'` = `PT-001`
- Nugget IDs follow `nugget-PT-001-NNN` format
- Re-analysis replaces nuggets (77→77, not accumulated)

## Fixes

1. **Participant submit action_id mismatch** — `study_select` → `add_participant_study_select`
2. **Brief modal checkbox text truncation** — 150 char limit for Slack Block Kit
3. **Brief methodology partial matching** — "moderated usability testing with 8 participants" now matches dropdown
4. **Fieldwork add participant code preview** — Shows assigned code when study pre-selected
5. **Notes modal displayName format** — Fixed `initial_option` mismatch
6. **Removed derived PT-XXX fallbacks** — Uses `participant_code` directly
7. **Error logging for /qori-brief** — Detailed Slack API error messages

## Test plan

- [x] Add participant from fieldwork → code preview shows
- [x] Submit participant → saves correctly
- [x] Open notes modal → no Block Kit error
- [x] /qori-brief → methodology auto-selects in dropdown
- [x] /qori-analyze → nuggets use correct PT-XXX code
- [x] Re-analyze same session → nugget count stays same (replaces, not accumulates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)