### PR TITLE
fix: bug batch B1-B4 — stale refs, status enum alignment

### DIFF
--- a/backend/src/constants/participantStatus.ts
+++ b/backend/src/constants/participantStatus.ts
@@ -6,6 +6,7 @@ export const PARTICIPANT_STATUS = {
   NEEDS_RESCHEDULE: 'needs_reschedule',
   COMPLETED: 'completed',
   DECLINED: 'declined',
+  DISQUALIFIED: 'disqualified',
   NO_RESPONSE: 'no_response',
   CANCELED: 'canceled',
 } as const;
@@ -22,6 +23,7 @@ export const PARTICIPANT_STATUS_LABELS: Record<ParticipantStatus, string> = {
   needs_reschedule: 'Needs reschedule',
   completed: 'Completed',
   declined: 'Declined',
+  disqualified: 'Disqualified',
   no_response: 'No response',
   canceled: 'Canceled',
 };
@@ -39,6 +41,7 @@ export const ACTIVE_STATUSES: readonly ParticipantStatus[] = [
 export const TERMINAL_STATUSES: readonly ParticipantStatus[] = [
   PARTICIPANT_STATUS.COMPLETED,
   PARTICIPANT_STATUS.DECLINED,
+  PARTICIPANT_STATUS.DISQUALIFIED,
   PARTICIPANT_STATUS.NO_RESPONSE,
   PARTICIPANT_STATUS.CANCELED,
 ];

--- a/config/prompts/participant_tracker.yaml
+++ b/config/prompts/participant_tracker.yaml
@@ -6,10 +6,10 @@ id: participant_tracker
 name: generate_participant_tracker
 label: "👥 Participant Tracker"
 description: Generate and manage participant tracker for a VA research study with recruitment tracking
-version: "v1.1"
+version: "v1.2"
 author: Qori R&D
 created: 2025-07-07
-last_updated: 2026-04-29
+last_updated: 2026-06-03
 
 input_type: structured
 input_processing: validate_and_organize
@@ -54,31 +54,40 @@ inputs:
 # STATUS & SOURCE MAPPINGS
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# Status mappings aligned to canonical PARTICIPANT_STATUS enum (participantStatus.ts)
+# 10-status enum as of v1.2: not_contacted, contacted, scheduled, confirmed,
+# needs_reschedule, completed, declined, disqualified, no_response, canceled
 status_mappings:
-  recruited:
-    display: "📝 Recruited"
-    description: "Initial contact made, screening in progress"
+  not_contacted:
+    display: "📋 Not Contacted"
+    description: "Added to tracker, not yet reached out"
+  contacted:
+    display: "📧 Contacted"
+    description: "Outreach sent, awaiting response"
+  scheduled:
+    display: "📅 Scheduled"
+    description: "Session date/time set, awaiting confirmation"
   confirmed:
     display: "✅ Confirmed"
-    description: "Session scheduled and confirmed"
+    description: "Session scheduled and confirmed by participant"
+  needs_reschedule:
+    display: "🕐 Needs Reschedule"
+    description: "Session needs to be rescheduled"
   completed:
     display: "🎯 Completed"
     description: "Session completed successfully"
-  pending:
-    display: "⏳ Pending"
-    description: "Awaiting response from participant"
-  rescheduling:
-    display: "🕐 Rescheduling"
-    description: "Need to reschedule session"
-  backup:
-    display: "🔄 Backup"
-    description: "Backup participant if needed"
-  canceled:
-    display: "❌ Canceled"
-    description: "Participant canceled or no-show"
+  declined:
+    display: "🙅 Declined"
+    description: "Participant opted out of the study"
   disqualified:
     display: "🚫 Disqualified"
-    description: "Did not meet study criteria"
+    description: "Did not meet screening criteria"
+  no_response:
+    display: "⏳ No Response"
+    description: "No response after multiple contact attempts"
+  canceled:
+    display: "❌ Canceled"
+    description: "Session canceled or participant no-show"
 
 recruitment_sources:
   internal_panel: "🗂️ Internal VA Panel"

--- a/config/prompts/session_summary.yaml
+++ b/config/prompts/session_summary.yaml
@@ -4,7 +4,7 @@
 id: session_summary
 name: analyze_session_notes
 label: "Analyze Notes"
-version: "v7.1"
+version: "v7.2"
 
 description: |
   Analyze session transcript and observer notes to produce a structured
@@ -19,7 +19,7 @@ description: |
 
 author: Qori R&D
 created: 2025-10-25
-last_updated: 2026-06-02
+last_updated: 2026-06-03
 
 # ═══════════════════════════════════════════════════════════
 # CONFIGURATION
@@ -49,13 +49,10 @@ input_variables:
       min_selections: 1
       max_selections: 10
 
-  - coded_transcript_file:
-      type: "select"
-      required: true
-      label: "Session transcript"
-      placeholder: "Select session transcript file..."
-      data_source: "coded_transcripts"
-      help_text: "Primary source for analysis"
+  # NOTE: coded_transcript_file was removed in v7.2 (B1 cleanup).
+  # The old coded-transcript workflow no longer exists — transcripts are now
+  # uploaded via /qori-notes with transcript=true flag, and the handler
+  # (analyzeNotesHandler.ts) provides coded_transcript_content directly.
 
   - participant_id:
       type: "hidden"
@@ -79,7 +76,8 @@ input_variables:
 
   - coded_transcript_content:
       type: "hidden"
-      derived_from: "coded_transcript_file.content"
+      # Handler-provided: analyzeNotesHandler.ts fetches transcript content
+      # directly from notes marked transcript=true. No YAML derivation.
 
   - analyzer:
       type: "hidden"


### PR DESCRIPTION
## Summary

Bug fixes batch from v1.0 cleanup campaign.

### B1 — `coded_transcript` stale reference ✅
- Removed dead `coded_transcript_file` input variable from `session_summary.yaml`
- Handler (`analyzeNotesHandler.ts`) provides `coded_transcript_content` directly
- Old coded-transcript workflow no longer exists

### B2 — participant_tracker status labels ✅
- Extended `PARTICIPANT_STATUS` enum from 9→10 statuses
- Added `disqualified` to preserve distinction from `declined`:
  - `declined` = participant opted out
  - `disqualified` = failed screening criteria
- Tracker `status_mappings` now match canonical enum exactly

### B3 — session_length not in cascade ✅ CLOSED
- Working as designed: modal → handler → template flow works
- No downstream consumer needs it as cascade variable

### B4 — task → topic rename ✅ CLOSED
- User-facing labels already say "tasks / topics"
- YAML template is methodology-aware
- Internal variable name change not worth 30+ reference blast radius

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (123 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)