### PR TITLE
fix: remove dead study_name write from discovery variables

### DIFF
--- a/backend/src/helpers/studyVariables.ts
+++ b/backend/src/helpers/studyVariables.ts
@@ -1282,9 +1282,6 @@ async function writeDiscoveryToPostgresByProject(
           await StudyVariable.create({
             project_id: projectId,
             study_id: null,
-            // Discovery variables use synthetic study_name since study_id is null
-            // Pattern: discovery:{projectId}:{artifactId} for traceability
-            study_name: `discovery:${projectId}:${artifactId}`,
             variable_key: key,
             variable_type: isPool ? 'pool' : 'singleton',
             item_key: (typeof item === 'object' && item !== null && (item as Record<string, unknown>).id as string) || null,


### PR DESCRIPTION
## Summary
- Removes dead `study_name` write from `writeDiscoveryToPostgresByProject()`
- The `study_name` column was dropped in migration 20260522000002, but the write code was still trying to set it
- This caused all `/qori-discover` commands to fail with "app did not respond" (handler threw before ack)
- #213 claimed to fix this but was an empty commit with no actual file changes

## Root cause
`writeDiscoveryToPostgresByProject()` was writing:
```typescript
study_name: `discovery:${projectId}:${artifactId}`,
```
But the production `study_variables` table has no `study_name` column (dropped by migration).

## Test plan
- [ ] Deploy to Railway
- [ ] Run `/qori-discover` in Slack
- [ ] Verify modal launches and discovery write succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)