### PR TITLE
feat: H9 pre-transmission PII redaction

### DIFF
--- a/backend/src/__tests__/integration/h9-pii-redaction.test.ts
+++ b/backend/src/__tests__/integration/h9-pii-redaction.test.ts
@@ -1,0 +1,165 @@
+/**
+ * H9 PII Redaction Integration Test
+ *
+ * Acceptance criteria:
+ * 1. Inspected payload shows known participant name ABSENT, participant code PRESENT
+ * 2. No downstream leaks to study_variables or logs
+ * 3. Fail-closed throw actually fires (prevents API call on failed redaction)
+ */
+
+import { redactTranscript, assertKnownNamesRedacted, PiiRedactionError } from '../../helpers/piiRedaction';
+
+describe('H9: Pre-transmission PII redaction', () => {
+  describe('Acceptance Test 1: Inspected payload (name absent, code present)', () => {
+    const realTranscript = `
+# Interview Transcript - Jane Smith
+
+**Date:** January 15, 2026
+**Duration:** 45 minutes
+
+**Interviewer:** Thank you for joining us today, Jane Smith. Can you tell me about your experience?
+
+**Jane Smith:** Sure, I've been using the VA healthcare system for about 5 years now. My name is Jane Smith and I'm a veteran from the Gulf War.
+
+**Interviewer:** Jane Smith, can you describe a typical visit?
+
+**Jane Smith:** Well, usually I check in at the front desk. They know me there - "Hi Jane Smith, how are you today?" kind of thing.
+
+The system works okay but sometimes there are delays. I mentioned to Dr. Johnson - she's my primary care - that Jane Smith has been having trouble with the scheduling system.
+
+**Interviewer:** Thank you, Jane Smith. That's very helpful.
+`;
+
+    it('redacts all occurrences of full participant name', () => {
+      const redacted = redactTranscript(realTranscript, 'Jane Smith', 'PT-001');
+
+      // VERIFICATION: Name should be ABSENT
+      expect(redacted).not.toContain('Jane Smith');
+      expect(redacted).not.toContain('jane smith');
+      expect(redacted).not.toContain('JANE SMITH');
+
+      // VERIFICATION: Code should be PRESENT (replacing each name occurrence)
+      const codeCount = (redacted.match(/PT-001/g) || []).length;
+      expect(codeCount).toBe(9); // All 9 occurrences of "Jane Smith" replaced
+
+      // VERIFICATION: Other content unchanged
+      expect(redacted).toContain('Dr. Johnson'); // Other names preserved (not the participant)
+      expect(redacted).toContain('Gulf War');
+      expect(redacted).toContain('45 minutes');
+    });
+
+    it('passes assertion after redaction', () => {
+      const redacted = redactTranscript(realTranscript, 'Jane Smith', 'PT-001');
+
+      // This is the check that runs BEFORE llm.invoke() — must not throw
+      expect(() => {
+        assertKnownNamesRedacted(redacted, ['Jane Smith'], 'PT-001');
+      }).not.toThrow();
+    });
+  });
+
+  describe('Acceptance Test 2: Fail-closed behavior', () => {
+    it('throws PiiRedactionError when redaction is skipped', () => {
+      const unreducedContent = 'Interview with Jane Smith about their experience.';
+
+      // Simulating: someone calls the API without redacting first
+      expect(() => {
+        assertKnownNamesRedacted(unreducedContent, ['Jane Smith'], 'PT-001');
+      }).toThrow(PiiRedactionError);
+    });
+
+    it('throws PiiRedactionError when redaction partially fails', () => {
+      // Simulating: name appears in a format that wasn't caught (edge case)
+      const partiallyRedacted = 'Interview with PT-001. Later, Jane   Smith was mentioned.';
+
+      // Double-space case wouldn't be caught by word-boundary regex
+      // This is a known limitation — we don't catch typos/variations
+      // But if we DID have the exact name in the payload, it MUST throw
+      const exactNameContent = 'Interview with PT-001. Later, Jane Smith was mentioned.';
+
+      expect(() => {
+        assertKnownNamesRedacted(exactNameContent, ['Jane Smith'], 'PT-001');
+      }).toThrow(PiiRedactionError);
+    });
+
+    it('PiiRedactionError includes diagnostic information', () => {
+      const unreducedContent = 'Interview with Jane Smith and John Doe.';
+
+      try {
+        assertKnownNamesRedacted(unreducedContent, ['Jane Smith', 'John Doe'], 'PT-001');
+        fail('Expected PiiRedactionError to be thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(PiiRedactionError);
+        const piiError = err as PiiRedactionError;
+
+        // Diagnostic info for debugging/auditing
+        expect(piiError.name).toBe('PiiRedactionError');
+        expect(piiError.participantCode).toBe('PT-001');
+        // Names available in error object for local debugging
+        expect(piiError.detectedNames).toContain('Jane Smith');
+        expect(piiError.detectedNames).toContain('John Doe');
+        // But message does NOT include names (could leak to Sentry)
+        expect(piiError.message).toContain('2 found');
+        expect(piiError.message).not.toContain('Jane Smith');
+        expect(piiError.message).not.toContain('John Doe');
+      }
+    });
+  });
+
+  describe('Acceptance Test 3: formatNoteContent header redaction', () => {
+    // Simulates what analyzeNotesHandler.formatNoteContent now does
+    const formatNoteContent = (
+      filename: string,
+      participantName: string | null,
+      participantCode: string,
+      sessionDate: string,
+      createdBy: string,
+      rawContent: string,
+    ): string => {
+      const redactedContent = redactTranscript(rawContent, participantName, participantCode);
+      // Use participant CODE in header, not participant NAME
+      return `# ${filename}\n\n` +
+        `**Participant:** ${participantCode}\n` +
+        `**Date:** ${sessionDate}\n` +
+        `**Note Taker:** ${createdBy}\n\n` +
+        `${redactedContent}`;
+    };
+
+    it('header uses code, not name', () => {
+      const content = 'Jane Smith discussed her experience.';
+      const formatted = formatNoteContent(
+        'interview-001.md',
+        'Jane Smith',
+        'PT-001',
+        'January 15, 2026',
+        'U123456',
+        content,
+      );
+
+      // Header should have code, not name
+      expect(formatted).toContain('**Participant:** PT-001');
+      expect(formatted).not.toContain('**Participant:** Jane Smith');
+
+      // Body should have code, not name
+      expect(formatted).toContain('PT-001 discussed her experience');
+      expect(formatted).not.toContain('Jane Smith discussed');
+    });
+
+    it('entire formatted output passes assertion', () => {
+      const content = 'Jane Smith discussed her experience. Jane Smith said thank you.';
+      const formatted = formatNoteContent(
+        'interview-001.md',
+        'Jane Smith',
+        'PT-001',
+        'January 15, 2026',
+        'U123456',
+        content,
+      );
+
+      // The full output — header + body — must be clean
+      expect(() => {
+        assertKnownNamesRedacted(formatted, ['Jane Smith'], 'PT-001');
+      }).not.toThrow();
+    });
+  });
+});

--- a/backend/src/__tests__/unit/piiRedaction.test.ts
+++ b/backend/src/__tests__/unit/piiRedaction.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for PII redaction functions (H9 remediation)
+ */
+
+import {
+  redactTranscript,
+  assertKnownNamesRedacted,
+  PiiRedactionError,
+} from '../../helpers/piiRedaction';
+
+describe('piiRedaction', () => {
+  describe('redactTranscript', () => {
+    it('replaces full participant name with code', () => {
+      const content = 'Interview with Jane Smith about their experience.';
+      const result = redactTranscript(content, 'Jane Smith', 'PT-001');
+      expect(result).toBe('Interview with PT-001 about their experience.');
+    });
+
+    it('is case-insensitive', () => {
+      const content = 'jane smith said something. JANE SMITH confirmed.';
+      const result = redactTranscript(content, 'Jane Smith', 'PT-001');
+      expect(result).toBe('PT-001 said something. PT-001 confirmed.');
+    });
+
+    it('handles multiple occurrences', () => {
+      const content = 'John Doe mentioned that John Doe was present.';
+      const result = redactTranscript(content, 'John Doe', 'PT-002');
+      expect(result).toBe('PT-002 mentioned that PT-002 was present.');
+    });
+
+    it('respects word boundaries', () => {
+      const content = 'John Doe is not JohnDoe or John Doer.';
+      const result = redactTranscript(content, 'John Doe', 'PT-002');
+      expect(result).toBe('PT-002 is not JohnDoe or John Doer.');
+    });
+
+    it('returns original content if name is null', () => {
+      const content = 'Some content here.';
+      const result = redactTranscript(content, null, 'PT-001');
+      expect(result).toBe('Some content here.');
+    });
+
+    it('returns original content if name is too short (length <= 2)', () => {
+      const content = 'Al said something.';
+      const result = redactTranscript(content, 'Al', 'PT-001');
+      expect(result).toBe('Al said something.');
+    });
+
+    it('handles names with special regex characters', () => {
+      const content = 'Interview with John (Jack) Smith.';
+      const result = redactTranscript(content, 'John (Jack) Smith', 'PT-003');
+      expect(result).toBe('Interview with PT-003.');
+    });
+
+    it('returns empty string if content is empty', () => {
+      const result = redactTranscript('', 'Jane Smith', 'PT-001');
+      expect(result).toBe('');
+    });
+
+    it('handles transcript with multiple lines', () => {
+      const content = `Line 1: Jane Smith spoke.
+Line 2: More content.
+Line 3: Jane Smith concluded.`;
+      const result = redactTranscript(content, 'Jane Smith', 'PT-001');
+      expect(result).toBe(`Line 1: PT-001 spoke.
+Line 2: More content.
+Line 3: PT-001 concluded.`);
+    });
+  });
+
+  describe('assertKnownNamesRedacted', () => {
+    it('does not throw when names are properly redacted', () => {
+      const payload = 'Interview with PT-001 about their experience.';
+      expect(() => {
+        assertKnownNamesRedacted(payload, ['Jane Smith'], 'PT-001');
+      }).not.toThrow();
+    });
+
+    it('throws PiiRedactionError when a known name is detected', () => {
+      const payload = 'Interview with Jane Smith about their experience.';
+      expect(() => {
+        assertKnownNamesRedacted(payload, ['Jane Smith'], 'PT-001');
+      }).toThrow(PiiRedactionError);
+    });
+
+    it('includes detected names in the error', () => {
+      const payload = 'Interview with Jane Smith about their experience.';
+      try {
+        assertKnownNamesRedacted(payload, ['Jane Smith'], 'PT-001');
+        fail('Expected error to be thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(PiiRedactionError);
+        const piiError = err as PiiRedactionError;
+        expect(piiError.detectedNames).toEqual(['Jane Smith']);
+        expect(piiError.participantCode).toBe('PT-001');
+      }
+    });
+
+    it('skips names that are too short (length <= 2)', () => {
+      const payload = 'Al said something about Al.';
+      expect(() => {
+        assertKnownNamesRedacted(payload, ['Al'], 'PT-001');
+      }).not.toThrow();
+    });
+
+    it('handles null/undefined names in the array', () => {
+      const payload = 'Interview with PT-001.';
+      expect(() => {
+        assertKnownNamesRedacted(payload, [null, undefined, 'Jane Smith'], 'PT-001');
+      }).not.toThrow();
+    });
+
+    it('detects multiple names', () => {
+      const payload = 'Jane Smith and John Doe were present.';
+      try {
+        assertKnownNamesRedacted(payload, ['Jane Smith', 'John Doe'], 'PT-001');
+        fail('Expected error to be thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(PiiRedactionError);
+        const piiError = err as PiiRedactionError;
+        expect(piiError.detectedNames).toContain('Jane Smith');
+        expect(piiError.detectedNames).toContain('John Doe');
+      }
+    });
+
+    it('is case-insensitive when detecting names', () => {
+      const payload = 'JANE SMITH mentioned something.';
+      expect(() => {
+        assertKnownNamesRedacted(payload, ['Jane Smith'], 'PT-001');
+      }).toThrow(PiiRedactionError);
+    });
+  });
+
+  describe('integration: redact then assert', () => {
+    it('passes assertion after proper redaction', () => {
+      const original = 'Jane Smith said: "I work with Jane Smith daily."';
+      const redacted = redactTranscript(original, 'Jane Smith', 'PT-001');
+
+      expect(redacted).toBe('PT-001 said: "I work with PT-001 daily."');
+      expect(() => {
+        assertKnownNamesRedacted(redacted, ['Jane Smith'], 'PT-001');
+      }).not.toThrow();
+    });
+
+    it('fails assertion if redaction was skipped', () => {
+      const original = 'Jane Smith said something.';
+      // Intentionally skip redaction
+      expect(() => {
+        assertKnownNamesRedacted(original, ['Jane Smith'], 'PT-001');
+      }).toThrow(PiiRedactionError);
+    });
+  });
+});

--- a/backend/src/helpers/langchain.ts
+++ b/backend/src/helpers/langchain.ts
@@ -1,8 +1,25 @@
 import nunjucks from 'nunjucks';
 import { ChatAnthropic } from '@langchain/anthropic';
+import { assertKnownNamesRedacted } from './piiRedaction';
 
 // make sure nunjucks knows it's okay to render standalone strings
 nunjucks.configure({ autoescape: false });
+
+// ---------------------------------------------------------------------------
+// PII redaction context (H9)
+// ---------------------------------------------------------------------------
+
+/**
+ * Optional PII context passed to executeAiGenerationTasks.
+ * If provided, the assertion is run BEFORE each LLM API call.
+ * If any known name is detected in the prompt, the call is ABORTED.
+ */
+export interface PiiRedactionContext {
+  /** Participant names that should have been redacted */
+  knownNames: Array<string | null | undefined>;
+  /** Participant code that should appear instead */
+  participantCode?: string;
+}
 
 interface AiGenerationTask {
   task_id: string;
@@ -60,6 +77,7 @@ function unescapeNunjucksSyntax(str: string): string {
 export async function executeAiGenerationTasks(
   aiGenerationTasks: AiGenerationTask[],
   inputValues: Record<string, any>,
+  piiContext?: PiiRedactionContext,
 ): Promise<AiResponses> {
   const modelName = process.env.ANTHROPIC_MODEL_NAME || 'claude-sonnet-4-20250514';
   const temperature = parseFloat(process.env.ANTHROPIC_TEMPERATURE || '0.4');
@@ -92,6 +110,16 @@ export async function executeAiGenerationTasks(
       const nunjucksTemplate = convertHandlebarsToNunjucks(task.prompt);
       const jinjaOut = nunjucks.renderString(nunjucksTemplate, safeInputValues);
       const finalPrompt = unescapeNunjucksSyntax(jinjaOut);
+
+      // H9: Pre-transmission PII assertion — FAIL CLOSED if known names detected
+      // This is the LAST check before data crosses the wire to Anthropic
+      if (piiContext?.knownNames?.length) {
+        assertKnownNamesRedacted(
+          finalPrompt,
+          piiContext.knownNames,
+          piiContext.participantCode,
+        );
+      }
 
       const response = await llm.invoke(finalPrompt);
       return { taskId: task.task_id, response: response.content as string };

--- a/backend/src/helpers/piiRedaction.ts
+++ b/backend/src/helpers/piiRedaction.ts
@@ -1,0 +1,126 @@
+/**
+ * piiRedaction.ts — Pre-transmission PII redaction for LLM payloads
+ *
+ * H9 remediation: Replaces known participant names with participant codes
+ * BEFORE content is sent to the Anthropic API. This is pre-transmission
+ * redaction, not storage-time redaction.
+ *
+ * SCOPE LIMITATIONS (MVP):
+ * - Only redacts FULL participant names (not first-name-only)
+ * - Only redacts names we KNOW (from participant record)
+ * - Does NOT redact: other people mentioned, place identifiers, dates,
+ *   partial name matches, nicknames, or typos
+ *
+ * These limitations are documented — the system does not claim total PII
+ * coverage, only that KNOWN participant names are replaced with codes.
+ */
+
+import { PiiRedactionError } from '../types/handlers';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape special regex characters in a string.
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+/**
+ * Redact known participant name from content, replacing with participant code.
+ *
+ * @param content - The transcript/notes content to redact
+ * @param participantName - The full name to redact (e.g., "Jane Smith")
+ * @param participantCode - The code to substitute (e.g., "PT-001")
+ * @returns Content with name replaced by code
+ *
+ * DESIGN NOTES:
+ * - Full-name substitution ONLY (no first-name-only — corrupts common words)
+ * - Word-boundary matching to avoid partial replacements
+ * - Case-insensitive to catch "jane smith", "Jane Smith", "JANE SMITH"
+ * - Only substitutes names where name.length > 2 (avoid "Al" → "Also" issues)
+ */
+export function redactTranscript(
+  content: string,
+  participantName: string | null | undefined,
+  participantCode: string,
+): string {
+  if (!content) return content;
+  if (!participantName || participantName.trim().length <= 2) return content;
+
+  const trimmedName = participantName.trim();
+
+  // Full-name substitution with word boundaries
+  const fullNamePattern = new RegExp(
+    `\\b${escapeRegex(trimmedName)}\\b`,
+    'gi',
+  );
+  const redacted = content.replace(fullNamePattern, participantCode);
+
+  return redacted;
+}
+
+// ---------------------------------------------------------------------------
+// Assertion (fail-closed)
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert that no known participant names remain in the payload.
+ *
+ * FAIL-CLOSED: If any known name is detected, this function THROWS.
+ * The caller MUST NOT proceed with the API call.
+ *
+ * @param payload - The assembled prompt/payload string
+ * @param knownNames - Array of participant names that should have been redacted
+ * @param participantCode - The code that should appear instead
+ * @throws PiiRedactionError if any known name is still present
+ *
+ * DESIGN NOTES:
+ * - This is "known-name redaction verification", NOT "PII-free guarantee"
+ * - A passing check means: redactTranscript() worked correctly
+ * - A failing check means: a known name leaked through (redaction bug)
+ * - Names ≤2 chars are skipped (same as redaction — too short, false positives)
+ */
+export function assertKnownNamesRedacted(
+  payload: string,
+  knownNames: Array<string | null | undefined>,
+  participantCode?: string,
+): void {
+  const detectedNames: string[] = [];
+
+  for (const name of knownNames) {
+    if (!name || name.trim().length <= 2) continue;
+
+    const trimmedName = name.trim();
+    const pattern = new RegExp(`\\b${escapeRegex(trimmedName)}\\b`, 'gi');
+
+    if (pattern.test(payload)) {
+      detectedNames.push(trimmedName);
+    }
+  }
+
+  if (detectedNames.length > 0) {
+    // H9: Log count only, not actual names (could leak to Sentry)
+    console.error(
+      `[PII] known-name redaction failed: detected ${detectedNames.length} name(s) in payload`,
+    );
+    // Error message uses count, not names. detectedNames stored for local debugging only.
+    throw new PiiRedactionError(
+      `Known participant name(s) detected in payload after redaction (${detectedNames.length} found). Redaction failed - API call aborted.`,
+      participantCode,
+      detectedNames,  // Available in error object for local catch, NOT serialized to logs
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Re-export error for convenience
+// ---------------------------------------------------------------------------
+
+export { PiiRedactionError } from '../types/handlers';

--- a/backend/src/helpers/slack/commands/analyzeNotesHandler.ts
+++ b/backend/src/helpers/slack/commands/analyzeNotesHandler.ts
@@ -17,8 +17,10 @@ import sessionSummaryService from "../../../services/session-summary.service";
 import studyParticipantService from "../../../services/study_participant.service";
 import { getConfigRepo, YAML_TEMPLATE_PATH, fetchFileFromRepoByPath, fetchFileFromRepo } from "../../../helpers/github";
 import { processYamlTemplate } from "../../../helpers/yamlProcessor";
+import type { PiiRedactionContext } from "../../../helpers/langchain";
 import { readStudyVariablesByContext, type VariableContext } from '../../studyVariables';
 import { assertStudyAccess, AuthorizationError } from '../../../services/authorization.service';
+import { redactTranscript } from '../../../helpers/piiRedaction';
 
 // ─── Cascade context ─────────────────────────────────────────────
 
@@ -273,7 +275,9 @@ const handleAnalyzeNotesSubmission = async ({ ack, body, view, client }: SlackVi
 
     // sessionId from dropdown IS the participant database ID (see mapParticipantsToSessions)
     // Fetch participant to get system-assigned participant_code for cascade isolation
+    // AND participant_name for pre-transmission PII redaction (H9)
     let participantCode = 'PT-UNKNOWN';
+    let participantName: string | null = null;
     if (sessionId && sessionId !== "no_sessions") {
       console.log("Selected session ID (participant DB ID):", sessionId);
       const participantDbId = parseInt(sessionId, 10);
@@ -282,6 +286,11 @@ const handleAnalyzeNotesSubmission = async ({ ack, body, view, client }: SlackVi
         if (participant?.participant_code) {
           participantCode = participant.participant_code;
           console.log("Resolved participant_code:", participantCode);
+        }
+        if (participant?.participant_name) {
+          participantName = participant.participant_name;
+          // H9: Do NOT log participant_name — it's PII. Log only that we have it.
+          console.log("Resolved participant_name for PII redaction: [REDACTED]");
         }
       }
     }
@@ -358,13 +367,19 @@ const handleAnalyzeNotesSubmission = async ({ ack, body, view, client }: SlackVi
     // NOT extracted from note.participant_name (which is freeform and non-unique)
     // See ADR 0020: System-Assigned Per-Study Participant Codes
 
+    // H9: Pre-transmission PII redaction — replace participant name with code in content
+    // This happens BEFORE content goes to the LLM template
     const formatNoteContent = (note: NoteDetail): string => {
       const filename = note.filename || 'Unknown File';
+      // Redact participant name from GitHub content before embedding
+      const rawContent = note.githubContent || '[No content available]';
+      const redactedContent = redactTranscript(rawContent, participantName, participantCode);
+      // Use participant CODE in header, not participant NAME (H9)
       return `# ${filename}\n\n` +
-        `**Participant:** ${note.participant_name || 'Unknown Participant'}\n` +
+        `**Participant:** ${participantCode}\n` +
         `**Date:** ${note.session_date || 'Unknown Date'}\n` +
         `**Note Taker:** ${note.created_by || 'Unknown User'}\n\n` +
-        `${note.githubContent || '[No content available]'}`;
+        `${redactedContent}`;
     };
 
     const transcriptNotes = notesWithContent.filter((note: NoteDetail) => note.transcript === true);
@@ -377,6 +392,11 @@ const handleAnalyzeNotesSubmission = async ({ ack, body, view, client }: SlackVi
     const notes_content: string = regularNotes.length > 0
       ? regularNotes.map(formatNoteContent).join('\n\n---\n\n')
       : '';
+
+    // Log redaction stats for debugging (H9: do NOT log the actual name)
+    if (participantName) {
+      console.log(`[PII] Pre-transmission redaction applied: [REDACTED] → "${participantCode}"`);
+    }
 
     const templateData: SessionSummaryTemplateInput = {
       study_folder: studyName,
@@ -398,13 +418,19 @@ const handleAnalyzeNotesSubmission = async ({ ack, body, view, client }: SlackVi
     const studyPath = study?.path;
     if (!studyPath) throw new Error('Unexpected: study.path missing after resolution');
 
+    // H9: Construct PII context for pre-transmission assertion in langchain
+    const piiContext: PiiRedactionContext | undefined = participantName
+      ? { knownNames: [participantName], participantCode }
+      : undefined;
+
     const renderedYaml = await processYamlTemplate(
       yamlTemplateFile.content,
       templateData,
       studyPath,
       '',
       false,
-      variableContext
+      variableContext,
+      piiContext,  // H9: Pre-transmission PII assertion
     );
 
     // CRITICAL: Await extraction to ensure cascade variables are committed before returning success.
@@ -629,7 +655,8 @@ const handleSessionSelectionChange = async ({ ack, body, client }: SlackActionMi
     try {
       if (participantName) {
         studyNotes = await studyNotesService.getStudyNotesByParticipantName(participantName, studyId);
-        console.log(`✅ Loaded ${studyNotes.length} notes for participant "${participantName}" in study ${studyId} (session: "${sessionName}")`);
+        // H9: Do NOT log participant_name — it's PII
+        console.log(`✅ Loaded ${studyNotes.length} notes for participant [REDACTED] in study ${studyId}`);
       } else {
         // No participant_name means notes can't be scoped — show empty list
         console.warn(`No participant_name found for session "${sessionName}" — notes dropdown will be empty`);

--- a/backend/src/helpers/yamlProcessor.ts
+++ b/backend/src/helpers/yamlProcessor.ts
@@ -4,7 +4,7 @@ import Handlebars from 'handlebars';
 import { format } from 'date-fns';
 import path from 'path';
 import { createOrUpdateFileOnGitHub, type GitHubWriteResult } from './github';
-import { executeAiGenerationTasks } from './langchain';
+import { executeAiGenerationTasks, type PiiRedactionContext } from './langchain';
 import { extractVariables, type EmitSpec, type ExtractionResult } from './variableExtractor';
 import {
   readStudyVariablesByContext,
@@ -191,6 +191,7 @@ export async function processYamlTemplate(
   extraFolder = '',
   aiCheck = false,
   variableContext?: VariableContext,
+  piiContext?: PiiRedactionContext,
 ): Promise<ProcessResult> {
   // 1. Parse the raw YAML content first
   const yamlConfig = yaml.load(rawYamlContent) as YamlConfig | null;
@@ -282,11 +283,15 @@ export async function processYamlTemplate(
   // 4. Prepare LangChain tasks for AI generation (optional)
   let aiResponses: Record<string, string> = {};
   if (yamlConfig.ai_generation_tasks && yamlConfig.ai_generation_tasks.length > 0) {
-    aiResponses = await executeAiGenerationTasks(yamlConfig.ai_generation_tasks, {
-      ...inputValues,
-      current_date: format(new Date(), 'MMMM d, yyyy'),
-      current_date_iso: format(new Date(), 'yyyy-MM-dd'),
-    });
+    aiResponses = await executeAiGenerationTasks(
+      yamlConfig.ai_generation_tasks,
+      {
+        ...inputValues,
+        current_date: format(new Date(), 'MMMM d, yyyy'),
+        current_date_iso: format(new Date(), 'yyyy-MM-dd'),
+      },
+      piiContext,  // H9: Pass PII context for pre-transmission assertion
+    );
     console.log(
       `AI generation complete for ${yamlConfig.id}: ${Object.keys(aiResponses).length} task(s), ${Object.values(aiResponses).reduce((sum, v) => sum + (typeof v === 'string' ? v.length : 0), 0)} chars total`,
     );

--- a/backend/src/types/handlers.ts
+++ b/backend/src/types/handlers.ts
@@ -61,3 +61,25 @@ export class TemplateContractError extends Error {
     this.name = 'TemplateContractError';
   }
 }
+
+// ---------------------------------------------------------------------------
+// PII redaction error
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when PII redaction fails or known names are detected in a payload
+ * that should have been redacted.
+ *
+ * FAIL-CLOSED: If this error is thrown, the API call MUST be aborted.
+ * A known participant name in the payload means redaction failed.
+ */
+export class PiiRedactionError extends Error {
+  constructor(
+    message: string,
+    public readonly participantCode?: string,
+    public readonly detectedNames?: string[],
+  ) {
+    super(message);
+    this.name = 'PiiRedactionError';
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces known participant names with participant codes (PT-XXX) BEFORE content is sent to the Anthropic API
- Fail-closed assertion aborts API call if any known name is detected in payload after redaction
- Console logs and error messages redacted to prevent PII leaks to Sentry/logs

## Implementation

| File | Change |
|------|--------|
| `types/handlers.ts` | Add `PiiRedactionError` class |
| `helpers/piiRedaction.ts` | `redactTranscript()` + `assertKnownNamesRedacted()` |
| `analyzeNotesHandler.ts` | Fetch `participant_name`, call redaction, pass `piiContext` |
| `helpers/langchain.ts` | Assert before `llm.invoke()`, throw on detection |
| `helpers/yamlProcessor.ts` | Pass-through `piiContext` parameter |

## Data Flow

```
1. analyzeNotesHandler fetches participant_name + participant_code
2. formatNoteContent() calls redactTranscript(content, name, code)
3. Header uses code: "**Participant:** PT-001"
4. processYamlTemplate() receives piiContext
5. langchain.ts calls assertKnownNamesRedacted() BEFORE llm.invoke()
6. If name detected → PiiRedactionError thrown → API call ABORTED
```

## Leak-Check Verification

| Location | Status |
|----------|--------|
| Console logs | ✅ Shows `[REDACTED]` instead of name |
| Error messages | ✅ Contains count only, not names |
| Stored variables | ✅ All 17 schemas use `participant` (PT-###), never `participant_name` |
| templateData | ✅ Contains `participant_id: participantCode`, not name |

## Scope Limitations (Documented)

- Full-name substitution only (no first-name — corrupts common words like "Mark", "Grace")
- Only redacts names we KNOW (from participant record)
- Does NOT redact: other people mentioned, place identifiers, dates, typos, nicknames

## Test plan

- [x] Unit tests: 18 tests for redaction functions (`piiRedaction.test.ts`)
- [x] Integration tests: 7 acceptance tests (`h9-pii-redaction.test.ts`)
  - Payload inspection: name ABSENT, code PRESENT (9 occurrences replaced)
  - Fail-closed throw fires when redaction skipped
  - Header uses code, not name
  - Error diagnostics available for local debugging
- [x] All 179 integration tests pass
- [x] All 141 unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)