### PR TITLE
fix: complete study delete confirmation counts + admin postEphemeralOrDM

### DIFF
--- a/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
+++ b/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
@@ -826,7 +826,10 @@ export async function handleDeleteStudySelect({
                 `*Records to be deleted:*\n` +
                 `• ${counts.participants} participants\n` +
                 `• ${counts.notes} session notes/transcripts\n` +
+                `• ${counts.summaries || 0} session summaries\n` +
                 `• ${counts.variables} cascade variables\n` +
+                `• ${counts.plans || 0} research plans\n` +
+                `• ${counts.statuses || 0} approval records\n` +
                 `• GitHub files at \`${study.path || '(no path)'}\``,
             },
           },

--- a/backend/src/helpers/slack/commands/admin/adminCenterHandler.ts
+++ b/backend/src/helpers/slack/commands/admin/adminCenterHandler.ts
@@ -8,6 +8,7 @@
 import type { AllMiddlewareArgs, SlackCommandMiddlewareArgs } from '@slack/bolt';
 import { isProjectOwner, isProjectMember, getProjectStakeholder } from '../../../../services/authorization.service';
 import { buildAdminCenterModal, buildNonOwnerModal, type StakeholderInfo } from '../../ui/adminCenterModal';
+import { postEphemeralOrDM } from '../../slackHelpers';
 import sequelize from '../../../../database';
 
 import type { Project } from '../../../../database/models/project';
@@ -37,13 +38,13 @@ export async function adminCenterCommandHandler({
     });
 
     if (!project) {
-      await client.chat.postEphemeral({
-        channel: channelId,
-        user: userId,
-        text:
-          'This channel is not associated with a Qori project.\n\n' +
-          'Run `/qori-admin` from a project channel, or use `/qori-start` to create a new project.',
-      });
+      await postEphemeralOrDM(
+        client,
+        channelId,
+        userId,
+        'This channel is not associated with a Qori project.\n\n' +
+        'Run `/qori-admin` from a project channel, or use `/qori-start` to create a new project.'
+      );
       return;
     }
 
@@ -86,11 +87,12 @@ export async function adminCenterCommandHandler({
     }
   } catch (error) {
     console.error('[ADMIN] Error opening admin center:', error);
-    await client.chat.postEphemeral({
-      channel: channelId,
-      user: userId,
-      text: `Error opening Admin Center: ${error instanceof Error ? error.message : 'Unknown error'}`,
-    });
+    await postEphemeralOrDM(
+      client,
+      channelId,
+      userId,
+      `Error opening Admin Center: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
   }
 }
 

--- a/backend/src/services/audit.service.ts
+++ b/backend/src/services/audit.service.ts
@@ -21,6 +21,9 @@ const StudyParticipantModel = sequelize.models.StudyParticipant;
 const StudyNotesModel = sequelize.models.StudyNotes;
 const StudyVariableModel = sequelize.models.StudyVariable;
 const SessionObserverModel = sequelize.models.SessionObserver;
+const ResearchPlanModel = sequelize.models.ResearchPlan;
+const StudyStatusModel = sequelize.models.StudyStatus;
+const SessionSummaryModel = sequelize.models.SessionSummary;
 
 // ═══════════════════════════════════════════════════════════════════════
 // TYPES
@@ -109,16 +112,22 @@ export async function logDispositionAction(entry: AuditEntry): Promise<Dispositi
  * CALL THIS BEFORE DELETE — after delete, counts will be zero.
  */
 export async function gatherStudyRecordCounts(studyId: number): Promise<Record<string, number>> {
-  const [participants, notes, variables] = await Promise.all([
+  const [participants, notes, variables, plans, statuses, summaries] = await Promise.all([
     StudyParticipantModel.count({ where: { study_id: studyId } }),
     StudyNotesModel.count({ where: { study_id: studyId } }),
     StudyVariableModel.count({ where: { study_id: studyId } }),
+    ResearchPlanModel.count({ where: { study_id: studyId } }),
+    StudyStatusModel.count({ where: { study_id: studyId } }),
+    SessionSummaryModel.count({ where: { study_id: studyId } }),
   ]);
 
   return {
     participants,
     notes,
     variables,
+    plans,
+    statuses,
+    summaries,
   };
 }
 


### PR DESCRIPTION
## Summary
- Shows all related records in study delete confirmation (was missing summaries, plans, statuses)
- Adds postEphemeralOrDM to admin center handler (prevents crash in unlinked channels)

## Records now shown in delete confirmation:
- participants
- session notes/transcripts
- session summaries (NEW)
- cascade variables
- research plans (NEW)
- approval records (NEW)
- GitHub files

## Test plan
- [x] Typecheck passes
- [ ] Verify counts match actual database

🤖 Generated with [Claude Code](https://claude.com/claude-code)