### PR TITLE
feat(H9): operational assurance layer (Phase 2)

### DIFF
--- a/backend/src/__tests__/integration/h9-pii-redaction.test.ts
+++ b/backend/src/__tests__/integration/h9-pii-redaction.test.ts
@@ -82,7 +82,7 @@ The system works okay but sometimes there are delays. I mentioned to Dr. Johnson
       }).toThrow(PiiRedactionError);
     });
 
-    it('PiiRedactionError includes diagnostic information', () => {
+    it('PiiRedactionError includes count but NOT names (Sentry safety)', () => {
       const unreducedContent = 'Interview with Jane Smith and John Doe.';
 
       try {
@@ -92,13 +92,15 @@ The system works okay but sometimes there are delays. I mentioned to Dr. Johnson
         expect(err).toBeInstanceOf(PiiRedactionError);
         const piiError = err as PiiRedactionError;
 
-        // Diagnostic info for debugging/auditing
+        // Diagnostic info: count and code, never names
         expect(piiError.name).toBe('PiiRedactionError');
         expect(piiError.participantCode).toBe('PT-001');
-        // Names available in error object for local debugging
-        expect(piiError.detectedNames).toContain('Jane Smith');
-        expect(piiError.detectedNames).toContain('John Doe');
-        // But message does NOT include names (could leak to Sentry)
+
+        // SECURITY: Count only — no names on the error object
+        expect(piiError.detectedCount).toBe(2);
+        expect((piiError as any).detectedNames).toBeUndefined();
+
+        // Message uses count, not names (could leak to Sentry/#qori-alerts)
         expect(piiError.message).toContain('2 found');
         expect(piiError.message).not.toContain('Jane Smith');
         expect(piiError.message).not.toContain('John Doe');

--- a/backend/src/__tests__/unit/piiRedaction.test.ts
+++ b/backend/src/__tests__/unit/piiRedaction.test.ts
@@ -83,7 +83,7 @@ Line 3: PT-001 concluded.`);
       }).toThrow(PiiRedactionError);
     });
 
-    it('includes detected names in the error', () => {
+    it('includes detected COUNT (not names) in the error', () => {
       const payload = 'Interview with Jane Smith about their experience.';
       try {
         assertKnownNamesRedacted(payload, ['Jane Smith'], 'PT-001');
@@ -91,8 +91,11 @@ Line 3: PT-001 concluded.`);
       } catch (err) {
         expect(err).toBeInstanceOf(PiiRedactionError);
         const piiError = err as PiiRedactionError;
-        expect(piiError.detectedNames).toEqual(['Jane Smith']);
+        // SECURITY: Count only, never names — error may reach Sentry/#qori-alerts
+        expect(piiError.detectedCount).toBe(1);
         expect(piiError.participantCode).toBe('PT-001');
+        // Verify no detectedNames property exists
+        expect((piiError as any).detectedNames).toBeUndefined();
       }
     });
 
@@ -110,7 +113,7 @@ Line 3: PT-001 concluded.`);
       }).not.toThrow();
     });
 
-    it('detects multiple names', () => {
+    it('counts multiple detected names', () => {
       const payload = 'Jane Smith and John Doe were present.';
       try {
         assertKnownNamesRedacted(payload, ['Jane Smith', 'John Doe'], 'PT-001');
@@ -118,8 +121,9 @@ Line 3: PT-001 concluded.`);
       } catch (err) {
         expect(err).toBeInstanceOf(PiiRedactionError);
         const piiError = err as PiiRedactionError;
-        expect(piiError.detectedNames).toContain('Jane Smith');
-        expect(piiError.detectedNames).toContain('John Doe');
+        // SECURITY: Count only — 2 distinct names detected
+        expect(piiError.detectedCount).toBe(2);
+        expect(piiError.message).toContain('2 found');
       }
     });
 

--- a/backend/src/helpers/piiRedaction.ts
+++ b/backend/src/helpers/piiRedaction.ts
@@ -61,7 +61,18 @@ export function redactTranscript(
     `\\b${escapeRegex(trimmedName)}\\b`,
     'gi',
   );
-  const redacted = content.replace(fullNamePattern, participantCode);
+
+  // Count replacements for observability (positive signal redaction is running)
+  let replacementCount = 0;
+  const redacted = content.replace(fullNamePattern, () => {
+    replacementCount++;
+    return participantCode;
+  });
+
+  // H9: Log success signal (count only, never names) — catches silent no-op case
+  if (replacementCount > 0) {
+    console.log(`[PII] redaction applied: ${replacementCount} replacement(s)`);
+  }
 
   return redacted;
 }
@@ -110,11 +121,12 @@ export function assertKnownNamesRedacted(
     console.error(
       `[PII] known-name redaction failed: detected ${detectedNames.length} name(s) in payload`,
     );
-    // Error message uses count, not names. detectedNames stored for local debugging only.
+    // SECURITY: Error carries COUNT only, never names. This error may reach
+    // Sentry/#qori-alerts — exposing names on the failure path defeats redaction.
     throw new PiiRedactionError(
       `Known participant name(s) detected in payload after redaction (${detectedNames.length} found). Redaction failed - API call aborted.`,
       participantCode,
-      detectedNames,  // Available in error object for local catch, NOT serialized to logs
+      detectedNames.length,  // Count only — no names on the error object
     );
   }
 }

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -228,6 +228,40 @@ slackApp.error(async ({ error, body, logger }: { error: Error; body: any; logger
     return;
   }
 
+  // ── Handle PiiRedactionError (H9 fail-closed) ──────────────────────
+  // SECURITY: Alert is distinguishable ("PII Redaction Failure") so ops
+  // can spot repeated failures fast. User message stays generic — don't
+  // leak that it's a PII issue to the researcher.
+  if (original.name === 'PiiRedactionError') {
+    logger.error(`PII redaction failure: ${original.message}`);
+
+    // Post DISTINGUISHABLE alert — not buried in "Unhandled Error"
+    await postErrorAlert('PII Redaction Failure', original.message, {
+      userId,
+      command,
+      // Note: error.detectedCount is available but we don't need it here —
+      // the message already contains the count ("N found")
+    });
+
+    // User gets generic message — don't reveal it's a PII/redaction issue
+    if (userId) {
+      try {
+        const client = slackApp.client;
+        const im = await client.conversations.open({ users: userId });
+        if (im.channel?.id) {
+          await client.chat.postMessage({
+            channel: im.channel.id,
+            text: '*Something went wrong on our end*\n\nYour request did not complete. The team has been notified. Please try again, and if it keeps happening, let us know.',
+          });
+        }
+      } catch (dmErr) {
+        const dmMessage = dmErr instanceof Error ? dmErr.message : String(dmErr);
+        logger.error('Failed to send PiiRedactionError DM:', dmMessage);
+      }
+    }
+    return;
+  }
+
   // ── Generic error — notify the user so they aren't left waiting ──
   logger.error('Unhandled error:', error);
 

--- a/backend/src/types/handlers.ts
+++ b/backend/src/types/handlers.ts
@@ -72,12 +72,16 @@ export class TemplateContractError extends Error {
  *
  * FAIL-CLOSED: If this error is thrown, the API call MUST be aborted.
  * A known participant name in the payload means redaction failed.
+ *
+ * SECURITY: This error carries COUNT only, never actual names. The error
+ * may reach Sentry/#qori-alerts — exposing names on the failure path
+ * would defeat the purpose of redaction.
  */
 export class PiiRedactionError extends Error {
   constructor(
     message: string,
     public readonly participantCode?: string,
-    public readonly detectedNames?: string[],
+    public readonly detectedCount?: number,
   ) {
     super(message);
     this.name = 'PiiRedactionError';


### PR DESCRIPTION
## Summary

Completes H9 with operational observability on top of MVP redaction:

- **Remove `detectedNames` from `PiiRedactionError`** — failure path now carries zero names. Error only has `detectedCount: number`. Eliminates Sentry leak risk on the redaction-failure path.
- **Add count-only redaction success signal** — logs `[PII] redaction applied: N replacement(s)` on every successful redaction. Makes silent-no-op observable (catches the "refactor broke the call path" failure mode).
- **Distinguish PII failures in #qori-alerts** — `PiiRedactionError` now posts as "Error: PII Redaction Failure" (not buried in generic "Unhandled Error"). Ops can spot repeated failures fast.

Researcher-facing message stays generic (don't leak that it's a PII issue). Count-only everywhere — the fix for a leak risk does not itself surface names.

## Test plan

- [x] Unit tests updated and passing (141/141)
- [x] Integration tests updated and passing (H9 suite)
- [x] TypeScript typecheck clean
- [x] Grep confirms `detectedNames` removed from error object (only exists as local var for detection)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)