### PR TITLE
feat: Layer 2+3 method-aware barrier coverage derivation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   push:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   test:
@@ -55,6 +55,58 @@ jobs:
       - name: Run unit tests
         working-directory: backend
         run: npm test
+
+      - name: Verify migrations
+        working-directory: backend
+        env:
+          DB_HOST: localhost
+          DB_PORT: '5432'
+          DB_USER: qori_test
+          DB_PASSWORD: test
+          DB_NAME: qori_test
+          DB_DIALECT: postgres
+        run: |
+          echo "Running migrations..."
+          npx sequelize-cli db:migrate
+
+          echo "Verifying migration state..."
+          EXPECTED_COUNT=$(ls -1 src/database/migrations/*.js | wc -l | tr -d ' ')
+          APPLIED_COUNT=$(node -e "
+            const { Sequelize } = require('sequelize');
+            const seq = new Sequelize({
+              dialect: 'postgres',
+              host: 'localhost',
+              port: 5432,
+              database: 'qori_test',
+              username: 'qori_test',
+              password: 'test',
+              logging: false
+            });
+            seq.query('SELECT COUNT(*) as count FROM \"SequelizeMeta\"', { type: seq.QueryTypes.SELECT })
+              .then(r => { console.log(r[0].count); seq.close(); })
+              .catch(e => { console.error(e.message); process.exit(1); });
+          ")
+
+          echo "Migration count: $APPLIED_COUNT applied, $EXPECTED_COUNT expected"
+
+          if [ "$APPLIED_COUNT" != "$EXPECTED_COUNT" ]; then
+            echo "::error::Migration count mismatch! Applied: $APPLIED_COUNT, Expected: $EXPECTED_COUNT"
+            echo "::error::This may indicate missing migrations or migrations that failed silently."
+            exit 1
+          fi
+
+          echo "Migration state verified."
+
+      - name: Verify schema matches models
+        working-directory: backend
+        env:
+          DB_HOST: localhost
+          DB_PORT: '5432'
+          DB_USER: qori_test
+          DB_PASSWORD: test
+          DB_NAME: qori_test
+          DB_DIALECT: postgres
+        run: node scripts/validate-schema.js
 
       - name: Run integration tests
         working-directory: backend

--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,8 @@ celerybeat.pid
 
 # Environments
 .env*
+!.env.example
+!.env.dev.example
 .venv
 env/
 venv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,28 +72,48 @@ docker-compose up    # Starts app (3000), postgres (5432), redis (6379)
 
 **Environment:** Copy `backend/.env.example` to `backend/.env`. Required variables: Slack tokens (`SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN`), `GITHUB_TOKEN`/`GITHUB_OWNER`/`GITHUB_REPO`, `ANTHROPIC_API_KEY`, database credentials. See `.env.example` for the full list with descriptions.
 
-## Railway Deployment (Production)
+## Railway Deployment
 
-**Migrated 2026-04-23. Verified end-to-end 2026-04-24.** The backend runs on Railway with Postgres and Redis as managed services. Slack commands work end-to-end on the Railway URL (~95% of flows working as of 2026-04-24 alpha test).
+**Two environments:** Production (`main` branch) and Development (`dev` branch). Each has its own Postgres, Redis, and Slack app.
 
-**Services:**
-- **Backend** — Node.js service, deployed from `backend/` on push to `main`
-- **Postgres** — Railway-managed, connection string provided as `DATABASE_URL`. All 33 migrations run successfully. You can browse tables directly in Railway's Data tab.
-- **Redis** — Railway-managed, connection string provided as `REDIS_URL`
+| Environment | Branch | Slack App | Workspace |
+|-------------|--------|-----------|-----------|
+| Production | `main` | `Qori` | Research team workspace |
+| Development | `dev` | `Qori Dev` | Dev/test workspace |
 
-**Environment variables** are set in Railway's Variables tab per service. All the same vars from `.env.example` apply. Three gotchas to know:
+**Migrations run automatically on deploy.** The Dockerfile CMD is `scripts/start.sh`, which:
+1. Waits for database connection
+2. Runs `npx sequelize-cli db:migrate`
+3. Verifies migration count matches expected
+4. Starts the app
 
-1. **No spaces around `=` in Railway variables.** Railway's UI trims values, but if you paste `DB_DIALECT = postgres` (with spaces) from another source, the value becomes ` postgres` (leading space) and Sequelize will fail with "Dialect needs to be explicitly supplied." Always use `DB_DIALECT=postgres` with no spaces.
+This ensures code and schema always deploy together — the root cause of the June 2026 outage was code deploying without its migration.
 
-2. **Token values can get truncated/malformed on paste.** Both `SLACK_APP_TOKEN` and `GITHUB_TOKEN` were broken on initial setup because the value was truncated when pasted into Railway's Variables UI. If a token-based service fails to authenticate, re-paste the full value and verify character count matches the source.
+**Full setup guide:** See `docs/dev-environment-setup.md` for complete instructions on setting up the dev environment, including Slack app creation and Railway configuration.
 
-3. **Postgres public URL for migrations.** Railway's internal Postgres hostname (`postgres.railway.internal`) only resolves inside the private network. To run `npx sequelize-cli db:migrate` from your local machine or via `railway run`, use the **public** connection URL (with `DATABASE_PUBLIC_URL` fields) from the Postgres service's Connect tab (it has a `railway.app` hostname and a mapped port). The internal URL works for the backend service at runtime since it's on the same private network.
+**Services (per environment):**
+- **Backend** — Node.js service, auto-deploys from branch
+- **Postgres** — Railway-managed, migrations run on startup
+- **Redis** — Railway-managed
 
-**Start command:** Railway uses a Dockerfile (`backend/Dockerfile`) which runs `npm run build` during image creation and `node ./dist/app.js` at runtime. Clear the Custom Start Command in Railway's UI — the Dockerfile CMD handles it. Do **not** use `npm run prod` (runs raw source, can't load `.ts` files). Do **not** use `npm start` (`dist/bin/www.js` has broken relative paths).
+**Environment variables** are set in Railway's Variables tab per environment. Key gotchas:
 
-**Deploy flow:** Push to `main` → Railway auto-deploys. GitHub Actions CI runs typecheck + tests on every PR.
+1. **No spaces around `=` in Railway variables.** `DB_DIALECT = postgres` (with spaces) breaks Sequelize.
 
-**Full deployment checklist:** See `docs/deployment-checklist.md` for fresh deployments. Includes Slack scope requirements (critical: `groups:read` for private channels), environment variable setup, and post-deployment verification steps.
+2. **Token values can get truncated/malformed on paste.** Verify character count matches source.
+
+3. **Postgres public URL for manual migrations.** Use the public URL (`railway.app` hostname) from the Postgres Connect tab, not the internal URL (`postgres.railway.internal`).
+
+**Deploy flow:**
+```
+feature/* → PR to dev → CI checks → merge → Railway dev auto-deploys
+                                           ↓
+                            test in dev Slack workspace
+                                           ↓
+                        PR from dev to main → merge → Railway prod auto-deploys
+```
+
+**CI verification:** GitHub Actions runs typecheck, unit tests, integration tests, AND migration verification on every PR. The migration check runs all pending migrations and verifies the count matches the expected number of migration files.
 
 ## Key Directories
 

--- a/backend/.env.dev.example
+++ b/backend/.env.dev.example
@@ -1,0 +1,105 @@
+# ============================================
+# QORI DEV ENVIRONMENT - Environment Variables
+# ============================================
+# This file is a template for LOCAL DEVELOPMENT only.
+# Copy to .env and fill in your dev values.
+#
+# CRITICAL: Never use production credentials here.
+# If you see "qori-slack" (prod app) tokens, STOP.
+# You want "Qori Dev" (dev app) tokens from the dev workspace.
+
+# ============================================
+# ENVIRONMENT SAFETY CHECK
+# ============================================
+# Before running, verify ALL of these are dev values:
+#
+# 1. Slack app is "Qori Dev" (not "Qori" / "qori-slack")
+# 2. Workspace is the dev/test workspace (not the research team workspace)
+# 3. Database is local Docker OR Railway dev environment
+# 4. NODE_ENV=development
+#
+# If ANY of these point to production, STOP and fix your .env.
+
+# ============================================
+# Application Configuration
+# ============================================
+NODE_ENV=development
+PORT=3000
+
+# ============================================
+# Database Configuration (LOCAL Docker)
+# ============================================
+# For local Docker development (docker-compose-dev.yml):
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=qori_dev
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_DIALECT=postgres
+
+# For Railway dev environment, use values from Railway Variables tab.
+# The DB_HOST will be something like: containers-us-west-XXX.railway.app
+# NOT postgres.railway.internal (that's internal to Railway network)
+
+# ============================================
+# Redis Configuration (LOCAL Docker)
+# ============================================
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_URI=redis://localhost:6379
+
+# ============================================
+# Slack Configuration - DEV APP ONLY
+# ============================================
+# Get these from: https://api.slack.com/apps
+# Select the "Qori Dev" app (NOT the production "Qori" app)
+# Install to your DEV/TEST workspace (NOT the research team workspace)
+#
+# Verify: The app name in Slack API dashboard should say "Qori Dev"
+
+SLACK_BOT_TOKEN=xoxb-DEV-APP-TOKEN-HERE
+SLACK_SIGNING_SECRET=dev-signing-secret-here
+SLACK_APP_TOKEN=xapp-1-DEV-APP-TOKEN-HERE
+
+# ============================================
+# GitHub Configuration
+# ============================================
+# Can use the same GitHub token as prod (it's your personal token)
+# But consider using a separate test repo for GITHUB_REPO
+
+GITHUB_TOKEN=ghp_your-github-token
+GITHUB_OWNER=Friends-Innovation-Lab
+GITHUB_REPO=qori-studies-dev
+GITHUB_CONFIG_REPO=qori-slack
+
+# ============================================
+# AI/LLM Configuration
+# ============================================
+# Can use the same Anthropic key (API is stateless, no environment risk)
+
+ANTHROPIC_API_KEY=sk-ant-your-key
+ANTHROPIC_MODEL_NAME=claude-sonnet-4-20250514
+ANTHROPIC_TEMPERATURE=0.4
+ANTHROPIC_MAX_TOKENS=3000
+
+# ============================================
+# Security
+# ============================================
+# Generate a dev-specific secret:
+# node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+
+JWT_SECRET_KEY=dev-only-secret-key-here
+
+# ============================================
+# Monitoring (Optional in dev)
+# ============================================
+# Sentry DSN - leave empty for dev unless you want error tracking
+SENTRY_DSN=
+
+# Alert channel - can be a dev-specific channel
+QORI_ALERTS_CHANNEL_ID=
+
+# ============================================
+# Team Identity
+# ============================================
+QORI_TEAM_SLUG=friends-lab-dev

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,24 @@
 # ============================================
 # Copy this file to .env and fill in your values
 # DO NOT commit .env to version control!
+#
+# ============================================
+# ENVIRONMENT SAFETY GUARD
+# ============================================
+# Before running, verify you're using the correct environment:
+#
+# PRODUCTION indicators (STOP if you see these in local dev):
+#   - SLACK_APP_TOKEN starts with: xapp-1-A0... (prod app ID)
+#   - DB_HOST contains: railway.app or .railway.internal
+#   - NODE_ENV=production
+#
+# DEVELOPMENT indicators (correct for local/dev work):
+#   - SLACK_APP_TOKEN starts with: xapp-1-A0... (different app ID than prod)
+#   - DB_HOST: localhost OR dev.railway.app
+#   - NODE_ENV=development
+#
+# If you're doing local development and see prod indicators, STOP.
+# You're about to run against production. Check your .env file.
 
 # ============================================
 # Application Configuration

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,5 +28,6 @@ ENV NODE_ENV=production
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
   CMD node -e "require('http').get('http://localhost:3000/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})" || exit 1
 
-# Run the compiled app
-CMD ["node", "./dist/app.js"]
+# Run migrations on startup, then start the app
+# This ensures code+schema always deploy together
+CMD ["sh", "./scripts/start.sh"]

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -21,6 +21,7 @@ EXPOSE 3000
 # Set environment
 ENV NODE_ENV=development
 
-# Use nodemon for hot reload
-CMD ["npm", "run", "dev"]
+# Run migrations on startup, then start dev server with hot reload
+# Note: docker-compose-dev.yml mounts src/ as a volume for hot reload
+CMD ["sh", "-c", "npx sequelize-cli db:migrate && npm run dev"]
 

--- a/backend/config/method-coverage-map.yaml
+++ b/backend/config/method-coverage-map.yaml
@@ -1,0 +1,232 @@
+# Method → Category Coverage Map (Layer 2)
+#
+# PURPOSE: Defines which research methods can validate which barrier categories.
+# Layer 3 consumes this to determine barrier coverage state (full/partial/none).
+#
+# COVERAGE LOGIC (three-state):
+#   - full:    ALL barrier categories are covered by the chosen method
+#   - partial: SOME barrier categories are covered (surfaces uncovered dimensions)
+#   - none:    NO barrier categories are covered → out-of-scope candidate
+#
+# MANUAL REVIEW TRIGGERS:
+#   - Barriers tagged 'other' → always manual (no method covers 'other')
+#   - Method 'custom' → always manual (free-text, nothing to map)
+#   - Method 'mixed_methods' without component spec → manual until specified
+#
+# DESIGN DECISIONS (Lapedra, 2026-06-09):
+#   - user_interviews does NOT cover accessibility (interviews surface but don't validate)
+#   - usability_testing DOES cover content (observed comprehension failure = validation)
+#   - usability_testing does NOT cover performance (can't reproduce real latency)
+#   - contextual_inquiry covers accessibility (real-environment AT observation)
+#   - No Qori method covers 'performance' → performance barriers frequently out-of-scope
+#   - No Qori method covers 'other' → always manual review
+#
+# HONEST GAPS (not bugs, correct behavior):
+#   - Qori offers no a11y-audit, content-testing, or performance-testing methods
+#   - Performance barriers will be out-of-scope unless custom method specified
+#   - Accessibility barriers require contextual_inquiry for full coverage
+
+schema_version: "1.0"
+last_updated: "2026-06-09"
+approved_by: "Lapedra"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# BARRIER CATEGORIES
+# ═══════════════════════════════════════════════════════════════════════════════
+# Reference definitions — matches discovered_barrier.yaml enum
+
+barrier_categories:
+  ia:
+    label: "Information Architecture"
+    description: "Navigation, findability, mental models, labeling"
+  accessibility:
+    label: "Accessibility"
+    description: "Assistive technology, WCAG compliance, screen readers, motor/vision"
+  performance:
+    label: "Performance"
+    description: "Speed, latency, load times, system responsiveness"
+  content:
+    label: "Content"
+    description: "Readability, comprehension, terminology, tone, information quality"
+  task-flow:
+    label: "Task Flow"
+    description: "Task completion, workflow steps, error recovery, form design"
+  cognitive:
+    label: "Cognitive"
+    description: "Mental load, decision complexity, memory demands, learning curve"
+  other:
+    label: "Other"
+    description: "Escape hatch — no UX category applies, requires manual review"
+    manual_review_required: true
+    reason: "Barriers tagged 'other' cannot be mapped to any research method"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# METHOD COVERAGE DEFINITIONS
+# ═══════════════════════════════════════════════════════════════════════════════
+# Each method lists which barrier categories it can VALIDATE (not just surface).
+
+methods:
+  usability_testing:
+    label: "Usability Testing"
+    covers:
+      - ia           # Observes navigation/findability failures
+      - content      # Observes comprehension failures during tasks (Lapedra ruling)
+      - task-flow    # Observes task completion/failure
+      - cognitive    # Observes confusion, hesitation, mental load
+    does_not_cover:
+      - accessibility  # Requires AT-specific testing setup
+      - performance    # Cannot reproduce real latency in test session
+    rationale: "Moderated task observation validates IA, content comprehension, task completion, and cognitive barriers through direct observation of user behavior."
+
+  user_interviews:
+    label: "User Interviews"
+    covers:
+      - ia           # Users describe mental models, expectations
+      - content      # Users explain what they understood/didn't
+      - task-flow    # Users describe workflow experiences
+      - cognitive    # Users articulate confusion, decision difficulty
+    does_not_cover:
+      - accessibility  # Interviews surface but don't VALIDATE a11y barriers (Lapedra ruling)
+      - performance    # Self-report unreliable for latency perception
+    rationale: "Interviews capture user perspectives on IA mental models, content understanding, and cognitive load, but cannot validate accessibility barriers (hearing a report ≠ observing AT fail)."
+
+  contextual_inquiry:
+    label: "Contextual Inquiry"
+    covers:
+      - ia           # Observes real navigation in real context
+      - accessibility # Observes actual AT use in real environment (Lapedra confirmed)
+      - content      # Observes comprehension in real context
+      - task-flow    # Observes real workflows
+      - cognitive    # Observes real cognitive load indicators
+    does_not_cover:
+      - performance  # Real-world performance varies; hard to isolate
+    rationale: "Real-environment observation captures IA, accessibility (via actual AT use), content, task-flow, and cognitive barriers. Only method that validates accessibility through direct AT observation."
+
+  concept_testing:
+    label: "Concept Testing"
+    covers:
+      - content      # Tests comprehension of concepts/designs
+      - cognitive    # Tests whether concepts are understandable
+    does_not_cover:
+      - ia           # Concepts aren't navigated
+      - accessibility # Concepts aren't experienced with AT
+      - performance  # Concepts don't have latency
+      - task-flow    # Concepts aren't full task flows
+    rationale: "Validates comprehension and cognitive load / understandability of concepts/designs before implementation."
+
+  survey:
+    label: "Survey Research"
+    covers:
+      - cognitive    # Quantifies self-reported / perceived difficulty
+    does_not_cover:
+      - ia           # Self-report unreliable for navigation behavior
+      - accessibility # Cannot observe AT interactions
+      - performance  # Self-report unreliable for latency perception
+      - content      # Surveys measure attitudes, not comprehension
+      - task-flow    # Surveys measure perception, not behavior
+    rationale: "Quantifies self-reported / perceived cognitive load at scale. Does not observe mental load directly — captures user perception of difficulty, not behavior."
+
+  card_sorting:
+    label: "Card Sorting"
+    covers:
+      - ia           # Reveals mental models, categorization expectations
+      - cognitive    # Reveals how users conceptualize relationships
+    does_not_cover:
+      - accessibility # Cards aren't AT-accessible artifacts
+      - performance  # No latency component
+      - content      # Card labels ≠ content comprehension
+      - task-flow    # Sorting ≠ task completion
+    rationale: "Validates information architecture through user mental model elicitation."
+
+  tree_testing:
+    label: "Tree Testing"
+    covers:
+      - ia           # Validates findability in structure
+    does_not_cover:
+      - task-flow    # Tree test ends at click; doesn't observe task completion
+      - accessibility # Tree tests aren't AT-tested by default
+      - performance  # No latency component
+      - content      # Tests structure, not content comprehension
+      - cognitive    # Structure navigation ≠ cognitive load measurement
+    rationale: "Validates findability within an information structure. Ends when user locates the correct node — does not observe task completion, error recovery, or workflow behavior."
+
+  mixed_methods:
+    label: "Mixed Methods"
+    requires_component_specification: true
+    manual_review_until_specified: true
+    covers: []  # Determined by union of component methods
+    rationale: "Coverage is the union of specified component methods. If components not specified, routes to manual review to prevent false confidence."
+
+  custom:
+    label: "Custom Method"
+    manual_review_required: true
+    covers: []  # Cannot pre-map free-text methods
+    rationale: "Free-text method cannot be pre-mapped. Researcher determines scope manually."
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# COVERAGE RESOLUTION RULES (Layer 3 consumes)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+coverage_rules:
+  # How to determine barrier coverage state
+  resolution:
+    full:
+      condition: "ALL barrier_categories are in method.covers"
+      result: "Barrier included in scope"
+      display: "✓ Covered by {method}"
+
+    partial:
+      condition: "SOME barrier_categories are in method.covers"
+      result: "Barrier partially addressed — flag uncovered dimensions"
+      display: "◐ Partially covered — {method} addresses {covered_categories} but not {uncovered_categories}"
+
+    none:
+      condition: "NO barrier_categories are in method.covers"
+      result: "Barrier is out-of-scope candidate"
+      display: "○ Not covered by {method} — suggest out-of-scope"
+
+  # Manual review triggers
+  manual_review:
+    - trigger: "barrier has 'other' in barrier_categories"
+      reason: "No research method covers 'other' — requires manual categorization"
+      display: "⚠ Manual review required — barrier tagged 'other'"
+
+    - trigger: "method is 'custom'"
+      reason: "Custom method cannot be pre-mapped"
+      display: "⚠ Manual review required — custom method specified"
+
+    - trigger: "method is 'mixed_methods' AND components not specified"
+      reason: "Mixed methods coverage depends on component methods"
+      display: "⚠ Manual review required — specify component methods for coverage calculation"
+
+  # Out-of-scope suggestion format
+  out_of_scope_reason_template: |
+    "{barrier_title}" is suggested out-of-scope because:
+    - Barrier categories: {barrier_categories}
+    - Method chosen: {method}
+    - Method covers: {method_covers}
+    - Gap: {method} does not validate {uncovered_categories}
+
+    To include this barrier, consider:
+    - Adding a complementary method that covers {uncovered_categories}
+    - Using a custom method with manual scope determination
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# COVERAGE MATRIX (computed reference — Layer 3 derives from methods above)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+#                        | ia | a11y | perf | content | task-flow | cognitive |
+# -----------------------|----|------|------|---------|-----------|-----------|
+# usability_testing      | ✓  |      |      | ✓       | ✓         | ✓         |
+# user_interviews        | ✓  |      |      | ✓       | ✓         | ✓         |
+# contextual_inquiry     | ✓  | ✓    |      | ✓       | ✓         | ✓         |
+# concept_testing        |    |      |      | ✓       |           | ✓         |
+# survey                 |    |      |      |         |           | ✓         |
+# card_sorting           | ✓  |      |      |         |           | ✓         |
+# tree_testing           | ✓  |      |      |         |           |           |
+# mixed_methods          | ?  | ?    | ?    | ?       | ?         | ?         | → requires component spec
+# custom                 | ?  | ?    | ?    | ?       | ?         | ?         | → manual review
+#
+# GAPS (honest, not bugs):
+# - performance: NO method covers → always out-of-scope or manual
+# - accessibility: ONLY contextual_inquiry covers → frequently partial/none

--- a/backend/config/method-coverage-map.yaml
+++ b/backend/config/method-coverage-map.yaml
@@ -77,6 +77,7 @@ methods:
       - accessibility  # Requires AT-specific testing setup
       - performance    # Cannot reproduce real latency in test session
     rationale: "Moderated task observation validates IA, content comprehension, task completion, and cognitive barriers through direct observation of user behavior."
+    participant_guidance: "5-8 participants typically reveal 80% of major usability issues. Prioritize participants who represent primary user segments."
 
   user_interviews:
     label: "User Interviews"
@@ -89,6 +90,7 @@ methods:
       - accessibility  # Interviews surface but don't VALIDATE a11y barriers (Lapedra ruling)
       - performance    # Self-report unreliable for latency perception
     rationale: "Interviews capture user perspectives on IA mental models, content understanding, and cognitive load, but cannot validate accessibility barriers (hearing a report ≠ observing AT fail)."
+    participant_guidance: "8-12 participants for thematic saturation. Include mix of experience levels and usage patterns."
 
   contextual_inquiry:
     label: "Contextual Inquiry"
@@ -101,6 +103,7 @@ methods:
     does_not_cover:
       - performance  # Real-world performance varies; hard to isolate
     rationale: "Real-environment observation captures IA, accessibility (via actual AT use), content, task-flow, and cognitive barriers. Only method that validates accessibility through direct AT observation."
+    participant_guidance: "4-6 participants in their real environment. Schedule 90-120 min sessions to observe natural workflows."
 
   concept_testing:
     label: "Concept Testing"
@@ -113,6 +116,7 @@ methods:
       - performance  # Concepts don't have latency
       - task-flow    # Concepts aren't full task flows
     rationale: "Validates comprehension and cognitive load / understandability of concepts/designs before implementation."
+    participant_guidance: "6-10 participants per concept variant. Include decision-makers if testing concepts that require buy-in."
 
   survey:
     label: "Survey Research"
@@ -125,6 +129,7 @@ methods:
       - content      # Surveys measure attitudes, not comprehension
       - task-flow    # Surveys measure perception, not behavior
     rationale: "Quantifies self-reported / perceived cognitive load at scale. Does not observe mental load directly — captures user perception of difficulty, not behavior."
+    participant_guidance: "100+ responses for statistical reliability. Aim for 5% margin of error at 95% confidence."
 
   card_sorting:
     label: "Card Sorting"
@@ -137,6 +142,7 @@ methods:
       - content      # Card labels ≠ content comprehension
       - task-flow    # Sorting ≠ task completion
     rationale: "Validates information architecture through user mental model elicitation."
+    participant_guidance: "15-30 participants for reliable categorization patterns. Include mix of novice and experienced users."
 
   tree_testing:
     label: "Tree Testing"
@@ -149,6 +155,7 @@ methods:
       - content      # Tests structure, not content comprehension
       - cognitive    # Structure navigation ≠ cognitive load measurement
     rationale: "Validates findability within an information structure. Ends when user locates the correct node — does not observe task completion, error recovery, or workflow behavior."
+    participant_guidance: "50+ participants for statistically meaningful findability scores. Can run unmoderated at scale."
 
   mixed_methods:
     label: "Mixed Methods"

--- a/backend/docker-compose-dev.yml
+++ b/backend/docker-compose-dev.yml
@@ -53,7 +53,8 @@ services:
       # Mount source code for hot reload (if using nodemon in dev)
       - ./src:/app/src
       - ./package.json:/app/package.json
-    command: npm run dev
+    # Run migrations on startup, then start dev server
+    command: sh -c "npx sequelize-cli db:migrate && npm run dev"
 
   postgres:
     image: postgres:15-alpine

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "test:mocha": "NODE_ENV=test mocha --require @babel/register --exit",
     "test:watch": "NODE_ENV=test jest --config jest.config.js --watch",
     "db:migrate": "npx sequelize-cli db:migrate",
+    "db:validate": "node scripts/validate-schema.js",
     "adr": "../scripts/new-adr.sh",
     "adr:lesson": "../scripts/new-adr-lesson.sh",
     "build:cascade": "npx ts-node scripts/build-cascade-registry.ts"

--- a/backend/scripts/start.sh
+++ b/backend/scripts/start.sh
@@ -3,6 +3,8 @@
 # Runs migrations before starting the app, ensuring code+schema deploy together.
 # Used by Dockerfile CMD in both dev and prod Railway environments.
 
+echo ">>> START.SH IS RUNNING <<<"
+
 set -e
 
 echo "=== Qori Backend Startup ==="

--- a/backend/scripts/start.sh
+++ b/backend/scripts/start.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Qori Backend Startup Script
+# Runs migrations before starting the app, ensuring code+schema deploy together.
+# Used by Dockerfile CMD in both dev and prod Railway environments.
+
+set -e
+
+echo "=== Qori Backend Startup ==="
+echo "Environment: ${NODE_ENV:-development}"
+echo "Database: ${DB_HOST}:${DB_PORT:-5432}/${DB_NAME}"
+
+# Wait for database to be ready (Railway Postgres can take a moment)
+echo "Waiting for database connection..."
+MAX_RETRIES=30
+RETRY_COUNT=0
+
+until node -e "
+const { Sequelize } = require('sequelize');
+const seq = new Sequelize({
+  dialect: process.env.DB_DIALECT,
+  host: process.env.DB_HOST,
+  port: parseInt(process.env.DB_PORT || '5432'),
+  database: process.env.DB_NAME,
+  username: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  logging: false
+});
+seq.authenticate().then(() => process.exit(0)).catch(() => process.exit(1));
+" 2>/dev/null; do
+  RETRY_COUNT=$((RETRY_COUNT + 1))
+  if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
+    echo "ERROR: Could not connect to database after $MAX_RETRIES attempts"
+    exit 1
+  fi
+  echo "  Attempt $RETRY_COUNT/$MAX_RETRIES - waiting 2s..."
+  sleep 2
+done
+
+echo "Database connection verified."
+
+# Run migrations
+echo "Running database migrations..."
+npx sequelize-cli db:migrate
+
+if [ $? -eq 0 ]; then
+  echo "Migrations completed successfully."
+else
+  echo "ERROR: Migrations failed!"
+  exit 1
+fi
+
+# Verify migration state (count applied vs expected)
+APPLIED_COUNT=$(node -e "
+const { Sequelize } = require('sequelize');
+const seq = new Sequelize({
+  dialect: process.env.DB_DIALECT,
+  host: process.env.DB_HOST,
+  port: parseInt(process.env.DB_PORT || '5432'),
+  database: process.env.DB_NAME,
+  username: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  logging: false
+});
+seq.query('SELECT COUNT(*) as count FROM \"SequelizeMeta\"', { type: seq.QueryTypes.SELECT })
+  .then(r => { console.log(r[0].count); process.exit(0); })
+  .catch(e => { console.error(e.message); process.exit(1); });
+")
+
+EXPECTED_COUNT=$(ls -1 src/database/migrations/*.js 2>/dev/null | wc -l | tr -d ' ')
+
+echo "Migration state: $APPLIED_COUNT applied, $EXPECTED_COUNT expected"
+
+if [ "$APPLIED_COUNT" != "$EXPECTED_COUNT" ]; then
+  echo "ERROR: Migration count mismatch! Applied: $APPLIED_COUNT, Expected: $EXPECTED_COUNT"
+  echo "This may indicate migrations that failed silently or were not committed."
+  exit 1
+fi
+
+# Validate schema matches models
+# This catches the "code expects column that doesn't exist" class of bugs
+echo "Validating schema matches model definitions..."
+node scripts/validate-schema.js
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: Schema validation failed!"
+  exit 1
+fi
+
+# Start the application
+echo "Starting Qori backend..."
+exec node ./dist/app.js

--- a/backend/scripts/validate-schema.js
+++ b/backend/scripts/validate-schema.js
@@ -16,7 +16,11 @@
 
 require('@babel/register')({
   extensions: ['.js', '.ts'],
-  presets: ['@babel/preset-env', '@babel/preset-typescript'],
+  babelrc: false, // Ignore .babelrc to avoid config conflicts
+  presets: [
+    '@babel/preset-env',
+    ['@babel/preset-typescript', { allowDeclareFields: true }],
+  ],
 });
 
 const { Sequelize } = require('sequelize');

--- a/backend/scripts/validate-schema.js
+++ b/backend/scripts/validate-schema.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Schema Validation Script
+ *
+ * Verifies that all Sequelize model columns exist in the database.
+ * Catches the "code expects column that doesn't exist" class of bugs.
+ *
+ * Run after migrations, before starting the app or running tests.
+ *
+ * Usage: node scripts/validate-schema.js
+ *
+ * Exit codes:
+ *   0 - Schema valid, all model columns exist in database
+ *   1 - Schema invalid, missing columns found
+ */
+
+require('@babel/register')({
+  extensions: ['.js', '.ts'],
+  presets: ['@babel/preset-env', '@babel/preset-typescript'],
+});
+
+const { Sequelize } = require('sequelize');
+
+// Import model definers - same list as database/index.ts
+const modelDefiners = [
+  require('../src/database/models/channel_config').default,
+  require('../src/database/models/project').default,
+  require('../src/database/models/project_member').default,
+  require('../src/database/models/research_study').default,
+  require('../src/database/models/research_study_user_role').default,
+  require('../src/database/models/study_status').default,
+  require('../src/database/models/study_participant').default,
+  require('../src/database/models/session_observer').default,
+  require('../src/database/models/study_notes').default,
+  require('../src/database/models/research_plan').default,
+  require('../src/database/models/session_summary').default,
+  require('../src/database/models/study_variable').default,
+  require('../src/database/models/created_issue').default,
+  require('../src/database/models/slack_user_state').default,
+  require('../src/database/models/disposition_audit_log').default,
+];
+
+async function validateSchema() {
+  // Use environment variables for database connection
+  const sequelize = new Sequelize({
+    dialect: process.env.DB_DIALECT || 'postgres',
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || '5432'),
+    database: process.env.DB_NAME || 'qori_test',
+    username: process.env.DB_USER || 'qori_test',
+    password: process.env.DB_PASSWORD || 'test',
+    logging: false,
+  });
+
+  // Register all models
+  for (const defineModel of modelDefiners) {
+    defineModel(sequelize);
+  }
+
+  const errors = [];
+
+  for (const [modelName, model] of Object.entries(sequelize.models)) {
+    const tableName = model.getTableName();
+    if (typeof tableName !== 'string') continue;
+
+    // Get actual columns from database
+    const dbColumns = await sequelize.query(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = '${tableName}'`,
+      { type: sequelize.QueryTypes.SELECT }
+    );
+    const dbColumnNames = new Set(dbColumns.map(c => c.column_name));
+
+    // Check if table exists
+    if (dbColumnNames.size === 0) {
+      errors.push(`Table "${tableName}" (model ${modelName}) does not exist in database`);
+      continue;
+    }
+
+    // Get expected columns from model
+    const modelAttrs = model.getAttributes();
+    for (const [attrName, attrDef] of Object.entries(modelAttrs)) {
+      const columnName = attrDef.field || attrName;
+      if (!dbColumnNames.has(columnName)) {
+        errors.push(`${modelName}.${attrName} expects column "${columnName}" but it does not exist in table "${tableName}"`);
+      }
+    }
+  }
+
+  await sequelize.close();
+
+  if (errors.length > 0) {
+    console.error('Schema validation FAILED:');
+    errors.forEach(e => console.error(`  - ${e}`));
+    console.error('');
+    console.error('This means the code expects database columns that do not exist.');
+    console.error('Check that all migrations have been run and that model definitions match migrations.');
+    process.exit(1);
+  }
+
+  console.log(`Schema validation passed: ${Object.keys(sequelize.models).length} models verified`);
+  process.exit(0);
+}
+
+validateSchema().catch(e => {
+  console.error('Schema validation error:', e.message);
+  process.exit(1);
+});

--- a/backend/src/database/models/channel_config.ts
+++ b/backend/src/database/models/channel_config.ts
@@ -26,6 +26,8 @@ class ChannelConfig extends Model<
   declare repo: string | null;
   declare product_folder_name: string | null;
   declare sub_folder_name: string | null;
+  // FAIL-STOP TEST: This column does not exist in the database
+  declare fake_nonexistent_column: string | null;
   declare created_at: CreationOptional<Date>;
   declare updated_at: CreationOptional<Date>;
 
@@ -80,6 +82,11 @@ export default (sequelize: Sequelize) => {
         allowNull: true,
       },
       sub_folder_name: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      // FAIL-STOP TEST: This column does not exist in the database
+      fake_nonexistent_column: {
         type: DataTypes.STRING,
         allowNull: true,
       },

--- a/backend/src/database/models/channel_config.ts
+++ b/backend/src/database/models/channel_config.ts
@@ -26,8 +26,6 @@ class ChannelConfig extends Model<
   declare repo: string | null;
   declare product_folder_name: string | null;
   declare sub_folder_name: string | null;
-  // FAIL-STOP TEST: This column does not exist in the database
-  declare fake_nonexistent_column: string | null;
   declare created_at: CreationOptional<Date>;
   declare updated_at: CreationOptional<Date>;
 
@@ -82,11 +80,6 @@ export default (sequelize: Sequelize) => {
         allowNull: true,
       },
       sub_folder_name: {
-        type: DataTypes.STRING,
-        allowNull: true,
-      },
-      // FAIL-STOP TEST: This column does not exist in the database
-      fake_nonexistent_column: {
         type: DataTypes.STRING,
         allowNull: true,
       },

--- a/backend/src/helpers/barrierCoverageDerivation.ts
+++ b/backend/src/helpers/barrierCoverageDerivation.ts
@@ -71,6 +71,7 @@ interface MethodConfig {
   manual_review_required?: boolean;
   requires_component_specification?: boolean;
   manual_review_until_specified?: boolean;
+  participant_guidance?: string;
 }
 
 interface CoverageMapConfig {
@@ -271,8 +272,8 @@ export function deriveBarrierCoverage(
   const outOfScope = results.filter((r) => r.coverageState === 'none');
   const manualReview = results.filter((r) => r.coverageState === 'manual_review');
 
-  // Generate participant hints (OUTPUT B: vague category-level only)
-  const participantHints = deriveParticipantHints(barriers, config);
+  // Generate participant hints (OUTPUT B: method guidance + category composition)
+  const participantHints = deriveParticipantHints(barriers, config, methodKey);
 
   return {
     method: methodKey,
@@ -288,51 +289,56 @@ export function deriveBarrierCoverage(
 // ─── Participant hints (OUTPUT B) ────────────────────────────────
 
 /**
- * Derive VAGUE category-level participant composition hints from barriers.
+ * Derive participant composition hints from method guidance + barrier categories.
  *
- * CRITICAL: Never invent numbers, org names, or specifics.
- * Output is a SUGGESTION the researcher confirms/edits.
+ * Uses methodology-grounded guidance from the coverage map (e.g., "5-8 participants
+ * for usability testing") combined with category-specific composition notes.
+ *
+ * CRITICAL: Never invent study-specific numbers, org names, or fabricated specifics.
+ * The guidance comes from established methodology norms, not made-up details.
  */
 function deriveParticipantHints(
   barriers: DiscoveredBarrier[],
-  _config: CoverageMapConfig
+  config: CoverageMapConfig,
+  methodKey?: string
 ): string[] {
   const hints: string[] = [];
-  const categorySet = new Set<BarrierCategory>();
 
-  // Collect all categories across barriers
+  // 1. Method-specific guidance (from coverage map)
+  if (methodKey && config.methods[methodKey]?.participant_guidance) {
+    hints.push(config.methods[methodKey].participant_guidance!);
+  }
+
+  // 2. Category-specific composition recommendations (based on barriers)
+  const categorySet = new Set<BarrierCategory>();
   for (const barrier of barriers) {
     for (const cat of barrier.barrier_categories || []) {
       categorySet.add(cat);
     }
   }
 
-  // Generate category-level hints (NO specifics, NO numbers, NO org names)
+  // Add composition notes for specific barrier categories
   if (categorySet.has('accessibility')) {
     hints.push(
-      'Discovery surfaced accessibility barriers; consider including participants who use assistive technology.'
+      'Discovery surfaced accessibility barriers — include participants who use assistive technology.'
     );
   }
 
-  if (categorySet.has('cognitive')) {
+  if (categorySet.has('cognitive') && !hints.some(h => h.includes('proficiency'))) {
     hints.push(
-      'Discovery surfaced cognitive load barriers; consider including participants with varying tech proficiency levels.'
+      'Cognitive barriers present — include participants with varying tech proficiency levels.'
     );
   }
 
   if (categorySet.has('content')) {
     hints.push(
-      'Discovery surfaced content comprehension barriers; consider including participants with varying reading levels.'
+      'Content barriers present — include participants with varying reading levels.'
     );
   }
 
-  if (categorySet.has('performance')) {
-    hints.push(
-      'Discovery surfaced performance barriers; note that participant testing may not reproduce real-world latency conditions.'
-    );
-  }
+  // Note: performance barriers don't affect participant composition
+  // (the method either can or can't test performance)
 
-  // If no specific hints generated, return empty (honest-empty)
   return hints;
 }
 

--- a/backend/src/helpers/barrierCoverageDerivation.ts
+++ b/backend/src/helpers/barrierCoverageDerivation.ts
@@ -1,0 +1,363 @@
+/**
+ * barrierCoverageDerivation.ts — Layer 3 derivation logic
+ *
+ * Computes barrier coverage state (full/partial/none) based on the chosen
+ * research method and each barrier's categories. Generates traceable
+ * out-of-scope suggestions and vague participant composition hints.
+ *
+ * SINGLE SOURCE OF TRUTH: Loads method-coverage-map.yaml at runtime.
+ * No hardcoded coverage data in this file.
+ *
+ * DESIGN RULES (Lapedra, 2026-06-09):
+ * - Full: all barrier categories covered by method → in scope
+ * - Partial: some covered → in scope, but flag uncovered dimensions
+ * - None: no overlap → out-of-scope suggestion with traceable reason
+ * - 'other' category → always manual review
+ * - 'custom' method → always manual review
+ * - 'mixed_methods' without components → manual review
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { load as yamlLoad } from 'js-yaml';
+
+// ─── Types ───────────────────────────────────────────────────────
+
+export type BarrierCategory =
+  | 'ia'
+  | 'accessibility'
+  | 'performance'
+  | 'content'
+  | 'task-flow'
+  | 'cognitive'
+  | 'other';
+
+export type CoverageState = 'full' | 'partial' | 'none' | 'manual_review';
+
+export interface DiscoveredBarrier {
+  id: string;
+  title: string;
+  summary?: string;
+  barrier_categories: BarrierCategory[];
+  source_document?: string;
+  [key: string]: unknown;
+}
+
+export interface BarrierCoverageResult {
+  barrierId: string;
+  barrierTitle: string;
+  barrierCategories: BarrierCategory[];
+  coverageState: CoverageState;
+  coveredCategories: BarrierCategory[];
+  uncoveredCategories: BarrierCategory[];
+  reason: string;
+  displayText: string;
+}
+
+export interface CoverageDerivationResult {
+  method: string;
+  methodLabel: string;
+  barriers: BarrierCoverageResult[];
+  inScope: BarrierCoverageResult[];
+  outOfScope: BarrierCoverageResult[];
+  manualReview: BarrierCoverageResult[];
+  participantHints: string[];
+}
+
+interface MethodConfig {
+  label: string;
+  covers: BarrierCategory[];
+  does_not_cover?: BarrierCategory[];
+  manual_review_required?: boolean;
+  requires_component_specification?: boolean;
+  manual_review_until_specified?: boolean;
+}
+
+interface CoverageMapConfig {
+  schema_version: string;
+  methods: Record<string, MethodConfig>;
+  barrier_categories: Record<string, { manual_review_required?: boolean }>;
+}
+
+// ─── Config loading ──────────────────────────────────────────────
+
+let cachedConfig: CoverageMapConfig | null = null;
+
+/**
+ * Load method-coverage-map.yaml at runtime.
+ * Single source of truth — no hardcoded coverage data.
+ */
+function loadCoverageConfig(): CoverageMapConfig {
+  if (cachedConfig) return cachedConfig;
+
+  // Path from src/helpers/ to config/ (which is at backend/config/)
+  const configPath = join(__dirname, '../../../config/method-coverage-map.yaml');
+  const raw = readFileSync(configPath, 'utf8');
+  cachedConfig = yamlLoad(raw) as CoverageMapConfig;
+  return cachedConfig;
+}
+
+/**
+ * Clear cached config (for testing).
+ */
+export function clearCoverageConfigCache(): void {
+  cachedConfig = null;
+}
+
+// ─── Coverage computation ────────────────────────────────────────
+
+/**
+ * Compute coverage state for a single barrier against a method.
+ */
+function computeBarrierCoverage(
+  barrier: DiscoveredBarrier,
+  methodKey: string,
+  config: CoverageMapConfig
+): BarrierCoverageResult {
+  const barrierCategories = barrier.barrier_categories || [];
+  const method = config.methods[methodKey];
+
+  // Manual review triggers
+  if (!method) {
+    return {
+      barrierId: barrier.id,
+      barrierTitle: barrier.title,
+      barrierCategories,
+      coverageState: 'manual_review',
+      coveredCategories: [],
+      uncoveredCategories: barrierCategories,
+      reason: `Unknown method '${methodKey}' — cannot compute coverage`,
+      displayText: `⚠ Manual review required — unknown method`,
+    };
+  }
+
+  if (method.manual_review_required) {
+    return {
+      barrierId: barrier.id,
+      barrierTitle: barrier.title,
+      barrierCategories,
+      coverageState: 'manual_review',
+      coveredCategories: [],
+      uncoveredCategories: barrierCategories,
+      reason: `Custom method cannot be pre-mapped — researcher determines scope`,
+      displayText: `⚠ Manual review required — custom method specified`,
+    };
+  }
+
+  if (method.requires_component_specification && method.manual_review_until_specified) {
+    return {
+      barrierId: barrier.id,
+      barrierTitle: barrier.title,
+      barrierCategories,
+      coverageState: 'manual_review',
+      coveredCategories: [],
+      uncoveredCategories: barrierCategories,
+      reason: `Mixed methods coverage depends on component methods — specify to calculate`,
+      displayText: `⚠ Manual review required — specify component methods`,
+    };
+  }
+
+  // Check for 'other' category
+  if (barrierCategories.includes('other')) {
+    return {
+      barrierId: barrier.id,
+      barrierTitle: barrier.title,
+      barrierCategories,
+      coverageState: 'manual_review',
+      coveredCategories: [],
+      uncoveredCategories: barrierCategories,
+      reason: `Barrier tagged 'other' — no research method covers this category`,
+      displayText: `⚠ Manual review required — barrier tagged 'other'`,
+    };
+  }
+
+  // Compute coverage
+  const methodCovers = new Set(method.covers || []);
+  const covered: BarrierCategory[] = [];
+  const uncovered: BarrierCategory[] = [];
+
+  for (const cat of barrierCategories) {
+    if (methodCovers.has(cat)) {
+      covered.push(cat);
+    } else {
+      uncovered.push(cat);
+    }
+  }
+
+  // Determine state
+  let coverageState: CoverageState;
+  let reason: string;
+  let displayText: string;
+
+  if (uncovered.length === 0 && covered.length > 0) {
+    // Full coverage
+    coverageState = 'full';
+    reason = `All barrier categories [${covered.join(', ')}] are covered by ${method.label}`;
+    displayText = `✓ Covered by ${method.label}`;
+  } else if (covered.length > 0 && uncovered.length > 0) {
+    // Partial coverage
+    coverageState = 'partial';
+    reason = `${method.label} addresses [${covered.join(', ')}] but not [${uncovered.join(', ')}]`;
+    displayText = `◐ Partially covered — ${method.label} addresses ${covered.join(', ')} but not ${uncovered.join(', ')}`;
+  } else {
+    // No coverage
+    coverageState = 'none';
+    reason = `${method.label} does not validate any of [${barrierCategories.join(', ')}]`;
+    displayText = `○ Not covered by ${method.label} — suggest out-of-scope`;
+  }
+
+  return {
+    barrierId: barrier.id,
+    barrierTitle: barrier.title,
+    barrierCategories,
+    coverageState,
+    coveredCategories: covered,
+    uncoveredCategories: uncovered,
+    reason,
+    displayText,
+  };
+}
+
+// ─── Main derivation ─────────────────────────────────────────────
+
+/**
+ * Derive barrier coverage for all discovered barriers against the chosen method.
+ *
+ * @param barriers - Array of discovered barriers with barrier_categories
+ * @param methodKey - The method value (e.g., 'usability_testing', 'custom')
+ * @returns Coverage results with in-scope, out-of-scope, and manual-review lists
+ */
+export function deriveBarrierCoverage(
+  barriers: DiscoveredBarrier[],
+  methodKey: string
+): CoverageDerivationResult {
+  const config = loadCoverageConfig();
+  const method = config.methods[methodKey];
+  const methodLabel = method?.label || methodKey;
+
+  const results: BarrierCoverageResult[] = barriers.map((b) =>
+    computeBarrierCoverage(b, methodKey, config)
+  );
+
+  // Categorize results
+  const inScope = results.filter(
+    (r) => r.coverageState === 'full' || r.coverageState === 'partial'
+  );
+  const outOfScope = results.filter((r) => r.coverageState === 'none');
+  const manualReview = results.filter((r) => r.coverageState === 'manual_review');
+
+  // Generate participant hints (OUTPUT B: vague category-level only)
+  const participantHints = deriveParticipantHints(barriers, config);
+
+  return {
+    method: methodKey,
+    methodLabel,
+    barriers: results,
+    inScope,
+    outOfScope,
+    manualReview,
+    participantHints,
+  };
+}
+
+// ─── Participant hints (OUTPUT B) ────────────────────────────────
+
+/**
+ * Derive VAGUE category-level participant composition hints from barriers.
+ *
+ * CRITICAL: Never invent numbers, org names, or specifics.
+ * Output is a SUGGESTION the researcher confirms/edits.
+ */
+function deriveParticipantHints(
+  barriers: DiscoveredBarrier[],
+  _config: CoverageMapConfig
+): string[] {
+  const hints: string[] = [];
+  const categorySet = new Set<BarrierCategory>();
+
+  // Collect all categories across barriers
+  for (const barrier of barriers) {
+    for (const cat of barrier.barrier_categories || []) {
+      categorySet.add(cat);
+    }
+  }
+
+  // Generate category-level hints (NO specifics, NO numbers, NO org names)
+  if (categorySet.has('accessibility')) {
+    hints.push(
+      'Discovery surfaced accessibility barriers; consider including participants who use assistive technology.'
+    );
+  }
+
+  if (categorySet.has('cognitive')) {
+    hints.push(
+      'Discovery surfaced cognitive load barriers; consider including participants with varying tech proficiency levels.'
+    );
+  }
+
+  if (categorySet.has('content')) {
+    hints.push(
+      'Discovery surfaced content comprehension barriers; consider including participants with varying reading levels.'
+    );
+  }
+
+  if (categorySet.has('performance')) {
+    hints.push(
+      'Discovery surfaced performance barriers; note that participant testing may not reproduce real-world latency conditions.'
+    );
+  }
+
+  // If no specific hints generated, return empty (honest-empty)
+  return hints;
+}
+
+// ─── Out-of-scope reason formatting ──────────────────────────────
+
+/**
+ * Generate a traceable out-of-scope reason for a barrier.
+ * Uses the template from method-coverage-map.yaml.
+ */
+export function formatOutOfScopeReason(result: BarrierCoverageResult, methodLabel: string): string {
+  const config = loadCoverageConfig();
+  const methodConfig = Object.values(config.methods).find((m) => m.label === methodLabel);
+  const methodCovers = methodConfig?.covers?.join(', ') || 'none';
+
+  return `"${result.barrierTitle}" is suggested out-of-scope because:
+- Barrier categories: [${result.barrierCategories.join(', ')}]
+- Method chosen: ${methodLabel}
+- Method covers: [${methodCovers}]
+- Gap: ${methodLabel} does not validate [${result.uncoveredCategories.join(', ')}]
+
+To include this barrier, consider:
+- Adding a complementary method that covers [${result.uncoveredCategories.join(', ')}]
+- Using a custom method with manual scope determination`;
+}
+
+// ─── Integration helpers ─────────────────────────────────────────
+
+/**
+ * Format out-of-scope suggestions for brief pre-population.
+ * Returns a bullet list suitable for the out_of_scope field.
+ */
+export function formatOutOfScopeSuggestions(
+  outOfScope: BarrierCoverageResult[],
+  methodLabel: string
+): string {
+  if (outOfScope.length === 0) return '';
+
+  const lines = outOfScope.map((r) => {
+    const uncovered = r.uncoveredCategories.join(', ');
+    return `- ${r.barrierTitle} (${methodLabel} does not cover: ${uncovered})`;
+  });
+
+  return lines.join('\n');
+}
+
+/**
+ * Format participant hints for brief pre-population.
+ * Returns a bullet list suitable for the participant_approach field.
+ */
+export function formatParticipantHints(hints: string[]): string {
+  if (hints.length === 0) return '';
+  return hints.map((h) => `- ${h}`).join('\n');
+}

--- a/backend/src/helpers/barrierCoverageDerivation.ts
+++ b/backend/src/helpers/barrierCoverageDerivation.ts
@@ -90,11 +90,22 @@ let cachedConfig: CoverageMapConfig | null = null;
 function loadCoverageConfig(): CoverageMapConfig {
   if (cachedConfig) return cachedConfig;
 
-  // Path from dist/helpers/ to config/ (which is at /app/config/ in Docker)
-  const configPath = join(__dirname, '../../../config/method-coverage-map.yaml');
+  // Path to config/ - try multiple approaches for Docker compatibility
+  // In Docker: /app/dist/helpers/ → ../../config/ = /app/config/
+  // Fallback to process.cwd() which should be /app/
+  const relativePath = join(__dirname, '../../config/method-coverage-map.yaml');
+  const cwdPath = join(process.cwd(), 'config/method-coverage-map.yaml');
+
+  // Try relative path first, then cwd-based path
+  let configPath = relativePath;
+  try {
+    require('fs').accessSync(relativePath);
+  } catch {
+    configPath = cwdPath;
+  }
 
   try {
-    console.log(`📊 Layer 3: Loading coverage config from ${configPath}`);
+    console.log(`📊 Layer 3: Loading coverage config from ${configPath} (cwd: ${process.cwd()}, __dirname: ${__dirname})`);
     const raw = readFileSync(configPath, 'utf8');
     cachedConfig = yamlLoad(raw) as CoverageMapConfig;
     console.log(`📊 Layer 3: Loaded ${Object.keys(cachedConfig.methods || {}).length} methods from coverage config`);

--- a/backend/src/helpers/barrierCoverageDerivation.ts
+++ b/backend/src/helpers/barrierCoverageDerivation.ts
@@ -90,11 +90,25 @@ let cachedConfig: CoverageMapConfig | null = null;
 function loadCoverageConfig(): CoverageMapConfig {
   if (cachedConfig) return cachedConfig;
 
-  // Path from src/helpers/ to config/ (which is at backend/config/)
+  // Path from dist/helpers/ to config/ (which is at /app/config/ in Docker)
   const configPath = join(__dirname, '../../../config/method-coverage-map.yaml');
-  const raw = readFileSync(configPath, 'utf8');
-  cachedConfig = yamlLoad(raw) as CoverageMapConfig;
-  return cachedConfig;
+
+  try {
+    console.log(`📊 Layer 3: Loading coverage config from ${configPath}`);
+    const raw = readFileSync(configPath, 'utf8');
+    cachedConfig = yamlLoad(raw) as CoverageMapConfig;
+    console.log(`📊 Layer 3: Loaded ${Object.keys(cachedConfig.methods || {}).length} methods from coverage config`);
+    return cachedConfig;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`❌ Layer 3: Failed to load coverage config from ${configPath}: ${message}`);
+    // Return a minimal fallback config to prevent crashes
+    return {
+      schema_version: '1.0',
+      methods: {},
+      barrier_categories: {},
+    };
+  }
 }
 
 /**

--- a/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
+++ b/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
@@ -2,6 +2,12 @@ import { researchBriefModal } from './researchBriefModal';
 import { loadDiscoveryArtifacts, aggregateDiscoveryVariables, type DiscoveryArtifact } from '../../discoveryLoader';
 import { formatVariableCategories } from '../../cascadeVariableCategories';
 import { getProjectApprover } from '../../../services/authorization.service';
+import {
+  deriveBarrierCoverage,
+  formatOutOfScopeSuggestions,
+  formatParticipantHints,
+  type DiscoveredBarrier,
+} from '../../barrierCoverageDerivation';
 import type { WebClient } from '@slack/web-api';
 
 // ─── Modal metadata contract ─────────────────────────────────────
@@ -36,9 +42,20 @@ interface BuildBriefEntryModalOptions {
 /**
  * Synthesize pre-population values from aggregated discovery variables.
  * Returns { method, participants, questions, outOfScope } for field pre-fills.
- * Risks are NOT pre-filled here — they're consumed by brief generation (research_brief.yaml).
+ *
+ * LAYER 3 DERIVATION (2026-06-09):
+ * - Out-of-scope: derived from barrier coverage analysis (method vs. barrier categories)
+ * - Participants: vague category-level hints only — NO fabricated numbers, orgs, or specifics
+ * - Risks are NOT pre-filled here — consumed by brief generation (research_brief.yaml)
+ *
+ * FABRICATION REMOVED: No longer invents "3 screen reader users", "VA Section 508 Office", etc.
+ * If discovery doesn't support a real implication → leave empty (honest-empty).
  */
-function synthesizeCascadeFields(upstream: Record<string, string>, _artifacts: DiscoveryArtifact[]): CascadeFields {
+function synthesizeCascadeFields(
+  upstream: Record<string, string>,
+  _artifacts: DiscoveryArtifact[],
+  methodKey?: string
+): CascadeFields {
   const result: CascadeFields = {};
 
   // Method — from methodology_recommendations
@@ -71,45 +88,60 @@ function synthesizeCascadeFields(upstream: Record<string, string>, _artifacts: D
     }
   }
 
-  // Out of scope — NOT pre-filled from discovery barriers (that was semantically wrong).
-  // Barriers are inputs to research, not scope exclusions. Layer 3 will derive
-  // method-aware exclusions once barrier typing is proven. For now, leave empty
-  // for researcher input. The LLM task has correct guidance for real scope boundaries.
-
-  // Participants — synthesize COMPOSITION from discovery evidence (no recruitment)
-  const segments: string[] = [];
-  const recruitmentChannels: string[] = [];
-
-  // Check for AT user evidence from constraints or survey
-  const constraintText = upstream.upstream_stakeholder_constraints || '';
-  const surveyText = upstream.upstream_survey_themes || '';
+  // ─── LAYER 3: Barrier coverage derivation ───────────────────────
+  // Parse discovered barriers for coverage analysis
   const barrierText = upstream.upstream_discovered_barriers || '';
+  let barriers: DiscoveredBarrier[] = [];
 
-  if (constraintText.match(/screen.reader|assistive.tech|508|accessibility/i) ||
-      surveyText.match(/screen.reader|assistive.tech|accessibility/i) ||
-      barrierText.match(/screen.reader|assistive.tech|accessibility/i)) {
-    segments.push('3 screen reader users');
-    segments.push('2 voice control users');
-    // Accessibility evidence suggests these recruitment channels
-    recruitmentChannels.push('VA Section 508 Office');
-    recruitmentChannels.push('MHV coordinators');
+  if (barrierText) {
+    try {
+      // Try parsing as JSON array first (structured format)
+      const parsed = JSON.parse(barrierText);
+      if (Array.isArray(parsed)) {
+        barriers = parsed as DiscoveredBarrier[];
+      }
+    } catch {
+      // Not JSON — try extracting from formatted text
+      // Format: id, title, barrier_categories, etc. on separate lines
+      const barrierBlocks = barrierText.split(/(?=id:\s*barrier-)/i);
+      for (const block of barrierBlocks) {
+        if (!block.trim()) continue;
+        const idMatch = block.match(/id:\s*(barrier-\d+)/i);
+        const titleMatch = block.match(/title:\s*(.+?)(?:\n|$)/i);
+        const catMatch = block.match(/barrier_categories:\s*\[([^\]]+)\]/i);
+        if (idMatch && titleMatch) {
+          const categories = catMatch
+            ? catMatch[1].split(',').map(c => c.trim().replace(/['"]/g, ''))
+            : [];
+          barriers.push({
+            id: idMatch[1],
+            title: titleMatch[1].trim(),
+            barrier_categories: categories as DiscoveredBarrier['barrier_categories'],
+          });
+        }
+      }
+    }
   }
 
-  // Check for age-related patterns
-  if (barrierText.match(/age|older|65\+|senior/i) ||
-      surveyText.match(/age|older|65\+|senior/i)) {
-    segments.push('at least 3 aged 65+');
+  // Derive coverage if we have barriers and a method
+  if (barriers.length > 0 && methodKey) {
+    const derivation = deriveBarrierCoverage(barriers, methodKey);
+
+    // Out-of-scope suggestions (method-aware, traceable)
+    if (derivation.outOfScope.length > 0) {
+      result.outOfScope = formatOutOfScopeSuggestions(derivation.outOfScope, derivation.methodLabel);
+    }
+
+    // Participant hints (vague category-level only, NO fabrication)
+    if (derivation.participantHints.length > 0) {
+      result.participants = formatParticipantHints(derivation.participantHints);
+    }
   }
 
-  // Composition only — no recruitment text
-  if (segments.length > 0) {
-    result.participants = `8-12 Veterans, including ${segments.join(', ')}. Mix of iOS and Android users.`;
-  }
-
-  // Recruitment separately
-  if (recruitmentChannels.length > 0) {
-    result.recruitment = recruitmentChannels.join(', ');
-  }
+  // ─── NO FABRICATION ─────────────────────────────────────────────
+  // Old code invented: "3 screen reader users", "VA Section 508 Office", etc.
+  // REMOVED. If typed barriers don't support a real implication → leave empty.
+  // Researcher fills in specifics based on their study needs.
 
   return result;
 }
@@ -295,54 +327,95 @@ export async function buildBriefEntryModal(options: BuildBriefEntryModalOptions)
 
       // Aggregate variables for pre-population (pre-fills only, no narration blocks)
       const upstream = aggregateDiscoveryVariables(artifacts) as Record<string, string>;
-      const cascade = synthesizeCascadeFields(upstream, artifacts);
 
-      // Pre-populate method — hybrid radio + override
-      if (cascade.method) {
-        const radioOptions: Record<string, string> = {
-          // Usability Testing
-          'usability testing': 'usability_testing',
-          'usability test': 'usability_testing',
-          'usability study': 'usability_testing',
-          'moderated usability testing': 'usability_testing',
-          'moderated usability test': 'usability_testing',
-          'unmoderated usability testing': 'usability_testing',
-          // User Interviews
-          'user interviews': 'user_interviews',
-          'user interview': 'user_interviews',
-          'interviews': 'user_interviews',
-          'interview': 'user_interviews',
-          // Contextual Inquiry
-          'contextual inquiry': 'contextual_inquiry',
-          'contextual inquiries': 'contextual_inquiry',
-          // Concept Testing
-          'concept testing': 'concept_testing',
-          'concept test': 'concept_testing',
-          'concept validation': 'concept_testing',
-          // Survey Research
-          'survey': 'survey',
-          'survey research': 'survey',
-          'surveys': 'survey',
-          // Card Sorting
-          'card sorting': 'card_sorting',
-          'card sort': 'card_sorting',
-          'card sorts': 'card_sorting',
-          // Tree Testing
-          'tree testing': 'tree_testing',
-          'tree test': 'tree_testing',
-          'tree tests': 'tree_testing',
-          // Mixed Methods
-          'mixed methods': 'mixed_methods',
-          'mixed method': 'mixed_methods',
-        };
-        const methodLower = cascade.method.toLowerCase();
+      // ─── Method resolution (needed for barrier coverage derivation) ───
+      const radioOptions: Record<string, string> = {
+        // Usability Testing
+        'usability testing': 'usability_testing',
+        'usability test': 'usability_testing',
+        'usability study': 'usability_testing',
+        'moderated usability testing': 'usability_testing',
+        'moderated usability test': 'usability_testing',
+        'unmoderated usability testing': 'usability_testing',
+        // User Interviews
+        'user interviews': 'user_interviews',
+        'user interview': 'user_interviews',
+        'interviews': 'user_interviews',
+        'interview': 'user_interviews',
+        // Contextual Inquiry
+        'contextual inquiry': 'contextual_inquiry',
+        'contextual inquiries': 'contextual_inquiry',
+        // Concept Testing
+        'concept testing': 'concept_testing',
+        'concept test': 'concept_testing',
+        'concept validation': 'concept_testing',
+        // Survey Research
+        'survey': 'survey',
+        'survey research': 'survey',
+        'surveys': 'survey',
+        // Card Sorting
+        'card sorting': 'card_sorting',
+        'card sort': 'card_sorting',
+        'card sorts': 'card_sorting',
+        // Tree Testing
+        'tree testing': 'tree_testing',
+        'tree test': 'tree_testing',
+        'tree tests': 'tree_testing',
+        // Mixed Methods
+        'mixed methods': 'mixed_methods',
+        'mixed method': 'mixed_methods',
+      };
 
+      // Extract method suggestion from upstream, resolve to method key
+      let resolvedMethodKey: string | undefined;
+      let methodSuggestion: string | undefined;
+
+      const methodRecs = upstream.upstream_methodology_recommendations;
+      if (methodRecs) {
+        const methods = methodRecs.split('\n').filter((l: string) => l.trim().startsWith('**') || l.trim().startsWith('-'));
+        if (methods.length > 0) {
+          const firstMethod = methods[0].replace(/^\*\*\d+\.\*\*\s*/, '').replace(/^-\s*/, '').split('\n')[0];
+          const methodName = firstMethod.match(/method(?:_name)?:\s*(.+?)(?:,|$)/i)?.[1] || firstMethod.substring(0, 80);
+          methodSuggestion = methodName.trim();
+        }
+      }
+
+      if (methodSuggestion) {
+        const methodLower = methodSuggestion.toLowerCase();
         // Check for exact match first
-        let matchedRadio = radioOptions[methodLower];
-
+        resolvedMethodKey = radioOptions[methodLower];
         // If no exact match, check if method string CONTAINS any known method name
+        if (!resolvedMethodKey) {
+          const orderedKeys = Object.keys(radioOptions).sort((a, b) => b.length - a.length);
+          for (const key of orderedKeys) {
+            if (methodLower.includes(key)) {
+              resolvedMethodKey = radioOptions[key];
+              break;
+            }
+          }
+        }
+        // Check for combined/mixed methods indicators
+        if (!resolvedMethodKey) {
+          const combinedIndicators = ['followed by', 'then', ' + ', ' and ', 'combined with'];
+          const isCombined = combinedIndicators.some(ind => methodLower.includes(ind));
+          if (isCombined) {
+            resolvedMethodKey = 'mixed_methods';
+          }
+        }
+        // If still no match, it's a custom method
+        if (!resolvedMethodKey) {
+          resolvedMethodKey = 'custom';
+        }
+      }
+
+      // Now call synthesizeCascadeFields WITH the resolved method key
+      const cascade = synthesizeCascadeFields(upstream, artifacts, resolvedMethodKey);
+
+      // Pre-populate method — hybrid radio + override (reuse resolution above)
+      if (methodSuggestion) {
+        const methodLower = methodSuggestion.toLowerCase();
+        let matchedRadio = radioOptions[methodLower];
         if (!matchedRadio) {
-          // Priority order: longer matches first to avoid "interview" matching before "user interview"
           const orderedKeys = Object.keys(radioOptions).sort((a, b) => b.length - a.length);
           for (const key of orderedKeys) {
             if (methodLower.includes(key)) {
@@ -351,8 +424,6 @@ export async function buildBriefEntryModal(options: BuildBriefEntryModalOptions)
             }
           }
         }
-
-        // If still no match, check for combined/mixed methods indicators
         if (!matchedRadio) {
           const combinedIndicators = ['followed by', 'then', ' + ', ' and ', 'combined with'];
           const isCombined = combinedIndicators.some(ind => methodLower.includes(ind));

--- a/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
+++ b/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
@@ -110,16 +110,22 @@ function synthesizeCascadeFields(
     for (const block of barrierBlocks) {
       if (!block.trim()) continue;
 
-      // Extract title from header: **1.** Title here
+      // The markdown format from formatObjectAsMarkdown puts the ID in the header:
+      // **1.** barrier-001
+      //   title: Screen-transition latency exceeds abandonment threshold
+      //   barrier_categories: performance
+
+      // Extract id from header: **1.** barrier-001
       const headerMatch = block.match(/\*\*\d+\.\*\*\s*(.+?)(?:\n|$)/);
-      // Extract id: barrier-001 (with optional leading whitespace)
-      const idMatch = block.match(/^\s*id:\s*(barrier-\d+)/im);
+      // Extract title from the title: line
+      const titleMatch = block.match(/^\s*title:\s*(.+?)(?:\n|$)/im);
       // Extract barrier_categories: ia, task-flow (comma-separated, not JSON array)
       const catMatch = block.match(/^\s*barrier_categories:\s*(.+?)(?:\n|$)/im);
 
-      if (headerMatch) {
-        const title = headerMatch[1].trim();
-        const id = idMatch ? idMatch[1] : `barrier-${barriers.length + 1}`;
+      if (headerMatch || titleMatch) {
+        // Use title from the title: line, fall back to header content
+        const title = titleMatch ? titleMatch[1].trim() : (headerMatch ? headerMatch[1].trim() : 'Unknown barrier');
+        const id = headerMatch ? headerMatch[1].trim() : `barrier-${barriers.length + 1}`;
 
         // Parse categories - could be comma-separated or single value
         let categories: string[] = [];

--- a/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
+++ b/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
@@ -142,16 +142,26 @@ function synthesizeCascadeFields(
 
   // Derive coverage if we have barriers and a method
   if (barriers.length > 0 && methodKey) {
-    const derivation = deriveBarrierCoverage(barriers, methodKey);
+    try {
+      console.log(`📊 Layer 3: Deriving coverage for ${barriers.length} barriers with method '${methodKey}'`);
+      const derivation = deriveBarrierCoverage(barriers, methodKey);
+      console.log(`📊 Layer 3: Derivation complete: ${derivation.inScope.length} in-scope, ${derivation.outOfScope.length} out-of-scope, ${derivation.manualReview.length} manual-review`);
 
-    // Out-of-scope suggestions (method-aware, traceable)
-    if (derivation.outOfScope.length > 0) {
-      result.outOfScope = formatOutOfScopeSuggestions(derivation.outOfScope, derivation.methodLabel);
-    }
+      // Out-of-scope suggestions (method-aware, traceable)
+      if (derivation.outOfScope.length > 0) {
+        result.outOfScope = formatOutOfScopeSuggestions(derivation.outOfScope, derivation.methodLabel);
+        console.log(`📊 Layer 3: Generated out-of-scope text: ${result.outOfScope.substring(0, 100)}...`);
+      }
 
-    // Participant hints (vague category-level only, NO fabrication)
-    if (derivation.participantHints.length > 0) {
-      result.participants = formatParticipantHints(derivation.participantHints);
+      // Participant hints (vague category-level only, NO fabrication)
+      if (derivation.participantHints.length > 0) {
+        result.participants = formatParticipantHints(derivation.participantHints);
+        console.log(`📊 Layer 3: Generated participant hints: ${result.participants.substring(0, 100)}...`);
+      }
+    } catch (derivationError) {
+      const message = derivationError instanceof Error ? derivationError.message : String(derivationError);
+      console.error(`❌ Layer 3: Derivation failed: ${message}`);
+      // Continue without derivation - don't crash the modal
     }
   }
 

--- a/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
+++ b/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
@@ -94,33 +94,50 @@ function synthesizeCascadeFields(
   let barriers: DiscoveredBarrier[] = [];
 
   if (barrierText) {
-    try {
-      // Try parsing as JSON array first (structured format)
-      const parsed = JSON.parse(barrierText);
-      if (Array.isArray(parsed)) {
-        barriers = parsed as DiscoveredBarrier[];
-      }
-    } catch {
-      // Not JSON — try extracting from formatted text
-      // Format: id, title, barrier_categories, etc. on separate lines
-      const barrierBlocks = barrierText.split(/(?=id:\s*barrier-)/i);
-      for (const block of barrierBlocks) {
-        if (!block.trim()) continue;
-        const idMatch = block.match(/id:\s*(barrier-\d+)/i);
-        const titleMatch = block.match(/title:\s*(.+?)(?:\n|$)/i);
-        const catMatch = block.match(/barrier_categories:\s*\[([^\]]+)\]/i);
-        if (idMatch && titleMatch) {
-          const categories = catMatch
-            ? catMatch[1].split(',').map(c => c.trim().replace(/['"]/g, ''))
-            : [];
-          barriers.push({
-            id: idMatch[1],
-            title: titleMatch[1].trim(),
-            barrier_categories: categories as DiscoveredBarrier['barrier_categories'],
-          });
+    // Barriers are formatted as markdown by formatObjectAsMarkdown:
+    // **1.** Screen-transition latency exceeds abandonment threshold
+    //   id: barrier-001
+    //   summary: ...
+    //   barrier_categories: performance
+    //
+    // **2.** Navigation structure misaligns with user mental models
+    //   id: barrier-002
+    //   barrier_categories: ia, task-flow
+
+    // Split on numbered headers: **1.**, **2.**, etc.
+    const barrierBlocks = barrierText.split(/(?=\*\*\d+\.\*\*)/);
+
+    for (const block of barrierBlocks) {
+      if (!block.trim()) continue;
+
+      // Extract title from header: **1.** Title here
+      const headerMatch = block.match(/\*\*\d+\.\*\*\s*(.+?)(?:\n|$)/);
+      // Extract id: barrier-001 (with optional leading whitespace)
+      const idMatch = block.match(/^\s*id:\s*(barrier-\d+)/im);
+      // Extract barrier_categories: ia, task-flow (comma-separated, not JSON array)
+      const catMatch = block.match(/^\s*barrier_categories:\s*(.+?)(?:\n|$)/im);
+
+      if (headerMatch) {
+        const title = headerMatch[1].trim();
+        const id = idMatch ? idMatch[1] : `barrier-${barriers.length + 1}`;
+
+        // Parse categories - could be comma-separated or single value
+        let categories: string[] = [];
+        if (catMatch) {
+          const catStr = catMatch[1].trim();
+          // Handle both "ia, task-flow" and "performance" formats
+          categories = catStr.split(',').map(c => c.trim().replace(/['"[\]]/g, ''));
         }
+
+        barriers.push({
+          id,
+          title,
+          barrier_categories: categories as DiscoveredBarrier['barrier_categories'],
+        });
       }
     }
+
+    console.log(`📊 Layer 3: Parsed ${barriers.length} barriers from discovery for coverage analysis`);
   }
 
   // Derive coverage if we have barriers and a method
@@ -370,6 +387,8 @@ export async function buildBriefEntryModal(options: BuildBriefEntryModalOptions)
       let resolvedMethodKey: string | undefined;
       let methodSuggestion: string | undefined;
 
+      console.log(`📊 Layer 3: Discovery variables loaded: ${Object.keys(upstream).join(', ')}`);
+
       const methodRecs = upstream.upstream_methodology_recommendations;
       if (methodRecs) {
         const methods = methodRecs.split('\n').filter((l: string) => l.trim().startsWith('**') || l.trim().startsWith('-'));
@@ -409,7 +428,9 @@ export async function buildBriefEntryModal(options: BuildBriefEntryModalOptions)
       }
 
       // Now call synthesizeCascadeFields WITH the resolved method key
+      console.log(`📊 Layer 3: Method resolved to '${resolvedMethodKey || 'none'}' from suggestion '${methodSuggestion || 'none'}'`);
       const cascade = synthesizeCascadeFields(upstream, artifacts, resolvedMethodKey);
+      console.log(`📊 Layer 3: Cascade fields derived: outOfScope=${!!cascade.outOfScope}, participants=${!!cascade.participants}, method=${!!cascade.method}`);
 
       // Pre-populate method — hybrid radio + override (reuse resolution above)
       if (methodSuggestion) {

--- a/docs/dev-environment-setup.md
+++ b/docs/dev-environment-setup.md
@@ -1,0 +1,363 @@
+# Dev Environment Setup
+
+This document describes how to set up a proper development environment for Qori, with complete isolation from production.
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        PRODUCTION                                │
+│  Railway: main branch auto-deploy                                │
+│  Slack App: "Qori" in research team workspace                   │
+│  Database: Railway Postgres (prod)                               │
+│  URL: qori-slack-production.up.railway.app                      │
+└─────────────────────────────────────────────────────────────────┘
+         ▲
+         │ merge to main (human gate)
+         │
+┌─────────────────────────────────────────────────────────────────┐
+│                        DEVELOPMENT                               │
+│  Railway: dev branch auto-deploy                                 │
+│  Slack App: "Qori Dev" in dev/test workspace                    │
+│  Database: Railway Postgres (dev) OR local Docker               │
+│  URL: qori-slack-dev.up.railway.app OR localhost:3000           │
+└─────────────────────────────────────────────────────────────────┘
+         ▲
+         │ push to dev branch
+         │
+┌─────────────────────────────────────────────────────────────────┐
+│                     LOCAL DEVELOPMENT                            │
+│  feature/* branches                                              │
+│  Local Docker: Postgres + Redis                                  │
+│  ngrok: exposes localhost to Slack                              │
+│  Slack App: "Qori Dev" (same as Railway dev)                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Why This Setup?
+
+The 2-day outage (June 2026) traced to three problems:
+
+1. **No dev environment** — local dev pointed at prod DB
+2. **Two Slack apps in one workspace** — ambiguous command routing
+3. **Code/migration separation** — code deployed without migrations
+
+This setup fixes all three:
+- Separate Railway dev environment with its own DB
+- Separate dev Slack app in a separate workspace
+- Migrations run automatically on every deploy
+
+---
+
+## Step 1: Create Dev Slack App (One-time)
+
+### 1.1 Create the app
+
+1. Go to https://api.slack.com/apps
+2. Click "Create New App" → "From scratch"
+3. App Name: `Qori Dev`
+4. Workspace: Select your **dev/test workspace** (NOT the research team workspace)
+
+### 1.2 Configure Socket Mode
+
+1. Settings → Socket Mode → Enable
+2. Create an App-Level Token:
+   - Name: `socket-mode`
+   - Scopes: `connections:write`
+3. Copy the token (starts with `xapp-1-`)
+
+### 1.3 Configure Bot Token Scopes
+
+OAuth & Permissions → Bot Token Scopes:
+- `app_mentions:read`
+- `channels:history`
+- `channels:read`
+- `chat:write`
+- `commands`
+- `files:read`
+- `groups:history`
+- `groups:read` (critical for private channels)
+- `im:history`
+- `im:read`
+- `im:write`
+- `mpim:history`
+- `mpim:read`
+- `reactions:read`
+- `reactions:write`
+- `users:read`
+- `users:read.email`
+
+### 1.4 Create Slash Commands
+
+Slash Commands → Create New Command for each:
+- `/qori-plan`
+- `/qori-brief`
+- `/qori-discover`
+- `/qori-analyze`
+- `/qori-readout`
+- `/qori-guide`
+- `/qori-help`
+- `/qori-admin`
+
+For Socket Mode apps, Request URL is not needed.
+
+### 1.5 Enable Events
+
+Event Subscriptions → Enable Events
+Subscribe to bot events:
+- `app_mention`
+- `message.channels`
+- `message.groups`
+- `message.im`
+
+### 1.6 Enable Interactivity
+
+Interactivity & Shortcuts → Enable
+(Request URL not needed for Socket Mode)
+
+### 1.7 Install to Workspace
+
+OAuth & Permissions → Install to Workspace
+Copy the Bot Token (starts with `xoxb-`)
+
+### 1.8 Copy All Tokens
+
+You now have three values:
+- `SLACK_BOT_TOKEN` (xoxb-...)
+- `SLACK_SIGNING_SECRET` (from Basic Information page)
+- `SLACK_APP_TOKEN` (xapp-1-...)
+
+---
+
+## Step 2: Create Railway Dev Environment (One-time)
+
+### 2.1 Create the environment
+
+1. Go to your Railway project
+2. Settings → Environments → New Environment
+3. Name: `dev`
+
+Railway will automatically provision new Postgres and Redis instances for this environment.
+
+### 2.2 Configure dev environment
+
+In the `dev` environment:
+
+1. **Variables tab** — Set all environment variables:
+   - Copy from production, then change:
+   - `NODE_ENV=development`
+   - `SLACK_*` → use dev Slack app tokens
+   - `GITHUB_REPO=qori-studies-dev` (or keep same if OK to mix)
+   - `QORI_TEAM_SLUG=friends-lab-dev`
+
+2. **Settings tab** — Configure deployment:
+   - Deploy: `dev` branch
+   - Auto-deploy: Enabled
+
+### 2.3 Create the dev branch
+
+```bash
+git checkout main
+git pull
+git checkout -b dev
+git push -u origin dev
+```
+
+Railway will auto-deploy to the dev environment.
+
+### 2.4 Verify
+
+1. Check Railway deploy logs — should show migrations running
+2. Test a slash command in the dev Slack workspace
+3. Verify data appears in the dev Postgres (Railway Data tab)
+
+---
+
+## Step 3: Local Development Setup
+
+For local development before pushing to dev branch.
+
+### 3.1 Option A: Docker Compose (recommended)
+
+Uses local Postgres + Redis containers:
+
+```bash
+cd backend
+
+# Copy dev env template
+cp .env.dev.example .env
+
+# Edit .env with your dev Slack tokens
+# DB_HOST should be localhost
+
+# Start Postgres and Redis
+docker-compose -f docker-compose-dev.yml up -d postgres redis
+
+# Run the app locally (with hot reload)
+npm run dev
+```
+
+### 3.2 Option B: Railway Dev Database + Local App
+
+Uses Railway dev Postgres, local app:
+
+```bash
+cd backend
+
+# Copy dev env template
+cp .env.dev.example .env
+
+# Edit .env:
+# - Use Railway dev database credentials (from Railway Variables)
+# - Use dev Slack tokens
+
+# Run the app locally
+npm run dev
+```
+
+### 3.3 Expose Local to Slack (if needed)
+
+For local Socket Mode testing, no ngrok needed — Socket Mode handles the connection.
+
+For webhook-based testing (rare), use ngrok:
+```bash
+ngrok http 3000
+# Update Slack app URLs with ngrok URL
+```
+
+---
+
+## Step 4: Daily Workflow
+
+### Feature Development
+
+```bash
+# Start from dev branch
+git checkout dev
+git pull
+git checkout -b feature/my-feature
+
+# Make changes...
+
+# Test locally
+npm run dev
+npm test
+
+# Push to feature branch
+git push -u origin feature/my-feature
+
+# Create PR to dev branch
+# CI runs typecheck, tests, migration check
+# Merge when green
+
+# dev branch auto-deploys to Railway dev environment
+# Test in dev Slack workspace
+```
+
+### Promoting to Production
+
+```bash
+# After testing in dev environment:
+git checkout main
+git pull
+git merge dev
+git push
+
+# main branch auto-deploys to Railway production
+# Migrations run automatically
+```
+
+---
+
+## Step 5: Migration Discipline
+
+Migrations now run automatically on every deploy (dev and prod).
+
+### How it works
+
+1. `scripts/start.sh` runs before the app starts
+2. It waits for database connection
+3. Runs `npx sequelize-cli db:migrate`
+4. Verifies migration count matches expected
+5. Only then starts `node ./dist/app.js`
+
+### Creating new migrations
+
+```bash
+cd backend
+npx sequelize-cli migration:generate --name my-migration-name
+# Edit the migration file
+# Commit with the code that depends on it
+```
+
+### CI Verification
+
+CI runs a "Verify migrations" step that:
+1. Runs all pending migrations
+2. Counts applied vs expected
+3. Fails if there's a mismatch
+
+This catches migration issues before they reach production.
+
+---
+
+## Environment Safety Checklist
+
+Before running locally, verify:
+
+| Check | Dev Value | Prod Value (STOP) |
+|-------|-----------|-------------------|
+| `NODE_ENV` | `development` | `production` |
+| `SLACK_APP_TOKEN` | `xapp-1-A0X...` (dev app) | `xapp-1-A0Y...` (prod app) |
+| `DB_HOST` | `localhost` or `dev.railway.app` | `*.railway.internal` |
+| Workspace | Dev/test workspace | Research team workspace |
+
+If you see production values in your local `.env`, STOP and fix before running.
+
+---
+
+## Troubleshooting
+
+### "Dialect needs to be explicitly supplied"
+
+Check for spaces around `=` in your env vars. `DB_DIALECT = postgres` (with spaces) breaks Sequelize.
+
+### Slack commands go to wrong app
+
+Verify:
+1. You're in the correct workspace (dev vs prod)
+2. Only one Qori app is installed per workspace
+3. Socket Mode is enabled in the Slack app config
+
+### Migrations didn't run
+
+Check Railway deploy logs. Look for:
+```
+=== Qori Backend Startup ===
+Running database migrations...
+Migrations completed successfully.
+```
+
+If you see "ERROR: Migrations failed!", check the error message.
+
+### Database connection fails on startup
+
+The startup script waits 60 seconds for the database. If it still fails:
+1. Check Railway Postgres service is running
+2. Verify DB credentials in environment variables
+3. Check if Postgres is still provisioning (can take a minute on first deploy)
+
+---
+
+## Reference: File Locations
+
+| File | Purpose |
+|------|---------|
+| `backend/.env.example` | Prod environment template |
+| `backend/.env.dev.example` | Dev environment template |
+| `backend/.env` | Your local config (gitignored) |
+| `backend/scripts/start.sh` | Startup script with migrations |
+| `backend/Dockerfile` | Production container (runs start.sh) |
+| `backend/Dockerfile.dev` | Dev container (runs migrations + nodemon) |
+| `backend/docker-compose-dev.yml` | Local Docker setup |
+| `.github/workflows/ci.yml` | CI with migration verification |

--- a/docs/dev-environment-setup.md
+++ b/docs/dev-environment-setup.md
@@ -90,13 +90,20 @@ OAuth & Permissions → Bot Token Scopes:
 ### 1.4 Create Slash Commands
 
 Slash Commands → Create New Command for each:
-- `/qori-plan`
+- `/qori`
+- `/qori-start`
 - `/qori-brief`
+- `/qori-plan`
 - `/qori-discover`
+- `/qori-fieldwork`
 - `/qori-analyze`
-- `/qori-readout`
-- `/qori-guide`
-- `/qori-help`
+- `/qori-synthesis`
+- `/qori-report`
+- `/qori-tickets`
+- `/qori-ask`
+- `/qori-learn`
+- `/qori-repo`
+- `/qori-sync`
 - `/qori-admin`
 
 For Socket Mode apps, Request URL is not needed.
@@ -168,7 +175,7 @@ Railway will auto-deploy to the dev environment.
 ### 2.4 Verify
 
 1. Check Railway deploy logs — should show migrations running
-2. Test a slash command in the dev Slack workspace
+2. Test a slash command in the dev Slack workspace (e.g., `/qori`)
 3. Verify data appears in the dev Postgres (Railway Data tab)
 
 ---


### PR DESCRIPTION
## Summary
- Adds method-coverage-map.yaml as single source of truth for which research methods cover which barrier categories
- Implements Layer 3 derivation logic (barrierCoverageDerivation.ts) that computes barrier coverage state (full/partial/none)
- Generates traceable out-of-scope suggestions with method-aware reasoning
- Adds methodology-grounded participant guidance (e.g., "5-8 participants for usability testing") instead of fabricated specifics
- Removes all fabrication code paths from research brief modal

## Test plan
- [x] Proven on dev with real discovery data (6 barriers, 5 typed correctly)
- [x] Three-state coverage verified: partial = in-scope with uncovered-dimensions note
- [x] Participant hints traceable to YAML config + barrier categories
- [x] No fabricated specifics (confirmed via grep)
- [ ] After merge: verify prod deployment logs (start.sh → migration → schema validation)
- [ ] Run ONE brief in prod with discovery barriers to confirm participant field shows grounded guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)