### PR TITLE
hotfix: remove broken RAG imports crashing production

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -18,7 +18,6 @@ const configs = require("./config"); // ./config/index.js
 const { authenticationMiddleware, sentryMiddleware } = require("./middleware"); // ./middleware/index.js
 const { slackApp, slackExpressRouter } = require('./helpers/slack/events');
 const { createFolderWithDummyData, readFolderContents, listOrgRepos, listAllTopLevelFolders, readFolders } = require("./helpers/github");
-const { runRAG } = require("./helpers/rag");
 
 const { NODE_ENV, DB_NAME, DB_USER, DB_PASSWORD, DB_HOST, DB_PORT, PORT, DB_DIALECT } = process.env;
 

--- a/backend/src/helpers/queue/embededFile.queue.js
+++ b/backend/src/helpers/queue/embededFile.queue.js
@@ -1,5 +1,7 @@
+// RAG embedding queue — DISABLED (RAG system removed for alpha)
+// This queue was part of the vector store pipeline. See CLAUDE.md "How to Re-enable RAG"
+
 const Queue = require('bull');
-const { setupVectorStore } = require('../rag');
 
 const embedFileQueue = new Queue('embedFileQueue', {
   redis: { host: process.env.REDIS_HOST, port: process.env.REDIS_PORT },
@@ -10,10 +12,10 @@ const embedFileQueue = new Queue('embedFileQueue', {
   },
 });
 
-/** Worker: one job = one file **/
-embedFileQueue.process(5, async (job) => {           // concurrency = 5
-  const { content, folderName, path, sha } = job.data;
-  await setupVectorStore(content, folderName, path, sha);
+/** Worker: no-op while RAG is disabled **/
+embedFileQueue.process(5, async (job) => {
+  // RAG disabled — jobs silently complete
+  console.log(`[embedFileQueue] RAG disabled — skipping embed for ${job.data.path}`);
 });
 
 module.exports = { embedFileQueue };


### PR DESCRIPTION
## 🚨 HOTFIX — Production is crash-looping

PR #188 deleted `rag.js` but left imports in `app.js` and `embededFile.queue.js`, causing:

```
Error: Cannot find module './helpers/rag'
```

### Changes
- Remove `runRAG` import from `app.js` (line 21)
- Make `embedFileQueue` a no-op (worker called `setupVectorStore` which no longer exists)

### Test plan
- [x] `npm run build` succeeds
- [ ] Railway deployment stops crash-looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)