### PR TITLE
feat(ADR 0025): stakeholder role + brief approval review loop

### DIFF
--- a/backend/src/database/migrations/20260607000000-add-brief-status.js
+++ b/backend/src/database/migrations/20260607000000-add-brief-status.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/**
+ * Migration: Add brief approval status tracking
+ *
+ * Supports the brief approval review loop:
+ * - brief_status: State machine (pending_approval → changes_requested → approved)
+ * - brief_change_feedback: Last feedback from approver (preserved after approval)
+ * - brief_reviewer_id: Who reviews (for re-notify on resubmit)
+ */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add brief_status column
+    await queryInterface.addColumn('research_studies', 'brief_status', {
+      type: Sequelize.STRING(20),
+      allowNull: true, // NULL = no brief submitted yet
+      defaultValue: null,
+    });
+
+    // Add brief_change_feedback column
+    await queryInterface.addColumn('research_studies', 'brief_change_feedback', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+
+    // Add brief_reviewer_id column
+    await queryInterface.addColumn('research_studies', 'brief_reviewer_id', {
+      type: Sequelize.STRING(50),
+      allowNull: true,
+    });
+
+    // Index for dashboard queries (e.g., "show all briefs pending approval")
+    await queryInterface.addIndex('research_studies', ['brief_status'], {
+      name: 'idx_research_studies_brief_status',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('research_studies', 'idx_research_studies_brief_status');
+    await queryInterface.removeColumn('research_studies', 'brief_reviewer_id');
+    await queryInterface.removeColumn('research_studies', 'brief_change_feedback');
+    await queryInterface.removeColumn('research_studies', 'brief_status');
+  },
+};

--- a/backend/src/database/migrations/20260607000001-add-is-stakeholder.js
+++ b/backend/src/database/migrations/20260607000001-add-is-stakeholder.js
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+ * Migration: Add is_stakeholder flag to project_members
+ *
+ * Stakeholder is a FLAG, not a role. A user can be both owner AND stakeholder.
+ * This prevents the lockout bug where assigning stakeholder replaced owner role.
+ */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Check if column already exists (may have been added manually during dev)
+    const tableInfo = await queryInterface.describeTable('project_members');
+    if (!tableInfo.is_stakeholder) {
+      await queryInterface.addColumn('project_members', 'is_stakeholder', {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('project_members', 'is_stakeholder');
+  },
+};

--- a/backend/src/database/models/project_member.ts
+++ b/backend/src/database/models/project_member.ts
@@ -18,8 +18,11 @@ import type { Project } from './project';
 
 /**
  * Membership role values.
- * - owner: Project creator, can delete project
+ * - owner: Project creator, can delete project and access Admin Center
  * - member: Can access all studies in project
+ *
+ * Note: Stakeholder is a SEPARATE FLAG (is_stakeholder), not a role.
+ * An owner can also be the stakeholder. The flag doesn't affect role.
  */
 export type MembershipRole = 'owner' | 'member';
 
@@ -43,6 +46,7 @@ class ProjectMember extends Model<
   declare role: CreationOptional<MembershipRole>;
   declare source: CreationOptional<MembershipSource>;
   declare added_at: CreationOptional<Date>;
+  declare is_stakeholder: CreationOptional<boolean>;
 
   // — Association mixins —
   declare getProject: BelongsToGetAssociationMixin<Project>;
@@ -98,6 +102,11 @@ export default (sequelize: Sequelize) => {
         type: DataTypes.DATE,
         allowNull: false,
         defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      is_stakeholder: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
       },
     },
     {

--- a/backend/src/database/models/research_study.ts
+++ b/backend/src/database/models/research_study.ts
@@ -21,6 +21,14 @@ import type { StudyNotes } from './study_notes';
 import type { ResearchPlan } from './research_plan';
 import type { SessionSummary } from './session_summary';
 
+/**
+ * Brief approval status values.
+ * - pending_approval: Brief submitted, awaiting approver decision
+ * - changes_requested: Approver requested changes, awaiting researcher resubmit
+ * - approved: Brief approved, study can proceed
+ */
+export type BriefStatus = 'pending_approval' | 'changes_requested' | 'approved';
+
 class ResearchStudy extends Model<
   InferAttributes<ResearchStudy>,
   InferCreationAttributes<ResearchStudy>
@@ -45,6 +53,12 @@ class ResearchStudy extends Model<
   declare target_participants: number | null;
   declare created_at: CreationOptional<Date>;
   declare updated_at: CreationOptional<Date>;
+  /** Brief approval status: pending_approval | changes_requested | approved */
+  declare brief_status: CreationOptional<BriefStatus | null>;
+  /** Last feedback from approver (preserved after approval for audit trail) */
+  declare brief_change_feedback: CreationOptional<string | null>;
+  /** Slack user ID of the reviewer (for re-notify on resubmit) */
+  declare brief_reviewer_id: CreationOptional<string | null>;
 
   // — Association mixins (participants) —
   declare getParticipants: HasManyGetAssociationsMixin<StudyParticipant>;
@@ -185,6 +199,22 @@ export default (sequelize: Sequelize) => {
         type: DataTypes.DATE,
         allowNull: false,
         defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      brief_status: {
+        type: DataTypes.STRING(20),
+        allowNull: true,
+        defaultValue: null,
+        validate: {
+          isIn: [['pending_approval', 'changes_requested', 'approved']],
+        },
+      },
+      brief_change_feedback: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      brief_reviewer_id: {
+        type: DataTypes.STRING(50),
+        allowNull: true,
       },
     },
     {

--- a/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
+++ b/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
@@ -16,7 +16,8 @@ import sequelize from '../../../../database';
 import type { Project } from '../../../../database/models/project';
 import type { ResearchStudy } from '../../../../database/models/research_study';
 import type { StudyParticipant } from '../../../../database/models/study_participant';
-import type { AdminCenterMetadata } from '../../ui/adminCenterModal';
+import type { AdminCenterMetadata, StakeholderInfo } from '../../ui/adminCenterModal';
+import { setProjectStakeholder, assertProjectOwner, getProjectStakeholder } from '../../../../services/authorization.service';
 
 const ProjectModel = sequelize.models.Project as typeof Project;
 const ResearchStudyModel = sequelize.models.ResearchStudy as typeof ResearchStudy;
@@ -997,6 +998,318 @@ export async function handleDeleteStudyConfirm({
             text: {
               type: 'mrkdwn',
               text: `:x: Deletion failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          },
+        ],
+      },
+    });
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// STAKEHOLDER MANAGEMENT FLOW
+// ═══════════════════════════════════════════════════════════════════════
+
+interface StakeholderMetadata extends AdminCenterMetadata {
+  currentStakeholderId?: string;
+  currentStakeholderName?: string;
+}
+
+/**
+ * Open Stakeholder Management modal
+ * Shows current stakeholder (if any) and allows designate/change/clear.
+ */
+export async function handleStakeholderManage({
+  ack,
+  body,
+  client,
+}: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs): Promise<void> {
+  await ack();
+
+  const userId = body.user.id;
+  const metadata: AdminCenterMetadata = JSON.parse((body as any).view?.private_metadata || '{}');
+
+  try {
+    // Verify ownership (double-check, though modal should only be shown to owners)
+    await assertProjectOwner(userId, metadata.projectId);
+
+    // Get current stakeholder if any
+    const currentStakeholder = await getProjectStakeholder(metadata.projectId);
+    let stakeholderInfo: StakeholderInfo = null;
+
+    if (currentStakeholder) {
+      // Resolve display name
+      let displayName = currentStakeholder.user_id;
+      try {
+        const userInfo = await client.users.info({ user: currentStakeholder.user_id });
+        const user = userInfo.user as Record<string, unknown> | undefined;
+        const profile = user?.profile as Record<string, unknown> | undefined;
+        displayName = (user?.real_name || profile?.display_name || user?.name || currentStakeholder.user_id) as string;
+      } catch {
+        displayName = `<@${currentStakeholder.user_id}>`;
+      }
+      stakeholderInfo = { userId: currentStakeholder.user_id, displayName };
+    }
+
+    const extendedMetadata: StakeholderMetadata = {
+      ...metadata,
+      currentStakeholderId: stakeholderInfo?.userId,
+      currentStakeholderName: stakeholderInfo?.displayName,
+    };
+
+    // Build modal based on whether stakeholder exists
+    const blocks: Record<string, unknown>[] = [];
+
+    if (stakeholderInfo) {
+      // Current stakeholder exists - show them and offer change/clear
+      blocks.push(
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*Current Stakeholder:* ${stakeholderInfo.displayName}\n\nThe stakeholder approves research briefs for this project.`,
+          },
+        },
+        { type: 'divider' },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*Change stakeholder:*',
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'new_stakeholder_block',
+          optional: true,
+          label: { type: 'plain_text', text: 'Select new stakeholder' },
+          element: {
+            type: 'users_select',
+            action_id: 'new_stakeholder_select',
+            placeholder: { type: 'plain_text', text: 'Select a team member...' },
+          },
+        },
+        { type: 'divider' },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*Or clear stakeholder:*\n_Brief approvals will route to the project owner instead._',
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'clear_stakeholder_block',
+          optional: true,
+          label: { type: 'plain_text', text: 'Clear current stakeholder?' },
+          element: {
+            type: 'checkboxes',
+            action_id: 'clear_stakeholder_check',
+            options: [
+              {
+                text: { type: 'plain_text', text: 'Remove stakeholder (approvals go to owner)' },
+                value: 'clear',
+              },
+            ],
+          },
+        },
+      );
+    } else {
+      // No stakeholder - offer to designate one
+      blocks.push(
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*No stakeholder designated*\n\nBrief approvals currently route to the project owner.\n\nDesignate a stakeholder to receive brief approval requests instead.',
+          },
+        },
+        { type: 'divider' },
+        {
+          type: 'input',
+          block_id: 'new_stakeholder_block',
+          optional: false,
+          label: { type: 'plain_text', text: 'Designate stakeholder' },
+          element: {
+            type: 'users_select',
+            action_id: 'new_stakeholder_select',
+            placeholder: { type: 'plain_text', text: 'Select a team member...' },
+          },
+        },
+      );
+    }
+
+    await client.views.push({
+      trigger_id: (body as any).trigger_id,
+      view: {
+        type: 'modal',
+        callback_id: 'admin-stakeholder-submit',
+        title: { type: 'plain_text', text: 'Manage Stakeholder' },
+        submit: { type: 'plain_text', text: stakeholderInfo ? 'Update' : 'Designate' },
+        close: { type: 'plain_text', text: 'Cancel' },
+        private_metadata: JSON.stringify(extendedMetadata),
+        blocks: blocks as any,
+      },
+    });
+  } catch (error) {
+    console.error('[ADMIN] Error opening stakeholder modal:', error);
+
+    if (error instanceof AuthorizationError) {
+      await client.views.push({
+        trigger_id: (body as any).trigger_id,
+        view: {
+          type: 'modal',
+          callback_id: 'admin-stakeholder-error',
+          title: { type: 'plain_text', text: 'Access Denied' },
+          close: { type: 'plain_text', text: 'Close' },
+          blocks: [
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: ':lock: Only project owners can manage stakeholders.',
+              },
+            },
+          ],
+        },
+      });
+    }
+  }
+}
+
+/**
+ * Handle stakeholder management submission
+ */
+export async function handleStakeholderSubmit({
+  ack,
+  body,
+  view,
+  client,
+}: SlackViewMiddlewareArgs<ViewSubmitAction> & AllMiddlewareArgs): Promise<void> {
+  const userId = body.user.id;
+  const metadata: StakeholderMetadata = JSON.parse(view.private_metadata || '{}');
+
+  // Parse form values
+  const newStakeholderId =
+    (view.state.values as any).new_stakeholder_block?.new_stakeholder_select?.selected_user || null;
+  const clearChecked =
+    ((view.state.values as any).clear_stakeholder_block?.clear_stakeholder_check?.selected_options || [])
+      .some((opt: any) => opt.value === 'clear');
+
+  // Validate: can't both select new and clear
+  if (newStakeholderId && clearChecked) {
+    await ack({
+      response_action: 'errors',
+      errors: { clear_stakeholder_block: 'Cannot both select a new stakeholder and clear. Choose one.' },
+    });
+    return;
+  }
+
+  // If no stakeholder exists and no new one selected, error
+  if (!metadata.currentStakeholderId && !newStakeholderId) {
+    await ack({
+      response_action: 'errors',
+      errors: { new_stakeholder_block: 'Please select a stakeholder' },
+    });
+    return;
+  }
+
+  // If stakeholder exists but neither change nor clear selected, just close
+  if (metadata.currentStakeholderId && !newStakeholderId && !clearChecked) {
+    await ack();
+    return;
+  }
+
+  try {
+    // Verify ownership
+    await assertProjectOwner(userId, metadata.projectId);
+
+    console.log(`[ADMIN] Stakeholder submit: newStakeholderId=${newStakeholderId}, clearChecked=${clearChecked}, currentStakeholder=${metadata.currentStakeholderId}`);
+
+    if (clearChecked && metadata.currentStakeholderId) {
+      // Clear stakeholder flag (doesn't affect role — owner stays owner)
+      await setProjectStakeholder(metadata.projectId, null);
+    } else if (newStakeholderId) {
+      // Set new stakeholder (clears old, sets flag on new — doesn't affect roles)
+      await setProjectStakeholder(metadata.projectId, newStakeholderId);
+    }
+
+    // Fetch updated stakeholder for confirmation display
+    const updatedStakeholder = await getProjectStakeholder(metadata.projectId);
+    let stakeholderInfo: StakeholderInfo = null;
+
+    if (updatedStakeholder) {
+      let displayName = updatedStakeholder.user_id;
+      try {
+        const userInfo = await client.users.info({ user: updatedStakeholder.user_id });
+        const user = userInfo.user as Record<string, unknown> | undefined;
+        const profile = user?.profile as Record<string, unknown> | undefined;
+        displayName = (user?.real_name || profile?.display_name || user?.name || updatedStakeholder.user_id) as string;
+      } catch {
+        displayName = `<@${updatedStakeholder.user_id}>`;
+      }
+      stakeholderInfo = { userId: updatedStakeholder.user_id, displayName };
+    }
+
+    // Close the modal stack - change is complete
+    await ack({ response_action: 'clear' });
+
+    // Send confirmation via DM to the user who made the change
+    const confirmMessage = clearChecked
+      ? `Stakeholder cleared for *${metadata.projectName}*. Brief approvals will now route to the project owner.`
+      : stakeholderInfo
+        ? `*${stakeholderInfo.displayName}* is now the stakeholder for *${metadata.projectName}*.`
+        : `Stakeholder updated for *${metadata.projectName}*.`;
+
+    try {
+      await client.chat.postMessage({
+        channel: userId,
+        text: `:white_check_mark: ${confirmMessage}`,
+      });
+    } catch {
+      // DM failed, not critical
+    }
+
+    // Notify the new stakeholder (if one was assigned, not cleared)
+    if (stakeholderInfo && stakeholderInfo.userId !== userId) {
+      // Get the assigner's display name
+      let assignerName = userId;
+      try {
+        const assignerInfo = await client.users.info({ user: userId });
+        const assigner = assignerInfo.user as Record<string, unknown> | undefined;
+        const assignerProfile = assigner?.profile as Record<string, unknown> | undefined;
+        assignerName = (assigner?.real_name || assignerProfile?.display_name || assigner?.name || userId) as string;
+      } catch {
+        assignerName = `<@${userId}>`;
+      }
+
+      try {
+        await client.chat.postMessage({
+          channel: stakeholderInfo.userId,
+          text: `:clipboard: *${assignerName}* assigned you as stakeholder for *${metadata.projectName}*. You'll receive brief approval requests for studies in this project.`,
+        });
+      } catch {
+        // DM to stakeholder failed, not critical
+      }
+    }
+
+    console.log(`[ADMIN] Stakeholder submit: completed, modal closed`);
+  } catch (error) {
+    console.error('[ADMIN] Error updating stakeholder:', error);
+
+    await ack({
+      response_action: 'update',
+      view: {
+        type: 'modal',
+        callback_id: 'admin-stakeholder-error',
+        title: { type: 'plain_text', text: 'Update Failed' },
+        close: { type: 'plain_text', text: 'Close' },
+        blocks: [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `:x: Failed to update stakeholder: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           },
         ],

--- a/backend/src/helpers/slack/commands/admin/adminCenterHandler.ts
+++ b/backend/src/helpers/slack/commands/admin/adminCenterHandler.ts
@@ -6,8 +6,8 @@
  */
 
 import type { AllMiddlewareArgs, SlackCommandMiddlewareArgs } from '@slack/bolt';
-import { isProjectOwner, isProjectMember } from '../../../../services/authorization.service';
-import { buildAdminCenterModal, buildNonOwnerModal } from '../../ui/adminCenterModal';
+import { isProjectOwner, isProjectMember, getProjectStakeholder } from '../../../../services/authorization.service';
+import { buildAdminCenterModal, buildNonOwnerModal, type StakeholderInfo } from '../../ui/adminCenterModal';
 import sequelize from '../../../../database';
 
 import type { Project } from '../../../../database/models/project';
@@ -52,9 +52,26 @@ export async function adminCenterCommandHandler({
 
     // 3. Open appropriate modal
     if (userIsOwner) {
+      // Fetch current stakeholder for display
+      let stakeholder: StakeholderInfo = null;
+      const stakeholderMember = await getProjectStakeholder(project.id);
+      if (stakeholderMember) {
+        // Resolve display name
+        let displayName = stakeholderMember.user_id;
+        try {
+          const userInfo = await client.users.info({ user: stakeholderMember.user_id });
+          const user = userInfo.user as Record<string, unknown> | undefined;
+          const profile = user?.profile as Record<string, unknown> | undefined;
+          displayName = (user?.real_name || profile?.display_name || user?.name || stakeholderMember.user_id) as string;
+        } catch {
+          displayName = `<@${stakeholderMember.user_id}>`;
+        }
+        stakeholder = { userId: stakeholderMember.user_id, displayName };
+      }
+
       await client.views.open({
         trigger_id: command.trigger_id,
-        view: buildAdminCenterModal(project),
+        view: buildAdminCenterModal(project, stakeholder),
       });
     } else {
       // Check if at least a member (for context)

--- a/backend/src/helpers/slack/commands/briefHandler.ts
+++ b/backend/src/helpers/slack/commands/briefHandler.ts
@@ -26,7 +26,8 @@ import type { VariableContext } from '../../studyVariables';
 import { processYamlTemplate } from '../../yamlProcessor';
 import { executeAiGenerationTasks } from '../../langchain';
 import { addStudyStatus } from '../../../services/study-status.service';
-import { sendStudyResultMessage, generateStudyResultBlocks } from '../ui/studyResultBlocks';
+import { getProjectApprover } from '../../../services/authorization.service';
+import { generateStudyResultBlocks, sendStudyResultMessage } from '../ui/studyResultBlocks';
 import { loadDiscoveryArtifacts, aggregateDiscoveryVariables, type DiscoveryArtifact } from '../../discoveryLoader';
 import { parseBudget, parseParticipantTarget } from '../../../utils/budgetParser';
 import {
@@ -220,12 +221,6 @@ async function handleBriefSubmission({ ack, body, view, client }: SlackViewMiddl
     return;
   }
 
-  // Resolve target channel: project's bound channel takes priority over trigger channel
-  // This ensures success messages land in the project's dedicated channel, not where
-  // the modal was triggered from (which may be a different project's channel).
-  const projectForChannel = await getProjectById(projectId);
-  const targetChannel = projectForChannel?.channel_id || channelId;
-
   // Helper function to extract values from different input types.
   const extract = (blockId: string, actionId: string): unknown => {
     const block = values[blockId];
@@ -244,14 +239,12 @@ async function handleBriefSubmission({ ack, body, view, client }: SlackViewMiddl
 
   console.log(`🚀 ~ Research Brief ~ studyName: ${studyName} (from project: ${projectName})`);
 
-  // Post "Generating..." progress message to project's bound channel
-  let progressTs: string | undefined;
+  // Post "working" message to researcher's DM (consistent with completion DM)
   try {
-    const progressResult = await client.chat.postMessage({
-      channel: targetChannel,
-      text: `:hourglass_flowing_sand: Creating research brief for *${studyName}*...`,
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: `:hourglass_flowing_sand: Creating research brief for *${studyName}*... This may take a moment.`,
     });
-    progressTs = progressResult.ts;
   } catch (err) {
     const progressErr = err instanceof Error ? err.message : String(err);
     console.warn('Could not post brief progress message:', progressErr);
@@ -547,30 +540,45 @@ async function handleBriefSubmission({ ack, body, view, client }: SlackViewMiddl
 
   const url: string = renderedYaml.result.url;
 
-  // Update progress message → completion (in project's bound channel)
-  if (progressTs) {
-    try {
-      await client.chat.update({
-        channel: targetChannel,
-        ts: progressTs,
-        text: `:memo: Research brief for *${studyName}* is ready — <${url}|view on GitHub>`,
-      });
-    } catch (err) {
-      const updateErr = err instanceof Error ? err.message : String(err);
-      console.warn('Could not update brief progress message:', updateErr);
-    }
+  // ── Send brief approval request to stakeholder (or owner fallback) ──
+  // This is the CRITICAL approval routing that was missing
+  const briefBlocks = generateStudyResultBlocks(studyName, study, url, channelId || '', 'brief');
+  await sendStudyResultMessage(client, channelId || '', studyName, briefBlocks, 'brief');
+
+  // ── Update brief status to pending_approval ──
+  const approverInfo = await getProjectApprover(projectId);
+  try {
+    await study.update({
+      brief_status: 'pending_approval',
+      brief_reviewer_id: approverInfo?.userId || null,
+    });
+    console.log(`📋 Brief status set to pending_approval, reviewer: ${approverInfo?.userId || 'none'}`);
+  } catch (updateErr) {
+    console.error('Failed to update brief status:', updateErr);
+    // Non-fatal: brief was created, just status tracking failed
   }
 
-  const blocks = generateStudyResultBlocks(studyName, study, url, targetChannel, 'brief');
-  await sendStudyResultMessage(client, targetChannel, studyName, blocks, 'brief');
-
-  // Notify researcher via DM
+  // ── Notify researcher via DM with specific approver info ──
   try {
+    let approverDisplay = 'the project owner';
+    let approverRole = 'owner';
+    if (approverInfo) {
+      approverRole = approverInfo.source === 'stakeholder' ? 'stakeholder' : 'owner';
+      try {
+        const userInfo = await client.users.info({ user: approverInfo.userId });
+        const user = userInfo.user as Record<string, unknown> | undefined;
+        const profile = user?.profile as Record<string, unknown> | undefined;
+        approverDisplay = (user?.real_name || profile?.display_name || user?.name || `<@${approverInfo.userId}>`) as string;
+      } catch {
+        approverDisplay = `<@${approverInfo.userId}>`;
+      }
+    }
+
     const im = await client.conversations.open({ users: body.user.id });
     if (im.channel?.id) {
       await client.chat.postMessage({
         channel: im.channel.id,
-        text: `✅ *Research Brief Created*\n\n*Study:* ${studyName}\n*View:* <${url}|GitHub>\n\nThe brief has been sent to the study team for approval.\n\n*Next:* Run \`/qori-plan\` to create an execution plan once approved.`,
+        text: `✅ *Research Brief Created*\n\n*Study:* ${studyName}\n*View:* <${url}|GitHub>\n\nBrief sent to *${approverDisplay}* (${approverRole}) for approval.\n\n*Next:* Run \`/qori-plan\` to create an execution plan once approved.`,
       });
     }
   } catch (error) {

--- a/backend/src/helpers/slack/commands/discoverHandler.ts
+++ b/backend/src/helpers/slack/commands/discoverHandler.ts
@@ -316,8 +316,9 @@ async function discoverHandler({ ack, body, client, command }: SlackCommandMiddl
     const message = err instanceof Error ? err.message : String(err);
     const detail = (err as Record<string, unknown>)?.data ?? message;
     console.error('Error opening discover hub:', detail);
-    await client.chat.postMessage({
+    await client.chat.postEphemeral({
       channel: channelId,
+      user: command.user_id,
       text: '❌ Failed to open the discovery hub. Please try again.',
     });
   }
@@ -377,12 +378,10 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
   const { channelId, projectId, projectSlug, discoveryType } = meta;
   const userId: string = body.user?.id || '';
 
-  const replyChannel: string = channelId || userId;
-
   // Validate project context (Phase 2D)
   if (!projectId || !projectSlug) {
     await client.chat.postMessage({
-      channel: replyChannel,
+      channel: userId,
       text: '❌ Project context missing. Please run `/qori-discover` from a project-linked channel.',
     });
     return;
@@ -391,7 +390,7 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
   // Read discovery type from private_metadata (set by action handler)
   if (!discoveryType || !DISCOVERY_TYPES[discoveryType as DiscoveryTypeKey]) {
     await client.chat.postMessage({
-      channel: replyChannel,
+      channel: userId,
       text: '❌ Discovery type missing. Please try again from /qori-discover.',
     });
     return;
@@ -413,7 +412,7 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
   // Validate required fields
   if (!topic) {
     await client.chat.postMessage({
-      channel: replyChannel,
+      channel: userId,
       text: '❌ Topic is required for discovery research.',
     });
     return;
@@ -421,7 +420,7 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
 
   if (!slugifyTopic(topic)) {
     await client.chat.postMessage({
-      channel: replyChannel,
+      channel: userId,
       text: '❌ Topic must contain alphanumeric characters.',
     });
     return;
@@ -429,7 +428,7 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
 
   if (uploadedFiles.length === 0) {
     await client.chat.postMessage({
-      channel: replyChannel,
+      channel: userId,
       text: '❌ Please upload at least one file to analyze.',
     });
     return;
@@ -455,7 +454,7 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
   console.log(`🔍 Discovery: project=${projectSlug}, type=${discoveryType}, topic="${topic}", slug="${topicSlug}", files=${uploadedFiles.length}`);
 
   await client.chat.postMessage({
-    channel: replyChannel,
+    channel: userId,
     text: `🔍 Running ${typeConfig.label} for "${topic}"... This may take a minute.`,
   });
 
@@ -473,7 +472,7 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
     const validation: ValidationResult = validateDocuments(documents);
     if (!validation.isValid) {
       await client.chat.postMessage({
-        channel: replyChannel,
+        channel: userId,
         text: `❌ ${validation.message}`,
       });
       return;
@@ -517,7 +516,7 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
 
     // Stakeholder-specific fields
     if (discoveryType === 'stakeholder_synthesis') {
-      data.study_channel = replyChannel;
+      data.study_channel = channelId || userId;
       data.researcher_contact = `<@${userId}>`;
       data.detected_files = documents.map(d => d.name).join('\n- ');
       (data as any).file_list = documents.map(d => d.name);
@@ -554,7 +553,7 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
       || 'Run `/qori-brief` to start your study.';
 
     await client.chat.postMessage({
-      channel: replyChannel,
+      channel: userId,
       blocks: [
         {
           type: 'section',
@@ -600,7 +599,7 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
     const message = error instanceof Error ? error.message : String(error);
     console.error('Error processing discovery:', error);
     await client.chat.postMessage({
-      channel: replyChannel,
+      channel: userId,
       text: `❌ Error running ${typeConfig.label}: ${message}\n\nPlease try again or contact support.`,
     });
   }

--- a/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
+++ b/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
@@ -17,11 +17,9 @@ import type { View } from '@slack/types';
 
 import { getConfigRepo, YAML_TEMPLATE_PATH, fetchFileFromRepo } from '../../../github';
 import { getStudyById } from '../../../../services/research_study.service';
-import { getProjectById } from '../../../../services/project.service';
 import { assertStudyAccess } from '../../../../services/authorization.service';
 import { processYamlTemplate } from '../../../yamlProcessor';
 import { addStudyStatus } from '../../../../services/study-status.service';
-import { sendStudyResultMessage, generateStudyResultBlocks } from '../../ui/studyResultBlocks';
 import { readStudyVariablesByContext, type VariableContext } from '../../../studyVariables';
 import { buildCascadeReadiness, buildCascadeBlocks } from '../../ui/cascadeReadinessBlocks';
 import {
@@ -383,12 +381,6 @@ async function handleDiscussionGuideSubmission({ ack, body, view, client }: Slac
   // Build VariableContext from validated metadata
   const variableContext: VariableContext = { projectId, studyId };
 
-  // Resolve target channel: project's bound channel takes priority over trigger channel
-  // This ensures success messages land in the project's dedicated channel, not where
-  // the modal was triggered from (which may be a different project's channel).
-  const projectForChannel = await getProjectById(projectId);
-  const targetChannel = projectForChannel?.channel_id || channelId;
-
   const extract = (blockId: string, actionId: string): string | null => {
     const block = values[blockId];
     if (!block) return null;
@@ -415,14 +407,12 @@ async function handleDiscussionGuideSubmission({ ack, body, view, client }: Slac
     }
   }
 
-  // Post "Generating..." progress message to project's bound channel
-  let progressTs: string | undefined;
+  // Post "working" message to researcher's DM (consistent with completion DM)
   try {
-    const progressResult = await client.chat.postMessage({
-      channel: targetChannel,
-      text: `:hourglass_flowing_sand: Generating discussion guide for *${studyName}*...`,
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: `:hourglass_flowing_sand: Generating discussion guide for *${studyName}*... This may take a moment.`,
     });
-    progressTs = progressResult.ts;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.warn('Could not post progress message:', message);
@@ -444,22 +434,19 @@ async function handleDiscussionGuideSubmission({ ack, body, view, client }: Slac
 
   const url: string = renderedYaml.result.url;
 
-  // Update progress message → completion notification (in project's bound channel)
-  if (progressTs) {
-    try {
-      await client.chat.update({
-        channel: targetChannel,
-        ts: progressTs,
-        text: `:speech_balloon: Discussion guide for *${studyName}* is ready — <${url}|view on GitHub>`,
+  // Notify researcher via DM (primary notification — no channel posting)
+  try {
+    const im = await client.conversations.open({ users: body.user.id });
+    if (im.channel?.id) {
+      await client.chat.postMessage({
+        channel: im.channel.id,
+        text: `✅ *Discussion Guide Created*\n\n*Study:* ${studyName}\n*View:* <${url}|GitHub>\n\n*Next:* Run \`/qori-fieldwork\` to manage participants and outreach, or \`/qori-analyze\` after sessions complete.`,
       });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.warn('Could not update progress message:', message);
     }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('Failed to send discussion guide DM:', message);
   }
-
-  const blocks = generateStudyResultBlocks(studyName, study, url, targetChannel, 'discussion');
-  await sendStudyResultMessage(client, targetChannel, studyName, blocks, 'discussion');
 
   await addStudyStatus({
     study_id: studyId,

--- a/backend/src/helpers/slack/commands/participantOutreachHandler.ts
+++ b/backend/src/helpers/slack/commands/participantOutreachHandler.ts
@@ -1091,8 +1091,8 @@ async function handleAddParticipantSubmit({ ack, body, view, client }: SlackView
     const savedParticipant = await studyParticipantService.createParticipant(participantData, fileData as any);
     console.log("🚀 ~ handleAddParticipantSubmit ~ savedParticipant:", savedParticipant);
 
-    // Check if this participant brings the total to 3 and send milestone message
-    const milestoneCheck = await studyParticipantService.checkStudyMilestone(study.id);
+    // Check if this participant brings the total to 5 and send milestone message
+    const milestoneCheck = await studyParticipantService.checkStudyMilestone(study.id, 5);
     const githubUrl = `https://github.com/${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}/tree/main/${study.path}/03-fieldwork/${study.name}_participant_tracker.md`;
     if (milestoneCheck.hasReachedMilestone) {
       // Generate a milestone message for the channel
@@ -1135,6 +1135,7 @@ async function handleAddParticipantSubmit({ ack, body, view, client }: SlackView
           }
         ]
       };
+      // Observer recruitment CTA posts to channel intentionally (recruiting observers)
       await client.chat.postMessage({
         channel: channelId,
         ...milestoneMessage

--- a/backend/src/helpers/slack/commands/planHandler.ts
+++ b/backend/src/helpers/slack/commands/planHandler.ts
@@ -20,10 +20,8 @@ import type { ResearchQuestion, TargetBarrier } from '../../../types/cascade';
 
 import { getConfigRepo, YAML_TEMPLATE_PATH, fetchFileFromRepo } from '../../github';
 import { getStudyById } from '../../../services/research_study.service';
-import { getProjectById } from '../../../services/project.service';
 import { processYamlTemplate } from '../../yamlProcessor';
 import { addStudyStatus } from '../../../services/study-status.service';
-import { sendStudyResultMessage, generateStudyResultBlocks } from '../ui/studyResultBlocks';
 import { calculatePerPersonCompensation } from '../../../utils/compensationCalculator';
 import { buildTimelinePhases, buildTimelineSummary, type TimelinePhase } from '../../../utils/timelineComputation';
 import { readUpstreamVariablesByContext, type VariableContext } from '../../studyVariables';
@@ -86,6 +84,17 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
 
   console.log('🚀 ~ Research Plan Generator ~ studyName:', studyName, 'studyId:', studyId, 'projectId:', projectId);
 
+  // Post "working" message to researcher's DM (consistent with completion DM)
+  try {
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: `:hourglass_flowing_sand: Creating research plan for *${studyName}*... This may take a moment.`,
+    });
+  } catch (err) {
+    const progressErr = err instanceof Error ? err.message : String(err);
+    console.warn('Could not post plan progress message:', progressErr);
+  }
+
   // Fetch study by ID (not name) — Phase 2D pattern
   const study = await getStudyById(studyId);
   if (!study) {
@@ -115,12 +124,6 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
 
   // Build VariableContext from validated metadata
   const variableContext: VariableContext = { projectId, studyId };
-
-  // Resolve target channel: project's bound channel takes priority over trigger channel
-  // This ensures success messages land in the project's dedicated channel, not where
-  // the modal was triggered from (which may be a different project's channel).
-  const projectForChannel = await getProjectById(projectId);
-  const targetChannel = projectForChannel?.channel_id || channelId;
 
   // Form extraction helper — Bolt's view state values are loosely typed
   const extract = (blockId: string, actionId: string): string | string[] | null => {
@@ -261,10 +264,8 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
     created_by: userId || body.user.id,
   };
   await research_planService.createResearchPlan(planData);
-  const blocks = generateStudyResultBlocks(studyName, study, url, targetChannel, 'plan');
-  await sendStudyResultMessage(client, targetChannel, studyName, blocks, 'plan');
 
-  // Send DM with next-step suggestion
+  // Notify researcher via DM (primary notification — no channel posting)
   const dmUserId = userId || body.user.id;
   try {
     const im = await client.conversations.open({ users: dmUserId });

--- a/backend/src/helpers/slack/commands/projectStartHandler.ts
+++ b/backend/src/helpers/slack/commands/projectStartHandler.ts
@@ -12,6 +12,7 @@ import type { WebClient } from '@slack/web-api';
 
 import { createProjectFromName, bindProjectToChannel } from '../../../services/project.service';
 import { scaffoldProject } from '../../../services/scaffolding.service';
+import { addProjectMember, setProjectStakeholder } from '../../../services/authorization.service';
 import { projectCreationModal, type ProjectCreationModalMetadata } from '../ui/projectCreationModal';
 
 // ─── Channel naming utilities ────────────────────────────────────
@@ -112,6 +113,10 @@ async function handleProjectCreateSubmission({ ack, body, view, client }: SlackV
     (opt: { value: string }) => opt.value === 'create_channel'
   );
 
+  // Extract stakeholder (optional — owner is fallback approver)
+  const stakeholderUserId: string | null =
+    values.project_stakeholder?.stakeholder_select?.selected_user || null;
+
   // Validate project name
   if (!projectName) {
     await ack({
@@ -143,6 +148,15 @@ async function handleProjectCreateSubmission({ ack, body, view, client }: SlackV
       created_by: body.user.id,
       status: 'active',
     });
+
+    // Add creator as project owner
+    await addProjectMember(project.id, body.user.id, 'creator', 'owner');
+
+    // Set stakeholder if provided (can be same as owner — flag doesn't affect role)
+    if (stakeholderUserId) {
+      await setProjectStakeholder(project.id, stakeholderUserId);
+      console.log(`✅ Set stakeholder ${stakeholderUserId} for project ${project.slug}`);
+    }
 
     // Scaffold project folder in GitHub with README
     // Phase B-0.5: Uses scaffolding service instead of inline README creation

--- a/backend/src/helpers/slack/commands/researchSynthesisHandler.ts
+++ b/backend/src/helpers/slack/commands/researchSynthesisHandler.ts
@@ -563,35 +563,7 @@ const handleResearchSynthesisSubmission = async ({ ack, body, view, client }: Sl
         ],
       });
 
-      if (study?.channel_name) {
-        await client.chat.postMessage({
-          channel: study.channel_name,
-          text: `*Research Synthesis Complete!*`,
-          blocks: [
-            {
-              type: 'section',
-              text: {
-                type: 'mrkdwn',
-                text: firstTwoLines,
-              },
-            },
-            {
-              type: 'section',
-              text: {
-                type: 'mrkdwn',
-                text: `*Study:* ${selectedStudyName}\n*Method:* ${analysisMethod.replace(/_/g, ' ')}`,
-              },
-            },
-            {
-              type: 'section',
-              text: {
-                type: 'mrkdwn',
-                text: `To see the complete synthesis and detailed insights, please visit:\n<${renderedAnalysis.result.url}|:github: View Full Analysis on GitHub>`,
-              },
-            },
-          ],
-        });
-      }
+      // Channel notification removed — DM notification above is sufficient
 
     } catch (error) {
       const errObj = error instanceof Error ? error : new Error(String(error));

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -37,6 +37,8 @@ import {
   handleDeleteStudyOpen,
   handleDeleteStudySelect,
   handleDeleteStudyConfirm,
+  handleStakeholderManage,
+  handleStakeholderSubmit,
 } from './commands/admin/adminActionsHandler';
 
 // Research brief
@@ -50,9 +52,10 @@ import { handlePlanSubmission } from './commands/planHandler';
 // Brief → plan/study transitions
 import { openPlanFromBrief } from './commands/modal-openers/briefToStudyHandler';
 
-// Approval flows
-import { handleApprovePlan as approvePlan, handleConfirmApprovePlan as confirmApprovePlan, handleRequestChangesPlan as requestChangesPlan, handleRequestChangesPlanModal as requestChangesPlanSubmission, handleApproveBrief as approveBrief, handleConfirmApproveBrief as confirmApproveBrief, handleRequestChangesBrief as requestChangesBrief, handleRequestChangesBriefModal as requestChangesBriefSubmission } from './commands/approval/approvalFlowHandler';
+// Approval flows (plan approval removed — brief is the only gate)
+import { handleApproveBrief as approveBrief, handleConfirmApproveBrief as confirmApproveBrief, handleRequestChangesBrief as requestChangesBrief, handleRequestChangesBriefModal as requestChangesBriefSubmission } from './commands/approval/approvalFlowHandler';
 import { handleMarkChangesCompleteAction, handleMarkChangesCompleteModal, handleApproveChanges } from './markChangesCompleteHandler';
+import { handleBriefResubmit } from './resubmitBriefHandler';
 
 // Discussion guide
 import { openDiscussionGuideModal, handleDiscussionGuideSubmission } from './commands/discussion-guide/discussionGuideHandler';
@@ -362,6 +365,7 @@ slackApp.command('/qori-brief', async ({ ack, client, command }) => {
       projectName: project.name,
       projectSlug: project.slug,
       source: 'qori_brief_command',
+      client,
     });
     // @ts-expect-error — modal blocks are Record<string,unknown>[] from JSON.parse; structurally valid at runtime
     await client.views.open({ trigger_id: command.trigger_id, view: modal });
@@ -430,6 +434,10 @@ slackApp.view('admin-dsar-delete-confirm', handleDsarDeleteConfirm);
 slackApp.view('admin-delete-study-select', handleDeleteStudySelect);
 slackApp.view('admin-delete-study-confirm', handleDeleteStudyConfirm);
 
+// Stakeholder management
+slackApp.action('admin-stakeholder-manage', handleStakeholderManage);
+slackApp.view('admin-stakeholder-submit', handleStakeholderSubmit);
+
 // ─── Research brief ─────────────────────────────────────────────
 
 slackApp.action('create_research_brief', openResearchBriefModal);
@@ -446,15 +454,13 @@ slackApp.view('research_plan_modal', handlePlanSubmission);
 slackApp.action('create_research_plan_from_brief', openPlanFromBrief);
 
 // ─── Approval flows ────────────────────────────────────────────
+// Plan approval removed — brief (scope) is the only approval gate.
 
-slackApp.action('approve_plan', approvePlan);
-slackApp.view('confirm_approve_plan', confirmApprovePlan);
-slackApp.action('request_changes_plan', requestChangesPlan);
-slackApp.view('request_changes_plan_modal', requestChangesPlanSubmission);
 slackApp.action('approve_brief', approveBrief);
 slackApp.view('confirm_approve_brief', confirmApproveBrief);
 slackApp.action('request_changes_brief', requestChangesBrief);
 slackApp.view('request_changes_brief_modal', requestChangesBriefSubmission);
+slackApp.action('brief_resubmit', handleBriefResubmit);
 slackApp.action('mark_changes_complete', handleMarkChangesCompleteAction);
 slackApp.view('mark_changes_complete_modal', handleMarkChangesCompleteModal);
 slackApp.action('approve_changes', handleApproveChanges);

--- a/backend/src/helpers/slack/requestChangesHandler.ts
+++ b/backend/src/helpers/slack/requestChangesHandler.ts
@@ -6,8 +6,12 @@ import { requestStudyChangesModal } from './ui/requestStudyChangesModal';
 // resolveStudyFromName retained for other flows (request changes, non-brief approvals) — migrate in future step
 import { getStudyByProjectAndName, resolveStudyFromName } from '../../services/research_study.service';
 import { getProjectByChannelId } from '../../services/project.service';
+import sequelize from '../../database';
+import type { ResearchStudy as ResearchStudyModel } from '../../database/models/research_study';
 
 import { addStudyStatus, getStudyStatusByStudyId } from '../../services/study-status.service';
+
+const ResearchStudyModelClass = sequelize.models.ResearchStudy as typeof ResearchStudyModel;
 
 type DocumentType = 'plan' | 'brief' | 'discussion';
 
@@ -58,6 +62,32 @@ export async function handleApprove(
   const { studyName, channelId, url, briefData } = JSON.parse(
     (body.actions[0] as { value: string }).value,
   ) as ActionValue;
+
+  // ── Stale button guard for briefs ──
+  if (type === 'brief') {
+    const project = await getProjectByChannelId(channelId);
+    if (project) {
+      const study = await getStudyByProjectAndName(project.id, studyName);
+      if (study?.brief_status === 'approved') {
+        // Already approved — stale button
+        await client.chat.postEphemeral({
+          channel: body.channel?.id || body.user.id,
+          user: body.user.id,
+          text: `This brief has already been approved. No action needed.`,
+        });
+        return;
+      }
+      if (study?.brief_status === 'changes_requested') {
+        // Waiting for researcher resubmit — can't approve old version
+        await client.chat.postEphemeral({
+          channel: body.channel?.id || body.user.id,
+          user: body.user.id,
+          text: `You've already requested changes on this brief. Wait for the researcher to resubmit.`,
+        });
+        return;
+      }
+    }
+  }
 
   await client.views.open({
     trigger_id: body.trigger_id,
@@ -112,6 +142,28 @@ export async function handleApproveSubmission(
       if (study && study.path) {
         existingStudy = study as unknown as ResearchStudy;
         studyId = study.id;
+
+        // ── STALE BUTTON GUARD: Check current status before approving ──
+        if (study.brief_status === 'approved') {
+          console.log(`[GUARD] Blocked stale approve: study ${studyId} already approved`);
+          try {
+            await client.chat.postMessage({
+              channel: user,
+              text: `This brief has already been approved. No action needed.`,
+            });
+          } catch { /* DM failed */ }
+          return;
+        }
+        if (study.brief_status === 'changes_requested') {
+          console.log(`[GUARD] Blocked stale approve: study ${studyId} awaiting resubmit`);
+          try {
+            await client.chat.postMessage({
+              channel: user,
+              text: `You've already requested changes on this brief. Wait for the researcher to resubmit before approving.`,
+            });
+          } catch { /* DM failed */ }
+          return;
+        }
       }
     }
   } else {
@@ -131,75 +183,77 @@ export async function handleApproveSubmission(
   });
 
   if (type === 'brief') {
-    const researchTeamChannelId = process.env.RESEARCH_TEAM_CHANNEL_ID || channelId;
-
-    // Study always exists at brief-approval time (created via /qori-start).
+    // Brief approval: DM only — no channel posts
     // Guard against missing context (edge case: old brief buttons before Phase 2D).
     if (!studyId || !projectId) {
       console.error(`❌ Brief approval missing context: studyId=${studyId}, projectId=${projectId}`);
-      await client.chat.postMessage({
-        channel: researchTeamChannelId,
-        text: `✅ *${studyName}* brief approved by <@${user}>.\n\n⚠️ Cannot offer "Create Research Plan" button — study context missing. Run \`/qori-plan\` manually.`,
-      });
+      // Still notify researcher via DM
+      if (existingStudy?.created_by) {
+        try {
+          const im = await client.conversations.open({ users: existingStudy.created_by });
+          await client.chat.postMessage({
+            channel: (im.channel as { id: string }).id,
+            text: `✅ *${studyName}* brief approved by <@${user}>.\n\n⚠️ Cannot offer "Create Research Plan" button — study context missing. Run \`/qori-plan\` manually.`,
+          });
+        } catch { /* DM failed, nothing more we can do */ }
+      }
       return;
     }
 
-    const ctaButton = {
-      type: 'button',
-      text: { type: 'plain_text', text: 'Create Research Plan', emoji: true },
-      style: 'primary',
-      action_id: 'create_research_plan_from_brief',
-      value: JSON.stringify({ studyName, studyId, projectId, briefUrl: url, channelId: researchTeamChannelId }),
-    };
-
-    const nextStepText = 'The research brief has been approved. Next step: create the research plan.';
-
+    // ── Update brief_status to approved ──
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const blocks: any[] = [
-        {
-          type: 'header',
-          text: {
-            type: 'plain_text',
-            text: `Research Brief Approved \u2014 ${studyName}`,
-            emoji: true,
-          },
-        },
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: `*Approved by:* <@${user}>\n*Brief:* <${url}|View on GitHub>`,
-          },
-        },
-        {
-          type: 'section',
-          text: { type: 'mrkdwn', text: nextStepText },
-        },
-        {
-          type: 'actions',
-          elements: [ctaButton],
-        },
-      ];
-      await client.chat.postMessage({
-        channel: researchTeamChannelId,
-        text: `*Research Brief Approved*\n\n*Study:* ${studyName}\n*Approved by:* <@${user}>`,
-        blocks,
-      });
-    } catch (err: unknown) {
-      console.error('Failed to send approval message to research team:', err);
-      await client.chat.postMessage({
-        channel: channelId,
-        text: `*${studyName}* ${typeLabelMap[type]} approved by <@${user}>!`,
-      });
+      await ResearchStudyModelClass.update(
+        { brief_status: 'approved' },
+        { where: { id: studyId } },
+      );
+      console.log(`✅ Brief status set to approved for study ${studyId}`);
+    } catch (updateErr) {
+      console.error('Failed to update brief status to approved:', updateErr);
+      // Non-fatal: approval is processed, just status tracking failed
     }
 
+    // Send approval notification to researcher via DM (not channel)
     if (existingStudy && existingStudy.created_by) {
+      const ctaButton = {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Create Research Plan', emoji: true },
+        style: 'primary',
+        action_id: 'create_research_plan_from_brief',
+        value: JSON.stringify({ studyName, studyId, projectId, briefUrl: url, channelId }),
+      };
+
       try {
         const im = await client.conversations.open({ users: existingStudy.created_by });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const blocks: any[] = [
+          {
+            type: 'header',
+            text: {
+              type: 'plain_text',
+              text: `Research Brief Approved — ${studyName}`,
+              emoji: true,
+            },
+          },
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `*Approved by:* <@${user}>\n*Brief:* <${url}|View on GitHub>`,
+            },
+          },
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: 'The research brief has been approved. Next step: create the research plan.' },
+          },
+          {
+            type: 'actions',
+            elements: [ctaButton],
+          },
+        ];
         await client.chat.postMessage({
           channel: (im.channel as { id: string }).id,
           text: `*${studyName}* research brief approved by <@${user}>! You can now create the research plan.`,
+          blocks,
         });
       } catch (err: unknown) {
         console.error('Failed to send DM to study creator:', err);
@@ -234,6 +288,32 @@ export async function handleRequestChanges(
   const { studyName, channelId, url } = JSON.parse(
     (body.actions[0] as { value: string }).value,
   ) as ActionValue;
+
+  // ── Stale button guard for briefs ──
+  if (type === 'brief') {
+    const project = await getProjectByChannelId(channelId);
+    if (project) {
+      const study = await getStudyByProjectAndName(project.id, studyName);
+      if (study?.brief_status === 'approved') {
+        // Already approved — stale button
+        await client.chat.postEphemeral({
+          channel: body.channel?.id || body.user.id,
+          user: body.user.id,
+          text: `This brief has already been approved. No action needed.`,
+        });
+        return;
+      }
+      if (study?.brief_status === 'changes_requested') {
+        // Already requested changes — stale button
+        await client.chat.postEphemeral({
+          channel: body.channel?.id || body.user.id,
+          user: body.user.id,
+          text: `You've already requested changes on this brief. Wait for the researcher to resubmit.`,
+        });
+        return;
+      }
+    }
+  }
 
   let fileOptions: FileOption[] = [];
   try {
@@ -330,21 +410,76 @@ export async function handleRequestChangesSubmission(
   console.log('Raw view.state.values:', Object.keys(values).length, 'blocks');
 
   // Resolve study first to get study_id for addStudyStatus (required by NOT NULL constraint)
-  const resolvedForChanges = await resolveStudyFromName(studyName);
-  const study = resolvedForChanges?.study as unknown as ResearchStudy | null;
+  let studyId: number | undefined;
+  let studyCreatedBy: string | undefined;
+
+  if (type === 'brief') {
+    // Brief: use project-based lookup (consistent with approval flow)
+    const project = await getProjectByChannelId(channelId);
+    if (project) {
+      const study = await getStudyByProjectAndName(project.id, studyName);
+      if (study) {
+        // ── STALE BUTTON GUARD: Check current status before requesting changes ──
+        if (study.brief_status === 'approved') {
+          console.log(`[GUARD] Blocked stale request-changes: study ${study.id} already approved`);
+          try {
+            await client.chat.postMessage({
+              channel: user,
+              text: `This brief has already been approved. No changes can be requested.`,
+            });
+          } catch { /* DM failed */ }
+          return;
+        }
+        if (study.brief_status === 'changes_requested') {
+          console.log(`[GUARD] Blocked stale request-changes: study ${study.id} already awaiting resubmit`);
+          try {
+            await client.chat.postMessage({
+              channel: user,
+              text: `You've already requested changes on this brief. Wait for the researcher to resubmit.`,
+            });
+          } catch { /* DM failed */ }
+          return;
+        }
+
+        studyId = study.id;
+        studyCreatedBy = study.created_by;
+
+        // ── Update brief_status to changes_requested and store feedback ──
+        try {
+          await ResearchStudyModelClass.update(
+            {
+              brief_status: 'changes_requested',
+              brief_change_feedback: changeFeedback,
+            },
+            { where: { id: study.id } },
+          );
+          console.log(`📋 Brief status set to changes_requested, feedback stored for study ${study.id}`);
+        } catch (updateErr) {
+          console.error('Failed to update brief status to changes_requested:', updateErr);
+        }
+      }
+    }
+  } else {
+    // Plan/discussion: use name-based lookup
+    const resolvedForChanges = await resolveStudyFromName(studyName);
+    if (resolvedForChanges?.study) {
+      studyId = resolvedForChanges.studyId;
+      studyCreatedBy = (resolvedForChanges.study as unknown as ResearchStudy).created_by;
+    }
+  }
 
   await addStudyStatus({
-    study_id: study?.id,
+    study_id: studyId,
     requested_by: user,
     status: 'need_changes',
     reason: changeFeedback,
     path: url,
   });
 
-  if (study?.created_by) {
+  if (studyCreatedBy) {
     try {
       const im = await client.conversations.open({
-        users: study.created_by,
+        users: studyCreatedBy,
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const dmBlocks: any[] = [
@@ -391,6 +526,40 @@ export async function handleRequestChangesSubmission(
           },
         },
       ];
+
+      // ── For briefs, add Resubmit CTA button ──
+      if (type === 'brief' && studyId) {
+        dmBlocks.push(
+          {
+            type: 'context',
+            elements: [
+              {
+                type: 'mrkdwn',
+                text: '_Edit the brief directly in GitHub, then click Resubmit when ready for re-review._',
+              },
+            ],
+          },
+          {
+            type: 'actions',
+            elements: [
+              {
+                type: 'button',
+                text: { type: 'plain_text', text: 'Resubmit for Approval', emoji: true },
+                style: 'primary',
+                action_id: 'brief_resubmit',
+                value: JSON.stringify({
+                  studyId,
+                  studyName,
+                  channelId,
+                  url,
+                  documentType: 'brief',
+                }),
+              },
+            ],
+          },
+        );
+      }
+
       await client.chat.postMessage({
         channel: (im.channel as { id: string }).id,
         text: `Changes requested for *${studyName}* ${type} by <@${user}>`,

--- a/backend/src/helpers/slack/resubmitBriefHandler.ts
+++ b/backend/src/helpers/slack/resubmitBriefHandler.ts
@@ -1,0 +1,228 @@
+/**
+ * resubmitBriefHandler.ts — Handle "Resubmit for Approval" button click
+ *
+ * Part of the brief approval review loop:
+ * 1. Researcher edits brief in GitHub
+ * 2. Researcher clicks "Resubmit for Approval" button in DM
+ * 3. Handler flips status to pending_approval
+ * 4. Handler DMs approver with prior feedback context + Approve/Request Changes
+ */
+
+import type { AllMiddlewareArgs, BlockAction, SlackActionMiddlewareArgs } from '@slack/bolt';
+import type { KnownBlock } from '@slack/types';
+import sequelize from '../../database';
+import type { ResearchStudy } from '../../database/models/research_study';
+import { getProjectApprover } from '../../services/authorization.service';
+import { generateStudyResultBlocks } from './ui/studyResultBlocks';
+
+const ResearchStudyModel = sequelize.models.ResearchStudy as typeof ResearchStudy;
+
+interface ResubmitButtonValue {
+  studyId: number;
+  studyName: string;
+  channelId: string;
+  url: string;
+  documentType: 'brief';
+}
+
+/**
+ * Handle "Resubmit for Approval" button click from researcher DM.
+ *
+ * Flow:
+ * 1. Verify brief is in changes_requested state (stale button guard)
+ * 2. Flip brief_status to pending_approval
+ * 3. DM approver with prior feedback context + Approve/Request Changes buttons
+ * 4. Confirm to researcher via ephemeral message
+ */
+export async function handleBriefResubmit({
+  ack,
+  body,
+  client,
+}: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs): Promise<void> {
+  await ack();
+
+  const action = body.actions[0] as { value: string };
+  const { studyId, studyName, channelId, url } = JSON.parse(action.value) as ResubmitButtonValue;
+  const researcherId = body.user.id;
+
+  // ── Fetch study and verify state ──
+  const study = await ResearchStudyModel.findByPk(studyId);
+
+  if (!study) {
+    await client.chat.postEphemeral({
+      channel: body.channel?.id || researcherId,
+      user: researcherId,
+      text: `Could not find study. It may have been deleted.`,
+    });
+    return;
+  }
+
+  // ── Stale button guard ──
+  if (study.brief_status === 'approved') {
+    await client.chat.postEphemeral({
+      channel: body.channel?.id || researcherId,
+      user: researcherId,
+      text: `This brief has already been approved. No resubmission needed.`,
+    });
+    return;
+  }
+
+  if (study.brief_status === 'pending_approval') {
+    await client.chat.postEphemeral({
+      channel: body.channel?.id || researcherId,
+      user: researcherId,
+      text: `This brief is already pending approval. The approver has been notified.`,
+    });
+    return;
+  }
+
+  if (study.brief_status !== 'changes_requested') {
+    await client.chat.postEphemeral({
+      channel: body.channel?.id || researcherId,
+      user: researcherId,
+      text: `This brief is not in a state that requires resubmission.`,
+    });
+    return;
+  }
+
+  // ── Get the prior feedback (for approver context) ──
+  const priorFeedback = study.brief_change_feedback;
+
+  // ── Update status to pending_approval ──
+  try {
+    await study.update({ brief_status: 'pending_approval' });
+    console.log(`📋 Brief resubmitted for study ${studyId}, status: pending_approval`);
+  } catch (updateErr) {
+    console.error('Failed to update brief status on resubmit:', updateErr);
+    await client.chat.postEphemeral({
+      channel: body.channel?.id || researcherId,
+      user: researcherId,
+      text: `Could not resubmit brief. Please try again.`,
+    });
+    return;
+  }
+
+  // ── Get approver (stakeholder → owner fallback) ──
+  const project = await sequelize.models.Project.findOne({
+    where: { id: study.project_id },
+  });
+
+  if (!project) {
+    await client.chat.postEphemeral({
+      channel: body.channel?.id || researcherId,
+      user: researcherId,
+      text: `Brief resubmitted, but could not find project to notify approver.`,
+    });
+    return;
+  }
+
+  const approverInfo = await getProjectApprover(project.get('id') as number);
+
+  if (!approverInfo) {
+    await client.chat.postEphemeral({
+      channel: body.channel?.id || researcherId,
+      user: researcherId,
+      text: `Brief resubmitted, but could not find an approver to notify.`,
+    });
+    return;
+  }
+
+  // ── Build approval message with prior feedback context ──
+  const briefBlocks = generateStudyResultBlocks(studyName, null, url, channelId, 'brief');
+
+  // Add context about resubmission and prior feedback
+  const contextBlocks: Record<string, unknown>[] = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: `📝 Brief Resubmitted — ${studyName}`,
+        emoji: true,
+      },
+    },
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `Resubmitted by <@${researcherId}> for re-review.`,
+        },
+      ],
+    },
+  ];
+
+  // Add prior feedback section if it exists
+  if (priorFeedback) {
+    contextBlocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Your prior feedback:*\n>${priorFeedback}`,
+      },
+    });
+    contextBlocks.push({
+      type: 'divider',
+    });
+  }
+
+  // Add the approval buttons (from briefBlocks, skip the header since we have our own)
+  const approvalButtons = briefBlocks.filter(
+    (block) => (block as { type: string }).type === 'actions' || (block as { type: string }).type === 'section',
+  );
+
+  const fullBlocks = [...contextBlocks, ...approvalButtons];
+
+  // ── DM the approver ──
+  try {
+    const im = await client.conversations.open({ users: approverInfo.userId });
+
+    if (im.channel?.id) {
+      const roleLabel = approverInfo.source === 'stakeholder' ? 'stakeholder' : 'owner';
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const messageBlocks: any[] = [
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: `You're receiving this as the *${roleLabel}* for this project.`,
+            },
+          ],
+        },
+        ...fullBlocks,
+      ];
+
+      await client.chat.postMessage({
+        channel: im.channel.id,
+        text: `📝 Brief resubmitted for *${studyName}* — please re-review`,
+        blocks: messageBlocks as KnownBlock[],
+      });
+
+      console.log(`✅ Resubmission notification sent to ${roleLabel} ${approverInfo.userId}`);
+    }
+  } catch (dmErr) {
+    console.error('Failed to DM approver on brief resubmit:', dmErr);
+  }
+
+  // ── Confirm to researcher ──
+  // Get approver display name
+  let approverDisplay = `<@${approverInfo.userId}>`;
+  try {
+    const userInfo = await client.users.info({ user: approverInfo.userId });
+    const user = userInfo.user as Record<string, unknown> | undefined;
+    const profile = user?.profile as Record<string, unknown> | undefined;
+    approverDisplay = (user?.real_name || profile?.display_name || user?.name || approverDisplay) as string;
+  } catch {
+    // Use mention fallback
+  }
+
+  try {
+    await client.chat.postMessage({
+      channel: researcherId,
+      text: `✅ Brief resubmitted for *${studyName}*. *${approverDisplay}* has been notified for re-review.`,
+    });
+  } catch {
+    // DM to researcher failed, not critical
+  }
+}

--- a/backend/src/helpers/slack/ui/adminCenterModal.ts
+++ b/backend/src/helpers/slack/ui/adminCenterModal.ts
@@ -4,7 +4,7 @@
  * Per ADR 0025: Unified interface for destructive operations,
  * gated to project owners only.
  *
- * Phase 1 ACTIVE: DSAR, Delete Study
+ * Phase 1 ACTIVE: DSAR, Delete Study, Manage Stakeholder
  * Phase 1 PREVIEW (disabled): Close Study, Legal Holds
  */
 
@@ -16,17 +16,29 @@ export interface AdminCenterMetadata {
   projectName: string;
 }
 
+export type StakeholderInfo = {
+  userId: string;
+  displayName: string;
+} | null;
+
 /**
  * Admin Center modal for project owners.
  *
- * Shows active actions (DSAR, Delete Study) and preview actions
+ * Shows active actions (DSAR, Delete Study, Manage Stakeholder) and preview actions
  * (Close Study, Legal Holds) that are visibly disabled.
  */
-export function buildAdminCenterModal(project: Project): View {
+export function buildAdminCenterModal(project: Project, stakeholder: StakeholderInfo): View {
   const metadata: AdminCenterMetadata = {
     projectId: project.id,
     projectName: project.name,
   };
+
+  // Build stakeholder status text
+  const stakeholderText = stakeholder
+    ? `*Stakeholder:* ${stakeholder.displayName}\nApproves research briefs for this project.`
+    : '*Stakeholder:* Not set\n_Brief approvals route to the project owner._';
+
+  const stakeholderButtonText = stakeholder ? 'Change' : 'Designate';
 
   return {
     type: 'modal',
@@ -45,7 +57,41 @@ export function buildAdminCenterModal(project: Project): View {
       },
       { type: 'divider' },
 
-      // === ACTIVE ACTIONS (Phase 1) ===
+      // === TEAM GOVERNANCE ===
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: '*Team Governance*',
+          },
+        ],
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: stakeholderText,
+        },
+        accessory: {
+          type: 'button',
+          text: { type: 'plain_text', text: stakeholderButtonText },
+          action_id: 'admin-stakeholder-manage',
+        },
+      },
+
+      { type: 'divider' },
+
+      // === DATA MANAGEMENT ===
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: '*Data Management*',
+          },
+        ],
+      },
       {
         type: 'section',
         text: {

--- a/backend/src/helpers/slack/ui/projectCreationModal.ts
+++ b/backend/src/helpers/slack/ui/projectCreationModal.ts
@@ -90,6 +90,27 @@ export function projectCreationModal(channelId: string) {
         },
       },
       {
+        type: "input",
+        block_id: "project_stakeholder",
+        optional: true,
+        label: {
+          type: "plain_text",
+          text: "Who approves research briefs for this team?",
+        },
+        hint: {
+          type: "plain_text",
+          text: "The stakeholder who reviews and approves briefs before research begins. Leave blank if you (the owner) will approve.",
+        },
+        element: {
+          type: "users_select",
+          action_id: "stakeholder_select",
+          placeholder: {
+            type: "plain_text",
+            text: "Select a stakeholder",
+          },
+        },
+      },
+      {
         type: "divider",
       },
       {

--- a/backend/src/helpers/slack/ui/requestStudyChangesModal.ts
+++ b/backend/src/helpers/slack/ui/requestStudyChangesModal.ts
@@ -123,14 +123,5 @@ export const requestStudyChangesModal = (fileOptionsArray: FileOption[]) => ({
         },
       ],
     },
-    {
-      type: "context",
-      elements: [
-        {
-          type: "mrkdwn",
-          text: "🎯 A GitHub issue will be created to track these changes and ensure nothing is missed.",
-        },
-      ],
-    },
   ],
 });

--- a/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
+++ b/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
@@ -1,6 +1,8 @@
 import { researchBriefModal } from './researchBriefModal';
 import { loadDiscoveryArtifacts, aggregateDiscoveryVariables, type DiscoveryArtifact } from '../../discoveryLoader';
 import { formatVariableCategories } from '../../cascadeVariableCategories';
+import { getProjectApprover } from '../../../services/authorization.service';
+import type { WebClient } from '@slack/web-api';
 
 // ─── Modal metadata contract ─────────────────────────────────────
 
@@ -27,6 +29,7 @@ interface BuildBriefEntryModalOptions {
   projectName: string;
   projectSlug: string;
   source: 'qori_brief_command' | 'project_next_steps';
+  client: WebClient;
 }
 
 /**
@@ -119,7 +122,7 @@ function synthesizeCascadeFields(upstream: Record<string, string>, _artifacts: D
  * Phase 2D: Requires projectId. Study name is inherited from project (no study_name_block).
  */
 export async function buildBriefEntryModal(options: BuildBriefEntryModalOptions) {
-  const { leadResearcher, channelId, projectId, projectName, projectSlug, source } = options;
+  const { leadResearcher, channelId, projectId, projectName, projectSlug, source, client } = options;
   const modalBlocks: Record<string, unknown>[] = JSON.parse(JSON.stringify(researchBriefModal.blocks));
 
   // Remove study_name_block — study inherits project name
@@ -141,6 +144,45 @@ export async function buildBriefEntryModal(options: BuildBriefEntryModalOptions)
   };
   // Insert after first block (usually a header context)
   modalBlocks.splice(1, 0, projectContextBlock);
+
+  // Replace editable stakeholder_select with read-only inherited stakeholder display
+  // Look up project approver (stakeholder, or owner as fallback)
+  const approverInfo = await getProjectApprover(projectId);
+  let approverDisplay = 'Not set';
+  let approverRoleLabel = 'project owner';
+
+  if (approverInfo) {
+    // Resolve display name from Slack
+    try {
+      const userInfo = await client.users.info({ user: approverInfo.userId });
+      const user = userInfo.user as Record<string, unknown> | undefined;
+      const profile = user?.profile as Record<string, unknown> | undefined;
+      approverDisplay = (user?.real_name || profile?.display_name || user?.name || approverInfo.userId) as string;
+    } catch {
+      approverDisplay = `<@${approverInfo.userId}>`;
+    }
+
+    if (approverInfo.source === 'stakeholder') {
+      approverRoleLabel = 'stakeholder';
+    } else {
+      approverRoleLabel = 'project owner';
+    }
+  }
+
+  // Replace stakeholder_block with read-only context block
+  const stakeholderIdx = modalBlocks.findIndex((b: Record<string, unknown>) => b.block_id === 'stakeholder_block');
+  if (stakeholderIdx !== -1) {
+    modalBlocks[stakeholderIdx] = {
+      type: "context",
+      block_id: "stakeholder_display_block",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: `:bust_in_silhouette: *Approver:* ${approverDisplay} (${approverRoleLabel} — approves this brief)`,
+        },
+      ],
+    };
+  }
 
   // Pre-fill lead researcher if available
   if (leadResearcher) {

--- a/backend/src/helpers/slack/ui/studyResultBlocks.ts
+++ b/backend/src/helpers/slack/ui/studyResultBlocks.ts
@@ -2,6 +2,7 @@ import type { KnownBlock } from '@slack/types';
 import type { WebClient } from '@slack/web-api';
 import type { ResearchStudyUserRole } from '../../../database/models/research_study_user_role';
 import { resolveStudyFromName } from '../../../services/research_study.service';
+import { getProjectApprover, type ApproverInfo } from '../../../services/authorization.service';
 
 interface UserRole {
   user_id: string;
@@ -25,23 +26,9 @@ export const generateStudyResultBlocks = (
   channelId: string,
   documentType: string,
 ) => {
+  // Plan approval removed per user request — brief (scope) is the only approval gate.
+  // Plan is execution detail; researcher owns it without a second approval step.
   const actionButtons: Record<string, Record<string, unknown>[]> = {
-    plan: [
-      {
-        type: 'button',
-        text: { type: 'plain_text', text: 'Approve Plan' },
-        style: 'primary',
-        action_id: 'approve_plan',
-        value: JSON.stringify({ studyName, channelId, url }),
-      },
-      {
-        type: 'button',
-        text: { type: 'plain_text', text: 'Request Plan Changes' },
-        style: 'danger',
-        action_id: 'request_changes_plan',
-        value: JSON.stringify({ studyName, channelId, url }),
-      },
-    ],
     brief: [
       {
         type: 'button',
@@ -182,7 +169,18 @@ const generateChannelBlocks = (studyName: string, study: StudyWithRoles | null, 
   return blocks;
 };
 
-// Generic function to send study result message
+/**
+ * Send approval request to the project's designated approver.
+ *
+ * Routing ladder (per stakeholder role design):
+ * 1. Stakeholder (role='stakeholder') — the designated approver
+ * 2. Owner (role='owner') — fallback if no stakeholder set
+ * 3. Channel — final fallback (should never fire per ADR 0025 owner guarantee)
+ *
+ * The message includes correct role labeling:
+ * - "...as the stakeholder for [project]" if routing to stakeholder
+ * - "...as the owner for [project]" if routing to owner (fallback)
+ */
 export const sendStudyResultMessage = async (
   client: WebClient,
   channelId: string,
@@ -194,76 +192,64 @@ export const sendStudyResultMessage = async (
   const fallbackText = `Here's your research ${documentType} for *${studyName}*`;
 
   try {
-    // Get the study object first (may be null for briefs from requests)
-    let study: StudyWithRoles | null = null;
+    // Resolve study to get project ID for approver lookup
+    let projectId: number | null = null;
+    let projectName = studyName;
     try {
       const resolved = await resolveStudyFromName(studyName);
-      study = resolved?.study as StudyWithRoles | null;
-      console.log("🚀 ~ sendStudyResultMessage ~ study:", study);
+      projectId = resolved?.projectId || null;
+      // Use study name as fallback for project name (study inherits project name in Phase 2D)
+      projectName = resolved?.study?.name || studyName;
+      console.log("🚀 ~ sendStudyResultMessage ~ projectId:", projectId);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       console.log("⚠️ Study not found (may be from request):", message);
-      // Study might not exist yet (e.g., brief from request)
     }
 
-    // Extract URL from the blocks - find the section with GitHub URL
-    const urlSection = blocks.find(block =>
-      block.type === 'section' &&
-      block.text &&
-      (block.text as Record<string, unknown>).text &&
-      ((block.text as Record<string, unknown>).text as string).includes('github.com')
-    );
-
-    if (!urlSection) {
-      throw new Error('Could not find GitHub URL in blocks');
+    // Look up project approver (stakeholder → owner → channel fallback)
+    let approver: ApproverInfo | null = null;
+    if (projectId) {
+      approver = await getProjectApprover(projectId);
+      console.log("🚀 ~ sendStudyResultMessage ~ approver:", approver);
     }
 
-    const urlMatch = ((urlSection.text as Record<string, unknown>).text as string).match(/<(.*?)\|/);
-    if (!urlMatch) {
-      throw new Error('Could not extract URL from GitHub section');
-    }
+    if (approver) {
+      // Route to the approver's DM with role-labeled message
+      const roleLabel = approver.source === 'stakeholder' ? 'stakeholder' : 'owner';
+      const contextMessage = `You're receiving this as the *${roleLabel}* for *${projectName}*.`;
 
-    const url = urlMatch[1];
-    console.log("🚀 ~ sendStudyResultMessage ~ url:", url);
+      try {
+        const im = await client.conversations.open({ users: approver.userId });
 
-    // Send simplified message to channel (without action buttons)
-    const channelBlocks = generateChannelBlocks(studyName, study, url, documentType);
-    console.log("🚀 ~ sendStudyResultMessage ~ channelBlocks:", channelBlocks);
+        if (im.channel?.id) {
+          // Add context block at the top of the message
+          const blocksWithContext: Record<string, unknown>[] = [
+            {
+              type: 'context',
+              elements: [
+                {
+                  type: 'mrkdwn',
+                  text: contextMessage,
+                },
+              ],
+            },
+            ...blocks,
+          ];
 
-    // await client.chat.postMessage({
-    //   channel: channelId,
-    //   text: fallbackText,
-    //   blocks: channelBlocks,
-    // });
-
-    // Send complete message with action buttons to each user in userRoles via DM
-    // Only if study exists and has userRoles
-    if (study && study.userRoles && Array.isArray(study.userRoles) && study.userRoles.length > 0) {
-      // Use Promise.all to send DMs concurrently
-      await Promise.all(
-        study.userRoles.map(async ({ user_id: userId }: UserRole) => {
-          try {
-            // Open DM with user
-            const im = await client.conversations.open({
-              users: userId,
-            });
-
-            // Send complete message with action buttons
-            if (im.channel?.id) {
-              await client.chat.postMessage({
-                channel: im.channel.id,
-                text: `🔔 New ${documentType} for *${studyName}* - Please review and take action`,
-                blocks: blocks as unknown as KnownBlock[],
-              });
-            }
-          } catch (error) {
-            console.error(`Failed to send DM to user ${userId}:`, error);
-          }
-        }),
-      );
+          await client.chat.postMessage({
+            channel: im.channel.id,
+            text: `🔔 New ${documentType} for *${studyName}* - Please review and take action`,
+            blocks: blocksWithContext as unknown as KnownBlock[],
+          });
+          console.log(`✅ Sent approval request to ${roleLabel} ${approver.userId}`);
+        }
+      } catch (error) {
+        console.error(`Failed to send DM to ${roleLabel} ${approver.userId}:`, error);
+        // Fall through to channel fallback
+      }
     } else {
-      // If no study or userRoles, send to channel instead
-      console.log("⚠️ No study or userRoles found, sending to channel instead");
+      // No approver found — channel fallback (should not happen per ADR 0025)
+      console.log("⚠️ No approver found, sending to channel instead");
       await client.chat.postMessage({
         channel: channelId,
         text: fallbackText,

--- a/backend/src/services/authorization.service.ts
+++ b/backend/src/services/authorization.service.ts
@@ -403,6 +403,9 @@ export async function assertStudyOwner(
  * Add a user to a project.
  * Used when auto-adding via channel membership or explicit add.
  *
+ * Note: Stakeholder is set separately via setProjectStakeholder().
+ * Role is only 'owner' or 'member' — stakeholder is a flag, not a role.
+ *
  * @param projectId - Project database ID
  * @param userId - Slack user ID
  * @param source - How the membership was granted
@@ -419,6 +422,49 @@ export async function addProjectMember(
     defaults: { project_id: projectId, user_id: userId, role, source },
   });
   return member;
+}
+
+/**
+ * Set or clear the stakeholder for a project.
+ * The stakeholder is a flag on a member row — does NOT change their role.
+ * An owner can be the stakeholder (owner + is_stakeholder=true).
+ *
+ * @param projectId - Project database ID
+ * @param userId - Slack user ID to designate as stakeholder (null to clear)
+ */
+export async function setProjectStakeholder(
+  projectId: number,
+  userId: string | null,
+): Promise<void> {
+  // Clear any existing stakeholder flag
+  await ProjectMemberModel.update(
+    { is_stakeholder: false },
+    { where: { project_id: projectId, is_stakeholder: true } },
+  );
+
+  if (userId) {
+    // Set the new stakeholder
+    const member = await ProjectMemberModel.findOne({
+      where: { project_id: projectId, user_id: userId },
+    });
+
+    if (member) {
+      await member.update({ is_stakeholder: true });
+      console.log(`[AUTH] Set stakeholder for project=${projectId}: ${userId} (role=${member.role})`);
+    } else {
+      // User isn't a member yet — add them as member with stakeholder flag
+      await ProjectMemberModel.create({
+        project_id: projectId,
+        user_id: userId,
+        role: 'member',
+        source: 'explicit' as MembershipSource,
+        is_stakeholder: true,
+      });
+      console.log(`[AUTH] Added new stakeholder for project=${projectId}: ${userId}`);
+    }
+  } else {
+    console.log(`[AUTH] Cleared stakeholder for project=${projectId}`);
+  }
 }
 
 /**
@@ -467,4 +513,91 @@ export async function getProjectsForMember(userId: string): Promise<Project[]> {
     where: { id: projectIds },
     order: [['created_at', 'DESC']],
   });
+}
+
+// ─── Stakeholder/Approver Lookup ──────────────────────────────────────
+
+/**
+ * Result of stakeholder lookup, includes fallback context.
+ */
+export interface ApproverInfo {
+  userId: string;
+  role: 'stakeholder' | 'owner';
+  source: 'stakeholder' | 'owner_fallback';
+}
+
+/**
+ * Get the approver for a project (stakeholder, or owner as fallback).
+ *
+ * Lookup order:
+ * 1. Member with is_stakeholder=true — the designated approver
+ * 2. Owner (role='owner') — fallback if no stakeholder set
+ *
+ * Note: The stakeholder may ALSO be the owner (same person, both flags).
+ *
+ * Returns null only if neither stakeholder nor owner exists (should never
+ * happen per ADR 0025 owner coverage guarantee).
+ *
+ * @param projectId - Project database ID
+ */
+export async function getProjectApprover(projectId: number): Promise<ApproverInfo | null> {
+  try {
+    // First, try to find a stakeholder (is_stakeholder flag)
+    const stakeholder = await ProjectMemberModel.findOne({
+      where: { project_id: projectId, is_stakeholder: true },
+    });
+
+    if (stakeholder) {
+      return {
+        userId: stakeholder.user_id,
+        role: 'stakeholder',
+        source: 'stakeholder',
+      };
+    }
+
+    // Fallback to owner
+    const owner = await ProjectMemberModel.findOne({
+      where: { project_id: projectId, role: 'owner' },
+    });
+
+    if (owner) {
+      return {
+        userId: owner.user_id,
+        role: 'owner',
+        source: 'owner_fallback',
+      };
+    }
+
+    // Neither found (should not happen per ADR 0025)
+    console.warn(`[AUTH] No stakeholder or owner found for project=${projectId}`);
+    return null;
+  } catch (error) {
+    console.error(
+      `[AUTH] getProjectApprover failed for project=${projectId}:`,
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
+}
+
+/**
+ * Get the stakeholder for a project (without fallback).
+ * Returns null if no stakeholder is set.
+ *
+ * Stakeholder is identified by is_stakeholder=true flag, not by role.
+ *
+ * @param projectId - Project database ID
+ */
+export async function getProjectStakeholder(projectId: number): Promise<ProjectMember | null> {
+  try {
+    return await ProjectMemberModel.findOne({
+      where: { project_id: projectId, is_stakeholder: true },
+    });
+  } catch (error) {
+    console.error(
+      `[AUTH] getProjectStakeholder failed for project=${projectId}:`,
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
 }

--- a/backend/src/services/research_study.service.ts
+++ b/backend/src/services/research_study.service.ts
@@ -101,7 +101,7 @@ const addResearchStudyWithRoles = async (data: StudyInput): Promise<ResearchStud
 const getStudyById = async (studyId: number): Promise<ResearchStudy | null> => {
   const study = await ResearchStudyModel.findOne({
     where: { id: studyId },
-    attributes: ['id', 'project_id', 'name', 'slug', 'description', 'path', 'created_by', 'researcher_name', 'researcher_email', 'created_at', 'updated_at', 'link', 'parsed_budget_amount', 'target_participants', 'session_timezone'],
+    attributes: ['id', 'project_id', 'name', 'slug', 'description', 'path', 'created_by', 'researcher_name', 'researcher_email', 'created_at', 'updated_at', 'link', 'parsed_budget_amount', 'target_participants', 'session_timezone', 'brief_status', 'brief_change_feedback', 'brief_reviewer_id'],
     include: [
       { model: UserRoleModel, as: 'userRoles', attributes: ['user_id', 'role', 'created_at'] },
       { model: ProjectModel, as: 'project', attributes: ['id', 'name', 'slug'] },
@@ -125,7 +125,7 @@ const getStudyById = async (studyId: number): Promise<ResearchStudy | null> => {
 const getStudyByProjectAndName = async (projectId: number, name: string): Promise<ResearchStudy | null> => {
   const study = await ResearchStudyModel.findOne({
     where: { project_id: projectId, name },
-    attributes: ['id', 'project_id', 'name', 'slug', 'description', 'path', 'created_by', 'researcher_name', 'researcher_email', 'created_at', 'updated_at', 'link', 'parsed_budget_amount', 'target_participants', 'session_timezone'],
+    attributes: ['id', 'project_id', 'name', 'slug', 'description', 'path', 'created_by', 'researcher_name', 'researcher_email', 'created_at', 'updated_at', 'link', 'parsed_budget_amount', 'target_participants', 'session_timezone', 'brief_status', 'brief_change_feedback', 'brief_reviewer_id'],
     include: [
       { model: UserRoleModel, as: 'userRoles', attributes: ['user_id', 'role', 'created_at'] },
       { model: ProjectModel, as: 'project', attributes: ['id', 'name', 'slug'] },


### PR DESCRIPTION
## Summary

- **Stakeholder as project-level flag**: `is_stakeholder` boolean on project_members — owner + stakeholder can coexist (no lockout)
- **Stakeholder management**: Designate at `/qori-start`, change/clear via Admin Center (owner-gated)
- **Brief approval routing**: DM to stakeholder → owner fallback, with role labels
- **Brief approval REVIEW LOOP**: State machine (`pending_approval` → `changes_requested` → `approved`), Request Changes → Resubmit → Re-review, multi-round with stale-button guards
- **Plan approval removed**: Brief is the single approval gate
- **Notification routing**: All confirmations → DM (only observer recruitment → channel)
- **Observer threshold**: 2→5, fires once
- **Removed vaporware**: "GitHub issue will be created" copy

## Test plan

- [x] Typecheck passes
- [x] Unit tests pass (141)
- [x] Integration tests pass (203)
- [x] Live tested: full approval loop (submit → request changes → resubmit → request changes again → resubmit → approve)
- [x] Live tested: stale button guards block after approval
- [x] Live tested: stakeholder assignment/change/clear
- [x] Live tested: owner + stakeholder coexist (no lockout)

## Migrations

- `20260607000000-add-brief-status` — adds `brief_status`, `brief_change_feedback`, `brief_reviewer_id` columns
- `20260607000001-add-is-stakeholder` — adds `is_stakeholder` boolean flag

🤖 Generated with [Claude Code](https://claude.ai/code)