### PR TITLE
fix: research plan participant deduplication + cascade fixes

### DIFF
--- a/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
+++ b/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
@@ -56,17 +56,26 @@ interface DiscussionGuideTemplateInput {
 
 // ─── Cascade formatting helpers ─────────────────────────────────
 
+interface ResearchObjective {
+  id?: string;
+  objective?: string;
+}
+
 interface ResearchQuestion {
   id?: string;
   question?: string;
   priority?: string;
 }
 
-/** Format research_objectives (array of strings) as bullet list for pre-fill. */
+/** Format research_objectives (array of {id, objective}) as bullet list for pre-fill. */
 function formatObjectivesForPrefill(objectives: unknown): string {
   if (!Array.isArray(objectives)) return '';
   return objectives
-    .map(obj => typeof obj === 'string' ? `• ${obj}` : '')
+    .map((obj: ResearchObjective) => {
+      const id = obj.id || '';
+      const objective = obj.objective || '';
+      return id && objective ? `• ${id}: ${objective}` : objective ? `• ${objective}` : '';
+    })
     .filter(Boolean)
     .join('\n');
 }

--- a/backend/src/helpers/slack/commands/planHandler.ts
+++ b/backend/src/helpers/slack/commands/planHandler.ts
@@ -39,7 +39,7 @@ interface PlanTemplateInput {
   operational_risks: string;
   per_participant_compensation: number | null;
   parsed_budget_amount: number | null;
-  target_participants: number | null;
+  target_participants: string;
   timeline_phases: TimelinePhase[];
   timeline_summary: string;
   start_date: string;
@@ -168,18 +168,20 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
     { key: 'timeline_preference', required: false },
     { key: 'start_date', required: false },
     { key: 'recruitment_sources', required: false },
+    { key: 'participant_approach', required: false },
   ]);
 
   // ── Cascade-owned fields (brief owns these — plan modal no longer has these fields) ──
   const timelinePref = (upstream.timeline_preference?.value as string) || 'standard';
   const startDate = (upstream.start_date?.value as string) || '';
   const recruitmentSources = (upstream.recruitment_sources?.value as string) || '';
+  const participantApproach = (upstream.participant_approach?.value as string) || '';
 
   // ── Timeline phases (mechanical) ──
   const timelinePhases = buildTimelinePhases(startDate, timelinePref);
   const timelineSummary = buildTimelineSummary(timelinePhases);
 
-  const upstreamObjectives = upstream.research_objectives?.value as string[] | undefined;
+  const upstreamObjectives = upstream.research_objectives?.value as { id?: string; objective?: string }[] | undefined;
   const upstreamQuestions = (upstream.research_questions?.value || []) as ResearchQuestion[];
   const upstreamBarriers = (upstream.target_barriers?.value || []) as TargetBarrier[];
   const methodology = (upstream.methodology_selection?.value || '') as string;
@@ -193,10 +195,10 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
     );
   }
 
-  // ── Transform objectives: brief emits plain strings (ADR 0006), plan needs {id, objective} ──
-  const objectives = upstreamObjectives.map((item: string, index: number) => ({
-    id: `OBJ-${String(index + 1).padStart(3, '0')}`,
-    objective: item,
+  // ── Brief emits {id, objective} objects (schema updated June 6, 2026) ──
+  const objectives = upstreamObjectives.map((item, index: number) => ({
+    id: item.id || `OBJ-${String(index + 1).padStart(3, '0')}`,
+    objective: item.objective || '',
   }));
 
   // ── Assemble the complete data object ──
@@ -209,7 +211,7 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
 
     per_participant_compensation: perParticipantComp,
     parsed_budget_amount: study!.parsed_budget_amount,
-    target_participants: study!.target_participants,
+    target_participants: participantApproach || (study!.target_participants ? String(study!.target_participants) : ''),
 
     timeline_phases: timelinePhases,
     timeline_summary: timelineSummary,

--- a/config/prompts/research_plan.yaml
+++ b/config/prompts/research_plan.yaml
@@ -4,11 +4,12 @@
 id: research_plan
 name: run_research_plan
 label: "📋 Research Plan"
-version: "v7.0"
+version: "v7.1"
 
 description: |
   Transform your research concept into a stakeholder-ready execution plan.
   Lean output focused on methodology, participants, timeline, and deliverables.
+  v7.1: Fix participant duplication — glance value in summary, detail once in section.
   v7.0: Interleaved Handlebars/AI architecture — computed values render
   mechanically, LLM only writes bounded prose sections.
 
@@ -220,9 +221,22 @@ ai_generation_tasks:
       screen recording, observer notes, post-session interviews, etc.
       Be specific to the methodology.
 
+  - task_id: "participant_glance"
+    prompt: |
+      Write a ONE-LINE glance summary of participant composition for an at-a-glance table.
+
+      {% if upstream_participant_approach %}
+      FULL APPROACH: {{upstream_participant_approach}}
+      {% endif %}
+
+      Output ONLY a single line with count + segment names. Example format:
+      "8-10 veterans across five segments: appointments, benefits, assistive-tech, lower tech proficiency, VA terminology"
+
+      NO rationale, NO detail — just count and segment names. This is for a summary table cell.
+
   - task_id: "participant_composition_prose"
     prompt: |
-      Write a short bullet list explaining required participant composition.
+      Write a brief participant requirements section with sample size and composition.
 
       {% if upstream_participant_criteria %}
       APPROVED CRITERIA: {{upstream_participant_criteria}}
@@ -231,9 +245,11 @@ ai_generation_tasks:
       APPROACH: {{upstream_participant_approach}}
       {% endif %}
 
-      Output ONLY the bullet list (use markdown dash -). Each distinct
-      criterion gets its own bullet. Include accessibility needs and
-      demographic diversity requirements if relevant.
+      Structure:
+      1. ONE sentence stating sample size and rationale (e.g., "Recruit 8-10 participants across five defined segments to ensure coverage of documented discovery barriers")
+      2. A bullet list (use markdown dash -) with each segment on its own line, including count per segment and brief rationale
+
+      Keep it actionable. Include accessibility segments and demographic diversity requirements if specified in the criteria.
 
   - task_id: "deliverables_narrative"
     prompt: |
@@ -328,7 +344,7 @@ output_template: |
   | | |
   |---|---|
   | **Method** | {{methodology}} |
-  | **Participants** | {{target_participants}} |
+  | **Participants** | {{ai_generated.participant_glance}} |
   | **Timeline** | {{timeline_summary}} |
 
   ---
@@ -368,10 +384,6 @@ output_template: |
   ---
 
   ## Participants
-
-  **Sample size** — {{target_participants}}
-
-  **Required composition:**
 
   {{ai_generated.participant_composition_prose}}
 
@@ -421,8 +433,6 @@ output_template: |
   {{#each brief_operationalization}}
   | **{{this.commitment}}** | {{this.address}} |
   {{/each}}
-
-  ---
 
   ---
 

--- a/config/prompts/research_plan.yaml
+++ b/config/prompts/research_plan.yaml
@@ -236,7 +236,7 @@ ai_generation_tasks:
 
   - task_id: "participant_composition_prose"
     prompt: |
-      Write a brief participant requirements section with sample size and composition.
+      Write participant requirements content (sample size + composition).
 
       {% if upstream_participant_criteria %}
       APPROVED CRITERIA: {{upstream_participant_criteria}}
@@ -249,6 +249,7 @@ ai_generation_tasks:
       1. ONE sentence stating sample size and rationale (e.g., "Recruit 8-10 participants across five defined segments to ensure coverage of documented discovery barriers")
       2. A bullet list (use markdown dash -) with each segment on its own line, including count per segment and brief rationale
 
+      Output ONLY the content. NO header (the template provides the section header).
       Keep it actionable. Include accessibility segments and demographic diversity requirements if specified in the criteria.
 
   - task_id: "deliverables_narrative"

--- a/docs/dev-environment-setup.md
+++ b/docs/dev-environment-setup.md
@@ -156,6 +156,7 @@ In the `dev` environment:
    - `SLACK_*` → use dev Slack app tokens
    - `GITHUB_REPO=qori-studies-dev` (or keep same if OK to mix)
    - `QORI_TEAM_SLUG=friends-lab-dev`
+   - `GITHUB_CONFIG_BRANCH=dev` ← **Critical for template testing**
 
 2. **Settings tab** — Configure deployment:
    - Deploy: `dev` branch
@@ -353,6 +354,18 @@ The startup script waits 60 seconds for the database. If it still fails:
 1. Check Railway Postgres service is running
 2. Verify DB credentials in environment variables
 3. Check if Postgres is still provisioning (can take a minute on first deploy)
+
+### Template changes not showing up in dev
+
+**Symptom:** You edited a YAML template in `config/prompts/`, pushed to dev branch, but dev environment still renders the old template.
+
+**Cause:** Templates are fetched from GitHub at runtime. Without `GITHUB_CONFIG_BRANCH` set, the backend fetches from the **default branch (main)**, not dev.
+
+**Fix:** Set `GITHUB_CONFIG_BRANCH=dev` in Railway dev environment variables.
+
+This is an invisible trap — dev tests dev's **code** but main's **templates** unless this variable is set. With it set, dev properly tests both dev code AND dev templates before promotion to main.
+
+**Note:** Production should NOT have this variable set (or set to `main`). Prod fetches from main, which is correct.
 
 ---
 


### PR DESCRIPTION
## Summary
- **Research plan participant deduplication (v7.1)**: Summary table now shows one-line glance value, detail appears once in Participants section (not three times)
- **Objectives [object Object] fix**: Handler now correctly extracts `objective` field from cascade objects
- **Participants empty fix**: Handler now loads `participant_approach` from cascade
- **Discussion guide session focus pre-fill**: Now correctly extracts objectives from cascade
- **Double header fix**: AI composition task no longer generates its own header

## Verified in dev
All fixes tested against dev templates with `GITHUB_CONFIG_BRANCH=dev` set.

## Test plan
- [x] Typecheck passes
- [x] Research plan renders participant info once (verified in dev)
- [x] Objectives render correctly (not [object Object])
- [x] No double headers in Participants section

🤖 Generated with [Claude Code](https://claude.com/claude-code)