### PR TITLE
fix: add postEphemeralOrDM helper for channel fallback to DM

### DIFF
--- a/backend/src/helpers/slack/commands/discoverHandler.ts
+++ b/backend/src/helpers/slack/commands/discoverHandler.ts
@@ -24,6 +24,7 @@ import { processSlackFiles } from '../../pdfProcessor';
 import { parseDocuments, validateDocuments } from '../../documentParser';
 import { getProjectByChannelId } from '../../../services/project.service';
 import type { VariableContext } from '../../studyVariables';
+import { postEphemeralOrDM } from '../slackHelpers';
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -216,15 +217,17 @@ async function discoverHandler({ ack, body, client, command }: SlackCommandMiddl
   await ack();
 
   const channelId = command.channel_id;
+  const userId = command.user_id;
 
   // Phase 2D: Check channel binding for project context
   const project = await getProjectByChannelId(channelId);
   if (!project) {
-    await client.chat.postEphemeral({
-      channel: channelId,
-      user: command.user_id,
-      text: `This channel isn't linked to a project yet.\n\n*Option 1:* Run \`/qori-start\` to create a new project with a dedicated channel, then run \`/qori-discover\` there.\n*Option 2:* Run \`/qori-discover\` in an existing project channel.`,
-    });
+    await postEphemeralOrDM(
+      client,
+      channelId,
+      userId,
+      `This channel isn't linked to a project yet.\n\n*Option 1:* Run \`/qori-start\` to create a new project with a dedicated channel, then run \`/qori-discover\` there.\n*Option 2:* Run \`/qori-discover\` in an existing project channel.`
+    );
     return;
   }
 
@@ -275,11 +278,12 @@ async function discoverHandler({ ack, body, client, command }: SlackCommandMiddl
     const message = err instanceof Error ? err.message : String(err);
     const detail = (err as Record<string, unknown>)?.data ?? message;
     console.error('Error opening discover hub:', detail);
-    await client.chat.postEphemeral({
-      channel: channelId,
-      user: command.user_id,
-      text: '❌ Failed to open the discovery hub. Please try again.',
-    });
+    await postEphemeralOrDM(
+      client,
+      channelId,
+      userId,
+      '❌ Failed to open the discovery hub. Please try again.'
+    );
   }
 }
 

--- a/backend/src/helpers/slack/slackHelpers.ts
+++ b/backend/src/helpers/slack/slackHelpers.ts
@@ -1,0 +1,48 @@
+/**
+ * slackHelpers.ts — Shared utilities for Slack interactions
+ *
+ * These helpers handle common edge cases like posting to channels
+ * where the bot may not be a member.
+ */
+
+import type { WebClient } from '@slack/web-api';
+import type { KnownBlock } from '@slack/types';
+
+/**
+ * Post an ephemeral message to a channel, falling back to DM if the bot
+ * isn't a member of the channel.
+ *
+ * Use this instead of raw `client.chat.postEphemeral` when the bot might
+ * not be a member of the channel (e.g., slash commands can be invoked
+ * from any channel, even ones the bot hasn't joined).
+ */
+export async function postEphemeralOrDM(
+  client: WebClient,
+  channelId: string,
+  userId: string,
+  text: string,
+  blocks?: KnownBlock[]
+): Promise<void> {
+  try {
+    await client.chat.postEphemeral({
+      channel: channelId,
+      user: userId,
+      text,
+      blocks,
+    });
+  } catch (err) {
+    // Channel post failed (bot not a member, channel archived, etc.)
+    // Fall back to DM to the user
+    const errorCode = (err as { data?: { error?: string } })?.data?.error;
+    if (errorCode === 'channel_not_found' || errorCode === 'not_in_channel') {
+      await client.chat.postMessage({
+        channel: userId,
+        text,
+        blocks,
+      });
+    } else {
+      // Re-throw unexpected errors
+      throw err;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds shared `slackHelpers.ts` with `postEphemeralOrDM` utility
- When slash commands are invoked in channels where the bot isn't a member, `postEphemeral` fails with `channel_not_found`. This helper falls back to DM when that happens.
- Updates `discoverHandler.ts` to use the shared helper
- Other handlers can adopt incrementally

## Test plan
- [x] Tested on dev: `/qori-discover` in unlinked channel now sends DM instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)