### PR TITLE
fix: 5f transcript validation — inline errors, trim check, content gate

### DIFF
--- a/backend/docs/qori-modal-design-standard.md
+++ b/backend/docs/qori-modal-design-standard.md
@@ -1,0 +1,329 @@
+# Qori Modal Design Standard
+
+This document captures the design rulings for Slack Block Kit modals across the Qori application. Each ruling (R1-R10) addresses a specific aspect of modal presentation and behavior.
+
+---
+
+## Rulings
+
+### R1: No Decorative Emoji
+
+Remove all decorative emoji from modals. Emoji are permitted only when they carry semantic meaning (e.g., `:warning:` for error states). Decorative emoji (`:file_folder:`, `:bust_in_silhouette:`, `:sparkles:`, artifact icons like `📄`, `🎙️`) should be removed.
+
+**Status:** Enforced. Applied to Research Synthesis, Analyze Session, Tickets, and Research Brief modals.
+
+---
+
+### R2: Action-Oriented Submit Labels
+
+Submit button text should describe the action, not just "Submit". Examples:
+- "Analyze" (for analyze modal when transcript is selected)
+- "Continue" (for analyze modal cascade steps)
+- "Generate" (for synthesis modal)
+- "Create Brief" (for brief modal)
+
+**Status:** Enforced.
+
+---
+
+### R3: No Redundant Section Headers
+
+Remove redundant section headers when the input label is self-explanatory. For example, a "Research Study" section header followed by a "Study *" select is redundant — the label suffices.
+
+**Status:** Enforced.
+
+---
+
+### R4: Domain-Accurate Terminology
+
+Use terminology that matches the domain. "Synthesis" (not "Analysis") for cross-session synthesis methods. "Analyze" for single-session analysis.
+
+**Status:** Enforced.
+
+---
+
+### R5: Researcher-Friendly Labels
+
+Translate system labels to researcher language. Examples:
+- "participant metadata" → "participant"
+- "target_barriers" → "target barriers"
+- Strip `_metadata` suffixes and convert `snake_case` to spaces.
+
+**Status:** Enforced.
+
+---
+
+### R6: App Icon Consistency
+
+The production app icon is canonical. The blue-book icon visible in the dev environment is a dev-environment artifact (the Qori Dev Slack app). No code change required — verify against production.
+
+**Status:** Verified. No action needed.
+
+---
+
+### R7: Required/Optional Field Convention
+
+Optional fields carry a `(optional)` suffix added by Slack's `optional: true` flag; all unmarked fields are required. No asterisks.
+
+Required fields are enforced by submit validation (inline error on empty), not visual marking alone. A field is REQUIRED if and only if the cascade variable it populates is consumed by a downstream template, per the `emits`/`consumes` contracts in the YAML templates.
+
+Prefill from discovery satisfies but does not alter required status.
+
+**Before changing modal code:** Derive the required-field set from YAML contracts (see §6 Required Field Derivation).
+
+**Status:** Pending derivation audit.
+
+---
+
+### R8: Grounding Context Blocks
+
+When showing cascade context (session counts, nuggets, enrichments), use a single subordinate context block with the pattern:
+
+```
+*Using:*  1 session • 12 nuggets • 5 target barriers
+```
+
+or
+
+```
+*Analyzing against:*  3 barriers • 5 questions • Usability Testing
+```
+
+Keep grounding information compact — one line, `•` separators, no decorative emoji.
+
+**Status:** Enforced.
+
+---
+
+### R9: Proper Pluralization
+
+Use correct singular/plural forms:
+- `${count} finding${count !== 1 ? 's' : ''}`
+- `${count} session${count !== 1 ? 's' : ''}`
+- `${count} barrier${count !== 1 ? 's' : ''}`
+
+**Status:** Enforced.
+
+---
+
+### R10: Visual Hierarchy
+
+- **Primary inputs** (study select, method select): Use `input` blocks with labels
+- **Grounding/status info**: Use `context` blocks (subordinate, smaller text)
+- **Section dividers**: Use sparingly, only between logical groups
+- **Warnings**: Use `context` blocks with `:warning:` prefix
+
+**Status:** Enforced.
+
+---
+
+## §5: Modal Inventory
+
+| Modal File | Primary Template | Command |
+|------------|------------------|---------|
+| `researchBriefModal.ts` / `researchBriefEntryModal.ts` | `research_brief.yaml` | `/qori-brief` |
+| `analyzeNotesModal.ts` | `session_summary.yaml` | `/qori-analyze` |
+| `researchSynthesisModal.ts` | `affinity_mapping.yaml`, `journey_mapping.yaml`, etc. | `/qori-synthesis` |
+| `readoutModal.ts` | `research_readout.yaml`, `designer_readout.yaml`, etc. | `/qori-readout` |
+| `discussionGuideModal.ts` | `discussion_guide.yaml` | `/qori-guide` |
+| `researchPlanGeneratorModal.ts` | `research_plan.yaml` | `/qori-plan` |
+| `discoverTypeModals.ts` | `desk_research.yaml`, `stakeholder_synthesis.yaml`, `survey_synthesis.yaml` | `/qori-discover` |
+| `projectCreationModal.ts` | (creates project, no template) | `/qori-project` |
+| `addParticipantModal.ts` | (DB operation, no template) | (fieldwork) |
+| `sessionNotesModal.ts` | (upload handler) | `/qori-notes` |
+| `uploadNotesModal.ts` | (upload handler) | `/qori-notes` |
+
+---
+
+## §6: Required Field Derivation
+
+**Status:** Audit in progress. Tables below derived from YAML contracts.
+
+For each modal in §5, derive:
+- field → cascade variable it populates → downstream consumer(s) → required Y/N
+- Cite YAML file + section for each consumer claim
+- Flag ambiguous contracts
+
+---
+
+### 6.1 Research Brief Modal
+
+**Emits → Consumes chain analysis:**
+
+| Brief emits | Required by downstream | YAML citation |
+|-------------|------------------------|---------------|
+| `research_objectives` | research_plan (required), discussion_guide (required) | `research_plan.yaml:54-58`, `discussion_guide.yaml:54-58` |
+| `research_questions` | research_plan (required), discussion_guide (required) | `research_plan.yaml:59-63`, `discussion_guide.yaml:59-63` |
+| `target_barriers` | research_plan (required), discussion_guide (required) | `research_plan.yaml:69-73`, `discussion_guide.yaml:69-73` |
+| `methodology_selection` | research_plan (required), discussion_guide (required) | `research_plan.yaml:64-68`, `discussion_guide.yaml:64-68` |
+| `participant_criteria` | research_plan (required) | `research_plan.yaml:74-78` |
+| `participant_approach` | research_plan (optional) | `research_plan.yaml:79-83` |
+| `out_of_scope` | research_plan (optional) | `research_plan.yaml:89-93` |
+| `business_context` | research_plan (optional) | `research_plan.yaml:84-88` |
+| `timeline_preference` | research_plan (optional) | `research_plan.yaml:94-98` |
+| `start_date` | research_plan (optional) | `research_plan.yaml:99-100` |
+| `decision_deadline` | (none) | — |
+| `budget` | (none) | — |
+| `recruitment_sources` | (none) | — |
+
+**Field → Cascade Variable → Required derivation:**
+
+| Modal Field | Cascade Variable | Required consumer? | R7 Required? |
+|-------------|------------------|-------------------|--------------|
+| `study_name` | `selected_study` (filename only) | No cascade consumer | **NO** |
+| `stakeholder` | `requestor_name` (masthead only) | No cascade consumer | **NO** |
+| `problem_statement` | → AI generates `business_context` | All consumers optional | **NO** |
+| `learning_objectives` | → AI generates `research_objectives` | research_plan, discussion_guide | **YES** |
+| `out_of_scope` | `out_of_scope` | All consumers optional | **NO** |
+| `research_method` | `methodology_selection` | research_plan, discussion_guide | **YES** |
+| `method_override` | (overrides methodology) | Same as research_method (override) | **NO** |
+| `participant_approach` | → AI generates `participant_criteria` | research_plan | **YES** |
+| `recruitment_sources` | `recruitment_sources` | No cascade consumer | **NO** |
+| `start_date` | `start_date` | All consumers optional | **NO** |
+| `decision_deadline` | `decision_deadline` | No cascade consumer | **NO** |
+| `budget` | `budget` | No cascade consumer | **NO** |
+
+**Ambiguous contracts (flagged for review):**
+
+1. **`research_questions`** — AI-generated from `learning_objectives`. Required by downstream (research_plan, discussion_guide). This makes `learning_objectives` indirectly required. ✅ Already covered above.
+
+2. **`target_barriers`** — AI-generated from `problem_statement` + discovery data. Required by downstream (research_plan, discussion_guide). Contract is ambiguous: `problem_statement` is one of multiple inputs to the AI task that generates barriers. **Recommendation:** If target_barriers must exist, then `problem_statement` should be required. Flagged for design review.
+
+**R7 Derived Required Fields for Brief modal:**
+- `learning_objectives` (populates `research_objectives`, required by research_plan/discussion_guide)
+- `research_method` (populates `methodology_selection`, required by research_plan/discussion_guide)
+- `participant_approach` (populates `participant_criteria`, required by research_plan)
+
+**Fields that are currently required but R7 says should be optional:**
+- `study_name` — no cascade consumer
+- `stakeholder` — no cascade consumer
+- `problem_statement` — ambiguous (see flag #2)
+- `out_of_scope` — all consumers optional
+- `start_date` — all consumers optional
+- `decision_deadline` — no cascade consumer
+
+---
+
+### 6.2 Current Brief Modal Validation State (by code inspection)
+
+Derived from `researchBriefModal.ts` — fields with `optional: true`:
+
+| Field | Block ID | Has `optional: true` | Slack blocks on empty? |
+|-------|----------|---------------------|------------------------|
+| study_name | `study_name_block` | No | **YES** |
+| stakeholder | `stakeholder_block` | No | **YES** |
+| problem_statement | `problem_statement_block` | No | **YES** |
+| learning_objectives | `learning_objectives_block` | No | **YES** |
+| out_of_scope | `out_of_scope_block` | No | **YES** |
+| research_method | `research_method_block` | No | **YES** |
+| method_override | `method_override_block` | **Yes** (line 216) | No |
+| participant_approach | `participant_approach_block` | No | **YES** |
+| recruitment_sources | `recruitment_sources_block` | **Yes** (line 256) | No |
+| start_date | `start_date_block` | No | **YES** |
+| decision_deadline | `decision_deadline_block` | No | **YES** |
+| budget | `budget_block` | **Yes** (line 322) | No |
+
+**Execution testing:** Code inspection shows Slack's native validation behavior. Execution testing (submit with empty fields) requires manual testing in dev environment. The above reflects what Slack will do based on the `optional` flag presence.
+
+---
+
+### 6.3 Analyze Session Modal
+
+**Consumes → field mapping:**
+
+| Consumed variable | Source | Required? | YAML citation |
+|-------------------|--------|-----------|---------------|
+| `target_barriers` | research_brief | optional | `session_summary.yaml:90-94` |
+| `research_questions` | research_brief | optional | `session_summary.yaml:96-100` |
+| `methodology_selection` | research_brief | optional | `session_summary.yaml:102-106` |
+
+**Field → Required derivation:**
+
+| Modal Field | Cascade Variable | Required consumer? | R7 Required? |
+|-------------|------------------|-------------------|--------------|
+| `study_select` | (routing only) | N/A | **NO** (but needed for routing) |
+| `session_select` | `session_id` | Required by session_summary | **YES** |
+| `transcript_select` | `coded_transcript_content` | Required by session_summary | **YES** |
+| `notes_select` | `notes_content` | Optional by session_summary | **NO** |
+
+**Emits:**
+- `atomic_nugget_core` → required by affinity_mapping, research_readout (`affinity_mapping.yaml:41-45`, `research_readout.yaml:66-70`)
+- `atomic_nugget_detail` → required by affinity_mapping, research_readout (`affinity_mapping.yaml:47-51`, `research_readout.yaml:72-75`)
+- `participant_metadata` → required by research_readout (`research_readout.yaml:76-80`)
+- `task_completion_records` → optional
+- `barrier_validations` → optional
+
+---
+
+### 6.4 Research Synthesis Modal
+
+**Consumes:**
+
+| Consumed variable | Source | Required? | YAML citation |
+|-------------------|--------|-----------|---------------|
+| `atomic_nugget_core` | session_summary | **required** | `affinity_mapping.yaml:41-45` |
+| `atomic_nugget_detail` | session_summary | **required** | `affinity_mapping.yaml:47-51` |
+| `target_barriers` | research_brief | optional | `affinity_mapping.yaml:53-57` |
+| `research_questions` | research_brief | optional | `affinity_mapping.yaml:59-63` |
+| `participant_metadata` | session_summary | optional | `affinity_mapping.yaml:65-69` |
+
+**Field → Required derivation:**
+
+| Modal Field | Cascade Variable | Required consumer? | R7 Required? |
+|-------------|------------------|-------------------|--------------|
+| `study_select` | (routing to load nuggets) | N/A | **NO** (but needed for routing) |
+| `analysis_method` | (selects template) | N/A | **YES** (determines which template runs) |
+
+**Note:** Synthesis modal primarily selects which synthesis method to run. The required inputs (`atomic_nugget_core`, `atomic_nugget_detail`) are loaded from the variable store, not entered via modal fields. If no session summaries exist, synthesis cannot run — this is a cascade precondition, not a modal field.
+
+---
+
+### 6.5 Readout Modal
+
+**Consumes (research_readout.yaml):**
+
+| Consumed variable | Source | Required? | YAML citation |
+|-------------------|--------|-----------|---------------|
+| `atomic_nugget_core` | session_summary | **required** | `research_readout.yaml:66-70` |
+| `atomic_nugget_detail` | session_summary | **required** | `research_readout.yaml:72-75` |
+| `participant_metadata` | session_summary | **required** | `research_readout.yaml:76-80` |
+| `research_objectives` | research_brief | optional | `research_readout.yaml:44-48` |
+| `research_questions` | research_brief | optional | `research_readout.yaml:49-53` |
+| `target_barriers` | research_brief | optional | `research_readout.yaml:54-58` |
+| `validated_themes` | affinity_mapping | optional | `research_readout.yaml:93-97` |
+| `personas` | persona_generator | optional | `research_readout.yaml:103-107` |
+| etc. | ... | optional | ... |
+
+**Field → Required derivation:**
+
+| Modal Field | Cascade Variable | Required consumer? | R7 Required? |
+|-------------|------------------|-------------------|--------------|
+| `study_select` | (routing) | N/A | **NO** (routing) |
+| `audience_select` | (selects template) | N/A | **YES** (determines which readout runs) |
+
+**Note:** Readout modal selects audience and study. Required inputs are loaded from variable store. Cascade preconditions (nuggets must exist) are enforced by the handler, not modal validation.
+
+---
+
+### 6.6 Summary: Required Fields by R7 Derivation
+
+| Modal | R7 Required Fields | R7 Optional Fields (currently required) |
+|-------|-------------------|----------------------------------------|
+| **Brief** | learning_objectives, research_method, participant_approach | study_name, stakeholder, out_of_scope, start_date, decision_deadline, problem_statement (flagged) |
+| **Analyze** | session_select, transcript_select | study_select, notes_select |
+| **Synthesis** | analysis_method | study_select |
+| **Readout** | audience_select | study_select |
+
+**Action items before changing code:**
+1. Review flagged ambiguity: Is `problem_statement` required because `target_barriers` (AI-generated from it) is required downstream?
+2. Decide if `study_name` and `stakeholder` should remain required for operational reasons (not cascade reasons)
+3. Execute validation testing in dev to confirm code-inspection findings
+
+---
+
+## Changelog
+
+| Date | Version | Changes |
+|------|---------|---------|
+| 2026-07-09 | 1.1 | R6 updated (production icon canonical), R7 updated (required/optional derivation), §6 required-field tables added |
+| 2026-07-09 | 1.0 | Initial document with R1-R10 rulings |

--- a/backend/docs/qori-modal-design-standard.md
+++ b/backend/docs/qori-modal-design-standard.md
@@ -1,6 +1,8 @@
 # Qori Modal Design Standard
 
-This document captures the design rulings for Slack Block Kit modals across the Qori application. Each ruling (R1-R10) addresses a specific aspect of modal presentation and behavior.
+This document captures the design rulings for Slack Block Kit modals across the Qori application. Each ruling (R1-R13) addresses a specific aspect of modal presentation and behavior.
+
+> **Standing note:** Ruling numbers are frozen. New rulings get new numbers (R14, R15, etc.). Never reuse or reassign existing ruling numbers — this corrupts references across the codebase and audit artifacts.
 
 ---
 
@@ -28,7 +30,7 @@ Submit button text should describe the action, not just "Submit". Examples:
 
 ### R3: No Redundant Section Headers
 
-Remove redundant section headers when the input label is self-explanatory. For example, a "Research Study" section header followed by a "Study *" select is redundant — the label suffices.
+Remove redundant section headers when the input label is self-explanatory. For example, a "Research Study" section header followed by a "Study *" select is redundant — the label suffices. No imperatives ("Select a..."), no colons after labels.
 
 **Status:** Enforced.
 
@@ -65,17 +67,81 @@ The production app icon is canonical. The blue-book icon visible in the dev envi
 
 Optional fields carry a `(optional)` suffix added by Slack's `optional: true` flag; all unmarked fields are required. No asterisks.
 
-Required fields are enforced by submit validation (inline error on empty), not visual marking alone. A field is REQUIRED if and only if the cascade variable it populates is consumed by a downstream template, per the `emits`/`consumes` contracts in the YAML templates.
+A field is REQUIRED if and only if:
+
+**(a) Cascade-required:** The cascade variable it populates is consumed with `required: true` by a downstream template (per `emits`/`consumes` contracts in YAML templates), OR
+
+**(b) Operationally required:** It is routing/identity (study selection) or a workflow gate (stakeholder/approver assignment).
+
+**(c) Primary content input:** The field(s) a content-entry surface exists to capture; where alternative inputs exist, at least one is required, enforced at handler level.
+
+Closed list. Everything else is optional.
 
 Prefill from discovery satisfies but does not alter required status.
 
 **Before changing modal code:** Derive the required-field set from YAML contracts (see §6 Required Field Derivation).
 
-**Status:** Pending derivation audit.
+**Resolved ambiguities:**
+
+- **`study_name`** — REQUIRED under (b): routing/identity field.
+- **`stakeholder`** — REQUIRED under (b): workflow gate (approver assignment).
+- **`problem_statement`** — REQUIRED under (a): `target_barriers` is hard-required downstream (`research_plan.yaml:69-73`, `discussion_guide.yaml:69-73`) and AI-generated from `problem_statement` + discovery. In the empty-cascade case (no discovery selected), an empty `problem_statement` forces the AI task to generate barriers from nothing — fabricated provenance flowing into plan and discussion guide. `problem_statement` is the human grounding; required.
+- **`session_date`, `session_time`, `current_status`** (Add Participant) — OPTIONAL. Not cascade-required (participant records don't feed YAML templates), not routing/identity, not workflow gates. These are operational metadata for scheduling, not required inputs.
+- **`recruitment_method`** (Add Participant) — FLAGGED. Currently marked required in code but doesn't satisfy (a), (b), or (c). Ambiguity: Is recruitment source tracking required for research compliance/methodology audit purposes (policy question), or is it optional metadata? Needs policy decision before fix.
+
+**Status:** Derivation complete for Brief, Analyze, Synthesis, Readout, Add Participant, Session Notes. Pending: Discover modals.
 
 ---
 
-### R8: Grounding Context Blocks
+### R8: Help Text Placement and Voice
+
+Help text (hints) should:
+- Use sentence case, not CAPS emphasis
+- Use **bold** for emphasis, not CAPS or italics
+- Be concise — one line preferred
+- Appear below the field, not in placeholders that duplicate help text
+
+**Status:** Pending audit.
+
+---
+
+### R9: Dividers
+
+Use dividers sparingly, only between logical groups. Do not use dividers:
+- Before every field
+- After every field
+- To create visual "boxes" around single fields
+
+**Status:** Enforced.
+
+---
+
+### R10: Information Hierarchy
+
+- **Primary inputs** (study select, method select): Use `input` blocks with labels
+- **Grounding/status info**: Use `context` blocks (subordinate, smaller text)
+- **Section dividers**: Use sparingly, only between logical groups
+- **Warnings**: Use `context` blocks with `:warning:` prefix
+- **One primary button per modal**: Submit is primary; secondary actions (Load, Refresh) are non-primary style
+
+**Status:** Enforced.
+
+---
+
+### R11: Help Text Earns Its Place
+
+Guidance only where a choice is non-obvious. No help text on self-evident fields. If the label and placeholder make the expected input clear, omit the hint.
+
+Examples of unnecessary help text:
+- "Enter the study name" on a field labeled "Study name"
+- "Select a date" on a datepicker
+- Help text that duplicates the placeholder text
+
+**Status:** Pending audit.
+
+---
+
+### R12: Grounding Context Blocks
 
 When showing cascade context (session counts, nuggets, enrichments), use a single subordinate context block with the pattern:
 
@@ -95,7 +161,7 @@ Keep grounding information compact — one line, `•` separators, no decorative
 
 ---
 
-### R9: Proper Pluralization
+### R13: Proper Pluralization
 
 Use correct singular/plural forms:
 - `${count} finding${count !== 1 ? 's' : ''}`
@@ -106,18 +172,56 @@ Use correct singular/plural forms:
 
 ---
 
-### R10: Visual Hierarchy
+## §5: Conformance Checklist
 
-- **Primary inputs** (study select, method select): Use `input` blocks with labels
-- **Grounding/status info**: Use `context` blocks (subordinate, smaller text)
-- **Section dividers**: Use sparingly, only between logical groups
-- **Warnings**: Use `context` blocks with `:warning:` prefix
+Per-modal audit state. ✓ = conforms, — = violation found, ? = not audited, N/A = not applicable.
 
-**Status:** Enforced.
+Scores reflect CURRENT code state, not intended state. A cell flips to ✓ with PR number when the fix ships.
+
+| Modal | R1 | R2 | R3 | R4 | R5 | R6 | R7 | R8 | R9 | R10 | R11 | R12 | R13 |
+|-------|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:---:|:---:|:---:|:---:|
+| Research Brief | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | — | ? | ✓ | ✓ | ? | ✓ | ✓ |
+| Analyze Session | — | ✓ | ✓ | ✓ | ✓ | N/A | — | ? | ✓ | ✓ | ? | ✓ | ✓ |
+| Research Synthesis | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | ✓ | ? | ✓ | ✓ | ? | ✓ | ✓ |
+| Readout | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| Discussion Guide | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| Research Plan | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| Discovery Launcher | — | ? | ? | ? | ? | N/A | ? | — | ? | ? | — | ? | ? |
+| Discover: Desk Research | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| Discover: Stakeholder | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| Discover: Survey | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| Project Creation | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| Add Participant | — | ? | — | ? | ? | N/A | — | — | ? | ? | — | ? | ? |
+| Update Participant | — | ? | ? | ? | ? | N/A | — | ? | ? | — | ? | ? | ? |
+| Add Observer | — | — | ? | ? | ? | N/A | ✓ | ? | ? | ? | ? | ? | ? |
+| Session Notes | ✓ | — | — | ? | ? | N/A | ? | ? | ? | — | — | ? | ? |
+| Participant Outreach | — | — | — | ? | ? | N/A | — | — | ? | ? | ? | ? | ? |
+| Session Confirmation | — | — | ? | ? | ? | N/A | — | ? | ? | ? | ? | ? | ? |
+| Tickets | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | ? | ? | ✓ | ✓ | ? | ✓ | ✓ |
+| PII Review (transcript) | — | ✓ | ✓ | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| PII Review (manual notes) | — | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| Fieldwork Dashboard | ? | ✓ | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| Join Observer | — | ✓ | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| Admin Center Hub | ? | — | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| Admin — Delete Study | ? | — | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| Admin — Manage Stakeholder | ? | ✓ | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+
+**Legend:**
+- ✓ Conforms
+- — Violation found (see §7 for details)
+- ? Not yet audited
+- N/A Not applicable to this modal
+
+**R7 scoring notes:**
+- Brief R7 = —: §6.2 shows out_of_scope, start_date, decision_deadline hard-required in code but R7 says optional
+- Analyze R7 = —: Uses asterisk in "Study *" label (analyzeNotesModal.ts:151) violating R7 no-asterisks rule
+- Add Observer R7 = ✓: Uses `optional: true` correctly on lines 41, 69
 
 ---
 
-## §5: Modal Inventory
+## §5.1: Modal Inventory (Appendix)
+
+> **Note:** Some surfaces are built inline in handlers, not as separate modal files. The inventory below covers `/ui/` files; inline surfaces are listed separately at the end to prevent omission in audits.
 
 | Modal File | Primary Template | Command |
 |------------|------------------|---------|
@@ -127,11 +231,23 @@ Use correct singular/plural forms:
 | `readoutModal.ts` | `research_readout.yaml`, `designer_readout.yaml`, etc. | `/qori-readout` |
 | `discussionGuideModal.ts` | `discussion_guide.yaml` | `/qori-guide` |
 | `researchPlanGeneratorModal.ts` | `research_plan.yaml` | `/qori-plan` |
+| `discoverHubModal.ts` | (launcher) | `/qori-discover` |
 | `discoverTypeModals.ts` | `desk_research.yaml`, `stakeholder_synthesis.yaml`, `survey_synthesis.yaml` | `/qori-discover` |
 | `projectCreationModal.ts` | (creates project, no template) | `/qori-project` |
 | `addParticipantModal.ts` | (DB operation, no template) | (fieldwork) |
 | `sessionNotesModal.ts` | (upload handler) | `/qori-notes` |
 | `uploadNotesModal.ts` | (upload handler) | `/qori-notes` |
+| `addObserverModal.ts` | (DB operation, no template) | (fieldwork) |
+| `outreach/*.ts` | (messaging templates) | `/qori-outreach` |
+
+**Inline surfaces (built in handlers, not separate files):**
+
+| Surface | Location | Flow |
+|---------|----------|------|
+| PII Review (manual notes) | `sessionNotesHandler.ts:661-700` | DM button approval (DB-held quarantine per ADR 0026) |
+| Admin — Delete Study | `adminActionsHandler.ts:686-750` | Inline modal in handler |
+| Admin — Manage Stakeholder | `adminActionsHandler.ts:1027-1175` | Inline modal in handler |
+| Admin — DSAR sub-modals | `adminActionsHandler.ts:33-110` | Inline modals in handler |
 
 ---
 
@@ -143,6 +259,122 @@ For each modal in §5, derive:
 - field → cascade variable it populates → downstream consumer(s) → required Y/N
 - Cite YAML file + section for each consumer claim
 - Flag ambiguous contracts
+
+---
+
+### 6.0 Cascade Loading: YAML Consumes vs Handler-Side
+
+**Loader semantics (YAML `consumes`):**
+
+Templates with `consumes:` blocks have their upstream variables loaded by `yamlProcessor.ts:249-289`. The enforcement point for `required: true` is at `yamlProcessor.ts:271-279`:
+
+```typescript
+for (const spec of yamlConfig.consumes) {
+  if (spec.required && !upstream[spec.key]) {
+    throw new TemplateContractError(
+      yamlConfig.id,
+      spec.key,
+      `Required cascade variable '${spec.key}' is missing for template '${yamlConfig.id}'.`
+```
+
+**Brief discovery consumption — handler-side loading:**
+
+`research_brief.yaml` has **no `consumes:` block**. Discovery is loaded manually by `briefHandler.ts` based on researcher checkbox selections. This is documented at `research_brief.yaml:67-69`:
+
+```yaml
+# Brief uses MANUAL discovery loading via briefHandler.ts (not YAML consumes).
+# Researcher selects which discovery artifacts to include via modal checkboxes.
+# This is intentional — researcher controls which sources inform the brief.
+```
+
+**Discovery→Brief consumption path (file+line citations):**
+
+| Step | Location | Operation |
+|------|----------|-----------|
+| 1 | `briefHandler.ts:396` | Extract user's discovery checkbox selections |
+| 2 | `briefHandler.ts:399` | `loadDiscoveryArtifacts(projectId)` loads all discovery artifacts from Postgres |
+| 3 | `briefHandler.ts:401` | Filter to selected artifacts based on slugs |
+| 4 | `briefHandler.ts:404` | `aggregateDiscoveryVariables(selectedArtifacts)` aggregates into `upstream_*` format |
+| 5 | `briefHandler.ts:405` | `Object.assign(discoveryContext, upstreamVars)` merges into context |
+| 6 | `briefHandler.ts:433` | `...discoveryContext` spread into `structuredTaskData` — feeds AI tasks |
+| 7 | `discoveryLoader.ts:160-214` | `aggregateDiscoveryVariables()` prefixes keys with `upstream_`, merges arrays, formats as markdown |
+| 8 | `research_brief.yaml:199-260` | AI tasks consume via Jinja conditionals: `{% if upstream_discovered_barriers %}` |
+
+**Why handler-side:** Research brief is the first document in study lifecycle. Prior discovery inputs are optional enrichment selected per-brief. YAML `consumes:` would imply required dependencies; handler-side loading enables researcher control over which discovery sources inform each brief.
+
+**Discovery provenance recording:** NOT recorded in DB. The set of discovery sources used is rendered into the brief's markdown footer (research_brief.yaml:534-543: `{{#if discovery_sources}}...{{discovery_sources}}...{{/if}}`) but not stored in any database table. Traceability exists only in the rendered document. If the generated markdown is lost or overwritten, provenance is lost.
+
+---
+
+### 6.0.1 Consumes Entry Audit
+
+**session_summary.yaml lines 77-80 (verbatim):**
+```yaml
+  - coded_transcript_content:
+      type: "hidden"
+      # Handler-provided: analyzeNotesHandler.ts fetches transcript content
+      # directly from notes marked transcript=true. No YAML derivation.
+```
+
+These are `input_variables`, NOT consumes entries. The consumes section starts at line 89.
+
+**Important:** `input_variables` entries are OUTSIDE cascade contract enforcement. The loader (`yamlProcessor.ts:271-279`) only checks `consumes` entries for `required: true`. Input variables with no explicit default are handler-provided — if a handler fails to provide one, the template renders with an empty/undefined value, potentially generating malformed output. This is why R7(c) requires handler-level enforcement for primary content inputs.
+
+**All consumes entries across all templates have explicit `required:` flags.** Sweep confirmed:
+- All templates with consumes sections (session_summary, research_plan, discussion_guide, affinity_mapping, etc.) explicitly declare `required: true` or `required: false` on every entry.
+- No silently degrading contracts under current loader behavior (`yamlProcessor.ts:271-279` only throws on explicit `spec.required === true`).
+
+**Verification:** Entries without `required:` in grep output are in `emits:` sections, not `consumes:` sections.
+
+---
+
+### 6.0.2 Discovery Type ID Matching
+
+**Loader identifiers** (discoveryLoader.ts:32-36):
+```typescript
+{ type: 'desk-research', icon: '📄', label: 'desk research' },
+{ type: 'stakeholder-interviews', icon: '🎙️', label: 'stakeholder' },
+{ type: 'survey-synthesis', icon: '📊', label: 'survey' },
+```
+
+**source_template values stored in DB** (from discoverHandler.ts:112-129):
+- `desk_research` → writes to type `desk-research`
+- `stakeholder_synthesis` → writes to type `stakeholder-interviews`
+- `survey_synthesis` → writes to type `survey-synthesis`
+
+**Mapping** (studyVariables.ts:18-29):
+```typescript
+const TEMPLATE_TO_DISCOVERY_TYPE: Record<string, string> = {
+  'desk_research': 'desk-research',
+  'stakeholder_synthesis': 'stakeholder-interviews',
+  'survey_synthesis': 'survey-synthesis',
+};
+const DISCOVERY_TYPE_TO_TEMPLATE: Record<string, string> = {
+  'desk-research': 'desk_research',
+  'stakeholder-interviews': 'stakeholder_synthesis',
+  'survey-synthesis': 'survey_synthesis',
+};
+```
+
+**Mapping verified in code.** The mapping layer correctly translates between YAML template IDs (`desk_research`) and discovery type identifiers (`desk-research`). The near-miss "Stakeholder synthesis" (modal label) vs "stakeholder-interviews" (type identifier) is intentional — label is UI-facing, type is storage-key.
+
+**Stored values verified (2026-07-09, dev + prod):**
+```sql
+SELECT DISTINCT source_template FROM study_variables WHERE scope = 'discovery';
+```
+```
+-- Dev:
+ desk_research
+ stakeholder_synthesis
+(2 rows)
+
+-- Prod:
+ stakeholder_synthesis
+ desk_research
+(2 rows)
+```
+
+No `_processor`-suffixed values exist in either environment. Stored values match current YAML template IDs exactly. ID matching confirmed.
 
 ---
 
@@ -168,39 +400,36 @@ For each modal in §5, derive:
 
 **Field → Cascade Variable → Required derivation:**
 
-| Modal Field | Cascade Variable | Required consumer? | R7 Required? |
-|-------------|------------------|-------------------|--------------|
-| `study_name` | `selected_study` (filename only) | No cascade consumer | **NO** |
-| `stakeholder` | `requestor_name` (masthead only) | No cascade consumer | **NO** |
-| `problem_statement` | → AI generates `business_context` | All consumers optional | **NO** |
-| `learning_objectives` | → AI generates `research_objectives` | research_plan, discussion_guide | **YES** |
-| `out_of_scope` | `out_of_scope` | All consumers optional | **NO** |
-| `research_method` | `methodology_selection` | research_plan, discussion_guide | **YES** |
-| `method_override` | (overrides methodology) | Same as research_method (override) | **NO** |
-| `participant_approach` | → AI generates `participant_criteria` | research_plan | **YES** |
-| `recruitment_sources` | `recruitment_sources` | No cascade consumer | **NO** |
-| `start_date` | `start_date` | All consumers optional | **NO** |
-| `decision_deadline` | `decision_deadline` | No cascade consumer | **NO** |
-| `budget` | `budget` | No cascade consumer | **NO** |
-
-**Ambiguous contracts (flagged for review):**
-
-1. **`research_questions`** — AI-generated from `learning_objectives`. Required by downstream (research_plan, discussion_guide). This makes `learning_objectives` indirectly required. ✅ Already covered above.
-
-2. **`target_barriers`** — AI-generated from `problem_statement` + discovery data. Required by downstream (research_plan, discussion_guide). Contract is ambiguous: `problem_statement` is one of multiple inputs to the AI task that generates barriers. **Recommendation:** If target_barriers must exist, then `problem_statement` should be required. Flagged for design review.
+| Modal Field | Cascade Variable | Required consumer? | R7 Required? | Rationale |
+|-------------|------------------|-------------------|--------------|-----------|
+| `study_name` | `selected_study` | N/A | **YES** | (b) routing/identity |
+| `stakeholder` | `requestor_name` | N/A | **YES** | (b) workflow gate |
+| `problem_statement` | → AI generates `target_barriers` | research_plan, discussion_guide | **YES** | (a) human grounding for required target_barriers |
+| `learning_objectives` | → AI generates `research_objectives` | research_plan, discussion_guide | **YES** | (a) cascade-required |
+| `out_of_scope` | `out_of_scope` | All consumers optional | **NO** | — |
+| `research_method` | `methodology_selection` | research_plan, discussion_guide | **YES** | (a) cascade-required |
+| `method_override` | (overrides methodology) | Same as research_method | **NO** | Override only |
+| `participant_approach` | → AI generates `participant_criteria` | research_plan | **YES** | (a) cascade-required |
+| `recruitment_sources` | `recruitment_sources` | No cascade consumer | **NO** | — |
+| `start_date` | `start_date` | All consumers optional | **NO** | — |
+| `decision_deadline` | `decision_deadline` | No cascade consumer | **NO** | — |
+| `budget` | `budget` | No cascade consumer | **NO** | — |
 
 **R7 Derived Required Fields for Brief modal:**
-- `learning_objectives` (populates `research_objectives`, required by research_plan/discussion_guide)
-- `research_method` (populates `methodology_selection`, required by research_plan/discussion_guide)
-- `participant_approach` (populates `participant_criteria`, required by research_plan)
+- `study_name` — (b) routing/identity
+- `stakeholder` — (b) workflow gate
+- `problem_statement` — (a) human grounding for target_barriers
+- `learning_objectives` — (a) populates research_objectives
+- `research_method` — (a) populates methodology_selection
+- `participant_approach` — (a) populates participant_criteria
 
-**Fields that are currently required but R7 says should be optional:**
-- `study_name` — no cascade consumer
-- `stakeholder` — no cascade consumer
-- `problem_statement` — ambiguous (see flag #2)
-- `out_of_scope` — all consumers optional
-- `start_date` — all consumers optional
-- `decision_deadline` — no cascade consumer
+**R7 Derived Optional Fields:**
+- `out_of_scope`
+- `method_override`
+- `recruitment_sources`
+- `start_date`
+- `decision_deadline`
+- `budget`
 
 ---
 
@@ -223,7 +452,7 @@ Derived from `researchBriefModal.ts` — fields with `optional: true`:
 | decision_deadline | `decision_deadline_block` | No | **YES** |
 | budget | `budget_block` | **Yes** (line 322) | No |
 
-**Execution testing:** Code inspection shows Slack's native validation behavior. Execution testing (submit with empty fields) requires manual testing in dev environment. The above reflects what Slack will do based on the `optional` flag presence.
+**Gap analysis:** `out_of_scope`, `start_date`, `decision_deadline` are currently required but should be optional per R7.
 
 ---
 
@@ -239,12 +468,12 @@ Derived from `researchBriefModal.ts` — fields with `optional: true`:
 
 **Field → Required derivation:**
 
-| Modal Field | Cascade Variable | Required consumer? | R7 Required? |
-|-------------|------------------|-------------------|--------------|
-| `study_select` | (routing only) | N/A | **NO** (but needed for routing) |
-| `session_select` | `session_id` | Required by session_summary | **YES** |
-| `transcript_select` | `coded_transcript_content` | Required by session_summary | **YES** |
-| `notes_select` | `notes_content` | Optional by session_summary | **NO** |
+| Modal Field | Cascade Variable | Required consumer? | R7 Required? | Rationale |
+|-------------|------------------|-------------------|--------------|-----------|
+| `study_select` | (routing) | N/A | **YES** | (b) routing/identity |
+| `session_select` | (routing) | N/A | **YES** | (b) routing/identity — determines which session to analyze |
+| `transcript_select` | (primary content) | N/A | **YES** | (c) primary content input. Enforcement: `analyzeNotesHandler.ts:246-252` returns modal error if no transcript. |
+| `notes_select` | `notes_content` | Optional by session_summary | **NO** | — |
 
 **Emits:**
 - `atomic_nugget_core` → required by affinity_mapping, research_readout (`affinity_mapping.yaml:41-45`, `research_readout.yaml:66-70`)
@@ -269,10 +498,10 @@ Derived from `researchBriefModal.ts` — fields with `optional: true`:
 
 **Field → Required derivation:**
 
-| Modal Field | Cascade Variable | Required consumer? | R7 Required? |
-|-------------|------------------|-------------------|--------------|
-| `study_select` | (routing to load nuggets) | N/A | **NO** (but needed for routing) |
-| `analysis_method` | (selects template) | N/A | **YES** (determines which template runs) |
+| Modal Field | Cascade Variable | Required consumer? | R7 Required? | Rationale |
+|-------------|------------------|-------------------|--------------|-----------|
+| `study_select` | (routing) | N/A | **YES** | (b) routing/identity |
+| `analysis_method` | (selects template) | N/A | **YES** | (b) determines which template runs |
 
 **Note:** Synthesis modal primarily selects which synthesis method to run. The required inputs (`atomic_nugget_core`, `atomic_nugget_detail`) are loaded from the variable store, not entered via modal fields. If no session summaries exist, synthesis cannot run — this is a cascade precondition, not a modal field.
 
@@ -292,14 +521,13 @@ Derived from `researchBriefModal.ts` — fields with `optional: true`:
 | `target_barriers` | research_brief | optional | `research_readout.yaml:54-58` |
 | `validated_themes` | affinity_mapping | optional | `research_readout.yaml:93-97` |
 | `personas` | persona_generator | optional | `research_readout.yaml:103-107` |
-| etc. | ... | optional | ... |
 
 **Field → Required derivation:**
 
-| Modal Field | Cascade Variable | Required consumer? | R7 Required? |
-|-------------|------------------|-------------------|--------------|
-| `study_select` | (routing) | N/A | **NO** (routing) |
-| `audience_select` | (selects template) | N/A | **YES** (determines which readout runs) |
+| Modal Field | Cascade Variable | Required consumer? | R7 Required? | Rationale |
+|-------------|------------------|-------------------|--------------|-----------|
+| `study_select` | (routing) | N/A | **YES** | (b) routing/identity |
+| `audience_select` | (selects template) | N/A | **YES** | (b) determines which readout runs |
 
 **Note:** Readout modal selects audience and study. Required inputs are loaded from variable store. Cascade preconditions (nuggets must exist) are enforced by the handler, not modal validation.
 
@@ -307,17 +535,173 @@ Derived from `researchBriefModal.ts` — fields with `optional: true`:
 
 ### 6.6 Summary: Required Fields by R7 Derivation
 
-| Modal | R7 Required Fields | R7 Optional Fields (currently required) |
-|-------|-------------------|----------------------------------------|
-| **Brief** | learning_objectives, research_method, participant_approach | study_name, stakeholder, out_of_scope, start_date, decision_deadline, problem_statement (flagged) |
-| **Analyze** | session_select, transcript_select | study_select, notes_select |
-| **Synthesis** | analysis_method | study_select |
-| **Readout** | audience_select | study_select |
+| Modal | R7 Required Fields | R7 Optional Fields | Flagged (policy) |
+|-------|-------------------|-------------------|------------------|
+| **Brief** | study_name (b), stakeholder (b), problem_statement (a), learning_objectives (a), research_method (a), participant_approach (a) | out_of_scope, method_override, recruitment_sources, start_date, decision_deadline, budget | — |
+| **Analyze** | study_select (b), session_select (b), transcript_select (c) | notes_select | — |
+| **Synthesis** | study_select (b), analysis_method (b) | — | — |
+| **Readout** | study_select (b), audience_select (b) | — | — |
+| **Add Participant** | study_select (b) | participant_name, session_date, session_time, current_status, notes_accommodations | recruitment_method, race_ethnicity, age_range, education_level, location_type |
+| **Session Notes** | study_select (b), session_select (b), transcript (c, XOR) | observer_notes | — |
 
-**Action items before changing code:**
-1. Review flagged ambiguity: Is `problem_statement` required because `target_barriers` (AI-generated from it) is required downstream?
-2. Decide if `study_name` and `stakeholder` should remain required for operational reasons (not cascade reasons)
-3. Execute validation testing in dev to confirm code-inspection findings
+---
+
+### 6.7 Add Participant Modal
+
+**Cascade analysis:** This modal does NOT emit cascade variables. Participant records are stored in DB, not passed to YAML templates. Therefore R7(a) does not apply — no downstream consumers.
+
+**Field → Required derivation:**
+
+| Modal Field | R7 Required? | Rationale |
+|-------------|--------------|-----------|
+| `study_select` | **YES** | (b) routing/identity — determines which study the participant belongs to |
+| `participant_name` | **NO** | Private alias, explicitly `optional: true` (line 66) |
+| `recruitment_method` | **FLAGGED** | No cascade consumer, not routing/identity, not workflow gate. Policy question: is recruitment source audit-required? |
+| `session_date` | **NO** | Operational metadata, not cascade-required. Participant can be added before scheduling. |
+| `session_time` | **NO** | Operational metadata, not cascade-required. |
+| `current_status` | **NO** | Operational metadata — has default (line 123: `initial_option: statusOptions[0]`). |
+| `race_ethnicity` | **FLAGGED** | Demographics — see note below |
+| `age_range` | **FLAGGED** | Demographics — see note below |
+| `education_level` | **FLAGGED** | Demographics — see note below |
+| `location_type` | **FLAGGED** | Demographics — see note below |
+| `notes_accommodations` | **NO** | Explicitly `optional: true` (line 229) |
+
+**Demographics fields policy note:** Four demographics fields (`race_ethnicity`, `age_range`, `education_level`, `location_type`) are currently marked required in code (no `optional: true`). These don't satisfy R7 criteria (a), (b), or (c). Whether they're required is a policy question for VA research compliance (data minimization vs representative sampling documentation). Design freeze on these fields pending policy decision.
+
+**R7 Derived Required Fields:** `study_select` only.
+
+**R7 Flagged (needs policy decision):** `recruitment_method`, `race_ethnicity`, `age_range`, `education_level`, `location_type`.
+
+**R7 Derived Optional Fields:** `participant_name`, `session_date`, `session_time`, `current_status`, `notes_accommodations`.
+
+---
+
+### 6.8 Session Notes Modal
+
+**Cascade analysis:** `coded_transcript_content` is an `input_variable` in session_summary.yaml (lines 77-80), NOT a consumes entry. It has no cascade contract semantics — requiredness rests entirely on R7(c) with handler-level enforcement.
+
+**Field → Required derivation:**
+
+| Modal Field | R7 Required? | Rationale |
+|-------------|--------------|-----------|
+| `study_select` | **YES** | (b) routing/identity |
+| `session_select` | **YES** | (b) routing/identity — determines which session transcript associates with |
+| `transcript_files` (upload) | **XOR** | (c) primary content — XOR with `transcript_paste` |
+| `transcript_paste` (text) | **XOR** | (c) primary content — XOR with `transcript_files` |
+| `observer_notes` | **NO** | Optional supporting context |
+
+**XOR enforcement (5f check):** Handler-level enforcement at `sessionNotesHandler.ts:438-465`:
+```typescript
+if (filesList.length > 0) {
+  const processedFiles: ProcessedFile[] = await processSlackFiles(filesList, process.env.SLACK_BOT_TOKEN!);
+  rawContent = processedFiles.map((file: ProcessedFile) => file.content).join('\n\n---\n\n');
+
+  templateData = {
+    ...templateData,
+    transcript_files: filesList.map((f: { name: string }) => f.name).join(', '),
+    filename: filesList[0]?.name || 'transcript_upload.md',
+    folder_context: templateData.study_name || '',
+    upload_date_utc: new Date().toISOString(),
+    transcript_source: 'file_upload',
+    manual_notes_text_or_blank: '',
+  };
+} else if (pastedText) {
+  rawContent = pastedText;
+  templateData = {
+    ...templateData,
+    manual_notes_text_or_blank: pastedText
+  };
+} else {
+  await ack();
+  ackCalled = true;
+  await client.chat.postMessage({
+    channel: body.user.id,
+    text: `❌ Please either upload files or paste transcript content.`,
+  });
+  return;
+}
+```
+
+**Check semantics:**
+- `filesList.length > 0` — mere presence (array length check, does not verify file content)
+- `pastedText` — truthy check (empty string `''` is falsy, so rejects empty). Does NOT trim — whitespace-only paste `"   "` would pass.
+
+**5f design finding:** The `ack()+DM` pattern closes the modal and discards user input. `analyzeNotesHandler.ts:246-252` uses the standard `response_action: "errors"` pattern that keeps the modal open with inline field errors.
+
+**5f fix spec (implemented, pending review):**
+
+| Fix | Location | Change |
+|-----|----------|--------|
+| (a) | `sessionNotesHandler.ts:457-465` | Convert to `response_action: "errors"` — modal stays open |
+| (b) | `sessionNotesHandler.ts:428` | Trim pastedText before check — whitespace-only fails |
+| (c) | `sessionNotesHandler.ts:440` | Validate `rawContent.trim()` after download — empty file content fails |
+
+**What happened TODAY with empty file:** File downloads → `rawContent = ""` → scrubTranscript runs on empty → empty transcript saved to quarantine → user sees PII review modal → if approved, empty transcript committed to Git → `/qori-analyze` generates garbage from no content. No validation existed after download.
+
+**Retrospective audit (2026-07-09, dev + prod):**
+- Dev: 8 transcripts (5 approved, 3 pending), 0 empty/whitespace content
+- Prod: 0 transcripts
+- Git verification: All 4 committed transcripts have 8-12KB content (verified via `gh api` file sizes)
+- Note: Approved rows have `pending_content = NULL` (cleared on approval); verification used Git file sizes, not DB content
+- Downstream consumers exist (affinity_mapping, research_readout, designer_readout) but derive from non-empty transcripts
+- **No evidence of empty content having passed through the system**
+
+**Ship gate:** Manual empty-submit test in dev required before merge.
+
+---
+
+### 6.9 Pending Derivations
+
+| Modal | Status |
+|-------|--------|
+| Discover: Desk Research | Pending (Section 3a) |
+| Discover: Stakeholder Synthesis | Pending (Section 3a) |
+| Discover: Survey Synthesis | Pending (Section 3a) |
+
+---
+
+### 6.10 Backlog Items
+
+See `docs/product-backlog.md` § "Modal design standard findings (2026-07-09)" for: structured discovery provenance, discovery naming-layer consolidation.
+
+---
+
+## §7: Violation Log
+
+Track specific violations found during audit, with fix status.
+
+| Modal | Ruling | Violation | Status |
+|-------|--------|-----------|--------|
+| Research Brief | R7 | out_of_scope, start_date, decision_deadline hard-required but should be optional | Pending |
+| Analyze Session | R7 | "Study *" label uses asterisk (line 151) | Pending |
+| Add Participant | R1 | Emoji section headers (📝🗓️📊) | Pending |
+| Add Participant | R3 | "Research study" → "Study" | Pending |
+| Add Participant | R7 | Trailing asterisks on required fields | Pending |
+| Add Participant | R8 | CAPS emphasis in help text | Pending |
+| Add Participant | R11 | Duplicative help text | Pending |
+| Update Participant | R1 | Emoji in labels | Pending |
+| Update Participant | R7 | "Update Notes* (optional)" contradiction | Pending |
+| Update Participant | R10 | Two primary-style buttons | Pending |
+| Add Observer | R1 | Emoji in role options (📝👁️📊🏛️) | Pending |
+| Add Observer | R2 | Button "Done" not action-oriented | Pending |
+| Session Notes | R2 | Button "Process & Submit" not action-oriented | Pending |
+| Session Notes | R3 | Nested header structure | Pending |
+| Session Notes | R10 | Tab renders as green primary | Pending |
+| Session Notes | R11 | Duplicative PII scrubbing help | Pending |
+| Session Confirmation | R1 | Emoji in section header (📅) | Pending |
+| Session Confirmation | R2 | Has "Generate" but form has asterisks on labels | Pending |
+| Session Confirmation | R7 | Asterisks in labels ("Session date *", "Session time *", "Meeting link *") | Pending |
+| Participant Outreach | R1 | Emoji in radio options | Pending |
+| Participant Outreach | R2 | Button "Next" not action-oriented | Pending |
+| Participant Outreach | R3 | "Select an existing study:" imperative | Pending |
+| Participant Outreach | R7 | Trailing asterisk | Pending |
+| Discovery Launcher | R1 | Emoji in option rows | Pending |
+| Discovery Launcher | R8 | Italics in help text | Pending |
+| PII Review (transcript) | R1 | Emoji in header (🔍), stats (✅⚠️), button (📄), footer (✅❌) | Pending |
+| PII Review (manual notes) | R1 | Emoji in DM message (🔍✅⚠️) | Pending |
+| Join Observer | R1 | Emoji in role options (📝👁️📊🏛️) | Pending |
+| Admin Center Hub | R2 | "Open" button label (lines 102, 115) not action-oriented | Pending |
+| Admin — Delete Study | R2 | "Open" button label not action-oriented | Pending |
 
 ---
 
@@ -325,5 +709,12 @@ Derived from `researchBriefModal.ts` — fields with `optional: true`:
 
 | Date | Version | Changes |
 |------|---------|---------|
+| 2026-07-09 | 1.8 | 5f fix spec implemented in sessionNotesHandler.ts: (a) inline errors, (b) trim paste, (c) validate content after download. Pending manual test. |
+| 2026-07-09 | 1.7 | §6.0.2 ID matching verified — SELECT confirms `desk_research`, `stakeholder_synthesis` only, no `_processor` values. |
+| 2026-07-09 | 1.6 | §6.8 full code context (lines 438-465), check semantics (presence vs content), 5f design finding (convert ack+DM to inline errors). §6.0.2 conclusion held open pending SELECT query. §6.10 moved to product-backlog.md. |
+| 2026-07-09 | 1.5 | §6.3/§6.8 corrected: transcript requiredness is R7(c) with handler enforcement, not R7(a) cascade-required. §6.0.1 input_variables note added (outside contract enforcement). 5f check documented: `sessionNotesHandler.ts:457-465` enforces XOR, `analyzeNotesHandler.ts:246-252` enforces transcript presence. §6.0.2 _processor grep: no hits. §6.10 backlog items filed (discovery provenance, naming-layer consolidation). |
+| 2026-07-09 | 1.4 | R7(c) text finalized with enforcement clause. §6.0.1 consumes audit (session_summary.yaml:77-80 are input_variables, not consumes; all consumes have explicit required flags). §6.0.2 discovery type ID matching (YAML IDs → storage types mapping confirmed). Discovery provenance NOT recorded in DB (markdown-only). |
+| 2026-07-09 | 1.3 | R7(c) added for primary content inputs. §6.0 cascade loading semantics with discovery→brief path citations (`briefHandler.ts:396-433`, `discoveryLoader.ts:160-214`, `yamlProcessor.ts:271-279`). §6.7 Add Participant derivation (demographics flagged for policy). §6.8 Session Notes derivation (XOR validation gap). session_date/session_time/current_status re-derived as OPTIONAL. recruitment_method flagged for policy. |
+| 2026-07-09 | 1.2 | Restored §5 conformance checklist, R8-R11 original numbering, added R12-R13, R7 amendment with (a)/(b) criteria, problem_statement ruling |
 | 2026-07-09 | 1.1 | R6 updated (production icon canonical), R7 updated (required/optional derivation), §6 required-field tables added |
 | 2026-07-09 | 1.0 | Initial document with R1-R10 rulings |

--- a/backend/src/helpers/slack/commands/analyzeNotesHandler.ts
+++ b/backend/src/helpers/slack/commands/analyzeNotesHandler.ts
@@ -503,7 +503,7 @@ const handleAnalyzeNotesSubmission = async ({ ack, body, view, client }: SlackVi
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `<${result.url}|:github: View Session Summary on GitHub>`,
+            text: `<${result.url}|View Session Summary on GitHub>`,
           },
         },
         { type: 'divider' },

--- a/backend/src/helpers/slack/commands/participantOutreachHandler.ts
+++ b/backend/src/helpers/slack/commands/participantOutreachHandler.ts
@@ -1073,7 +1073,7 @@ async function handleAddParticipantSubmit({ ack, body, view, client }: SlackView
             type: "section",
             text: {
               type: "mrkdwn",
-              text: `<${githubUrl}|:github: View Participant Tracker on GitHub>`,
+              text: `<${githubUrl}|View Participant Tracker on GitHub>`,
             },
           },
           {
@@ -1122,7 +1122,7 @@ async function handleAddParticipantSubmit({ ack, body, view, client }: SlackView
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `<${githubUrl}|:github: View Participant Tracker on GitHub>`
+            text: `<${githubUrl}|View Participant Tracker on GitHub>`
           }
         },
         {

--- a/backend/src/helpers/slack/commands/readoutHandler.ts
+++ b/backend/src/helpers/slack/commands/readoutHandler.ts
@@ -569,6 +569,17 @@ const handleReadoutModalSubmission = async ({ ack, body, view, client }: SlackVi
             const audienceReportData: ReadoutTemplateInput = { ...reportData, target_audience: audience };
             const rendered = await processYamlTemplate(file.content, audienceReportData, selectedStudy.path ?? '', '', false, variableContext);
 
+            // CRITICAL: Await extraction to ensure ticket_candidates are committed before notifying user.
+            // Without this, /qori-tickets won't find the tickets until extraction completes (can be 1+ min).
+            if (rendered.extractionPromise) {
+              const extractResult = await rendered.extractionPromise;
+              if (!extractResult.success) {
+                console.error(`❌ ${audience} extraction failed: ${extractResult.error}`);
+              } else {
+                console.log(`✅ ${audience} variables committed: ${extractResult.variableCount} items`);
+              }
+            }
+
             results.push({ audience, url: rendered.result.url, success: true });
 
             await client.chat.postMessage({
@@ -579,7 +590,7 @@ const handleReadoutModalSubmission = async ({ ack, body, view, client }: SlackVi
                   type: 'section',
                   text: {
                     type: 'mrkdwn',
-                    text: `✅ *${audience}* readout complete\n\n<${rendered.result.url}|View on GitHub>`,
+                    text: `✅ *${audience}* readout complete — tickets ready\n\n<${rendered.result.url}|View on GitHub>`,
                   },
                 },
               ],

--- a/backend/src/helpers/slack/commands/readoutHandler.ts
+++ b/backend/src/helpers/slack/commands/readoutHandler.ts
@@ -619,9 +619,29 @@ const handleReadoutModalSubmission = async ({ ack, body, view, client }: SlackVi
 
     } else {
       // Research readout (existing flow)
+      await client.chat.postMessage({
+        channel: body.user.id,
+        text: `🔄 Generating research readout for *${selectedStudyName}*... This may take a few minutes.`,
+      });
+
       const yamlTemplateName = 'research_readout.yaml';
       const file = await fetchFileFromRepo(getConfigRepo(), YAML_TEMPLATE_PATH, yamlTemplateName);
       const renderedYaml = await processYamlTemplate(file.content, reportData, selectedStudy.path ?? '', '', false, variableContext);
+
+      // CRITICAL: Await extraction to ensure cascade variables (prioritized_findings) are committed.
+      // Without this, targeted readouts won't see the findings. See ADR 0019.
+      if (renderedYaml.extractionPromise) {
+        const extractResult = await renderedYaml.extractionPromise;
+        if (!extractResult.success) {
+          console.error(`❌ Readout extraction failed: ${extractResult.error}`);
+          await client.chat.postMessage({
+            channel: body.user.id,
+            text: `⚠️ Report generated but variable extraction failed: ${extractResult.error}\n\nTargeted readouts may not work until you regenerate.`,
+          });
+          return;
+        }
+        console.log(`✅ Readout variables committed: ${extractResult.variableCount} items (${extractResult.keys?.join(', ')})`);
+      }
 
       await client.chat.postMessage({
         channel: body.user.id,
@@ -639,7 +659,7 @@ const handleReadoutModalSubmission = async ({ ack, body, view, client }: SlackVi
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: `*Next:* Run \`/qori-tickets\` to create engineering issues from findings.`,
+              text: `*Next:* Run \`/qori-report\` again and select *Targeted Readouts* to generate audience-specific reports, or \`/qori-tickets\` to create engineering issues.`,
             },
           },
         ],

--- a/backend/src/helpers/slack/commands/researchSynthesisHandler.ts
+++ b/backend/src/helpers/slack/commands/researchSynthesisHandler.ts
@@ -547,7 +547,7 @@ const handleResearchSynthesisSubmission = async ({ ack, body, view, client }: Sl
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: `<${renderedAnalysis.result.url}|:github: View on GitHub>`,
+              text: `<${renderedAnalysis.result.url}|View on GitHub>`,
             },
           },
           { type: 'divider' },

--- a/backend/src/helpers/slack/commands/sessionNotesHandler.ts
+++ b/backend/src/helpers/slack/commands/sessionNotesHandler.ts
@@ -361,11 +361,12 @@ const handleSessionNotesSubmission = async ({ ack, body, view, client }: SlackVi
     }
 
     if (!selectedSession || selectedSessionId === 'no_sessions') {
-      await ack();
-      ackCalled = true;
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `❌ Please select a valid session before submitting notes. No sessions are currently available.`,
+      // 5f pattern: inline errors instead of ack()+DM — modal stays open
+      await (ack as Function)({
+        response_action: "errors",
+        errors: {
+          session_select: "Please select a valid session. No sessions are currently available."
+        }
       });
       return;
     }
@@ -389,11 +390,12 @@ const handleSessionNotesSubmission = async ({ ack, body, view, client }: SlackVi
       const observations: string = values.observations?.observations_text?.value || '';
 
       if (!observations || observations.trim() === '') {
-        await ack();
-        ackCalled = true;
-        await client.chat.postMessage({
-          channel: body.user.id,
-          text: `❌ Please enter your observations before submitting.`,
+        // 5f pattern: inline errors instead of ack()+DM — modal stays open
+        await (ack as Function)({
+          response_action: "errors",
+          errors: {
+            observations: "Please enter your observations before submitting."
+          }
         });
         return;
       }
@@ -425,7 +427,10 @@ const handleSessionNotesSubmission = async ({ ack, body, view, client }: SlackVi
       // PII scrubbing happens here: extract real name, scrub, push review modal
       const filesInput = values.transcript_files?.files as { files?: Array<{ name: string; mimetype: string; url_private?: string; [key: string]: unknown }> } | undefined;
       const filesList = filesInput?.files || [];
-      const pastedText: string = values.transcript_paste?.text?.value || '';
+      // 5f fix (b): trim for validation only — whitespace-only must fail
+      // Raw content preserved for storage (both paste and file paths save unmodified input)
+      const pastedTextRaw: string = values.transcript_paste?.text?.value || '';
+      const pastedTextTrimmed: string = pastedTextRaw.trim();
 
       // ── Extract participant real name for scrubbing (TRANSIENT — never stored) ──
       // PRIVACY: This variable is used ONLY for in-memory find/replace.
@@ -439,6 +444,17 @@ const handleSessionNotesSubmission = async ({ ack, body, view, client }: SlackVi
         const processedFiles: ProcessedFile[] = await processSlackFiles(filesList, process.env.SLACK_BOT_TOKEN!);
         rawContent = processedFiles.map((file: ProcessedFile) => file.content).join('\n\n---\n\n');
 
+        // 5f fix (c): validate non-empty content AFTER download
+        if (!rawContent.trim()) {
+          await (ack as Function)({
+            response_action: "errors",
+            errors: {
+              transcript_files: "Uploaded file(s) contain no text content. Check that the file isn't empty or corrupted."
+            }
+          });
+          return;
+        }
+
         templateData = {
           ...templateData,
           transcript_files: filesList.map((f: { name: string }) => f.name).join(', '),
@@ -448,18 +464,20 @@ const handleSessionNotesSubmission = async ({ ack, body, view, client }: SlackVi
           transcript_source: 'file_upload',
           manual_notes_text_or_blank: '',
         };
-      } else if (pastedText) {
-        rawContent = pastedText;
+      } else if (pastedTextTrimmed) {
+        // Store raw content (preserves leading/trailing whitespace from user input)
+        rawContent = pastedTextRaw;
         templateData = {
           ...templateData,
-          manual_notes_text_or_blank: pastedText
+          manual_notes_text_or_blank: pastedTextRaw
         };
       } else {
-        await ack();
-        ackCalled = true;
-        await client.chat.postMessage({
-          channel: body.user.id,
-          text: `❌ Please either upload files or paste transcript content.`,
+        // 5f fix (a): inline errors instead of ack()+DM — modal stays open
+        await (ack as Function)({
+          response_action: "errors",
+          errors: {
+            transcript_paste: "Please either upload files or paste transcript content."
+          }
         });
         return;
       }

--- a/backend/src/helpers/slack/commands/ticketHandler.ts
+++ b/backend/src/helpers/slack/commands/ticketHandler.ts
@@ -182,7 +182,7 @@ function buildStep1Modal(
       {
         type: 'input',
         block_id: 'study_select',
-        label: { type: 'plain_text', text: 'Study' },
+        label: { type: 'plain_text', text: 'Study *' },  // R7: required marking
         element: {
           type: 'static_select',
           action_id: 'study_select_action',
@@ -194,7 +194,7 @@ function buildStep1Modal(
       {
         type: 'input',
         block_id: 'audience_select',
-        label: { type: 'plain_text', text: 'Audience' },
+        label: { type: 'plain_text', text: 'Audience *' },  // R7: required marking
         element: {
           type: 'static_select',
           action_id: 'audience_select_action',
@@ -305,7 +305,7 @@ const handleStep1Submit = async ({ ack, body, view, client }: SlackViewMiddlewar
     const alreadyCreated = existingTicketIds.has(t.id);
     const findingsCount = Array.isArray(t.addresses_findings) ? t.addresses_findings.length : 0;
     const label = `*${t.id}* — ${t.title}`;
-    const desc = `${t.priority} · ${t.effort} · ${findingsCount} finding(s)${alreadyCreated ? ' · ✅ Already created' : ''}`;
+    const desc = `${t.priority} · ${t.effort} · ${findingsCount} finding${findingsCount !== 1 ? 's' : ''}${alreadyCreated ? ' · ✅ Already created' : ''}`;
 
     return {
       text: { type: 'mrkdwn' as const, text: label },

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -417,7 +417,7 @@ slackApp.command('/qori-plan', async ({ ack, client, command }) => {
 slackApp.command('/qori-discover', discoverHandler);
 slackApp.command('/qori-fieldwork', fieldworkHandler);
 slackApp.command('/qori-analyze', analyzeNotesHandler);
-slackApp.command('/qori-synthesis', researchSynthesisHandler);
+slackApp.command('/qori-synthesize', researchSynthesisHandler);
 slackApp.command('/qori-report', openReadoutModal);
 slackApp.command('/qori-tickets', ticketHandler);
 slackApp.command('/qori-ask', askHandler);

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -417,7 +417,7 @@ slackApp.command('/qori-plan', async ({ ack, client, command }) => {
 slackApp.command('/qori-discover', discoverHandler);
 slackApp.command('/qori-fieldwork', fieldworkHandler);
 slackApp.command('/qori-analyze', analyzeNotesHandler);
-slackApp.command('/qori-synthesize', researchSynthesisHandler);
+slackApp.command('/qori-synthesis', researchSynthesisHandler);
 slackApp.command('/qori-report', openReadoutModal);
 slackApp.command('/qori-tickets', ticketHandler);
 slackApp.command('/qori-ask', askHandler);

--- a/backend/src/helpers/slack/requestChangesHandler.ts
+++ b/backend/src/helpers/slack/requestChangesHandler.ts
@@ -522,7 +522,7 @@ export async function handleRequestChangesSubmission(
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `<${url}|:github: View on GitHub>`,
+            text: `<${url}|View on GitHub>`,
           },
         },
       ];

--- a/backend/src/helpers/slack/ui/analyzeNotesModal.ts
+++ b/backend/src/helpers/slack/ui/analyzeNotesModal.ts
@@ -117,17 +117,8 @@ export const analyzeNotesModal = (
 
   const blocks: Record<string, unknown>[] = [];
 
-  // Section 1: Select Research Study (always shown if showStudy is true)
+  // Section 1: Select Study (R3: no redundant wrapper, just the input)
   if (showStudy) {
-    blocks.push({
-      type: "section",
-      block_id: "research_study_header",
-      text: {
-        type: "mrkdwn",
-        text: "*Research Study*",
-      },
-    });
-
     const studySelectElement: Record<string, unknown> = {
       type: "static_select",
       action_id: "study_select_test",
@@ -177,46 +168,38 @@ export const analyzeNotesModal = (
     }
   }
 
-  // Cascade Context: Show upstream brief variables when available
+  // Cascade context: R5 — translate to researcher language, keep grounding, context block (subordinate)
   if (cascadeContext && showSession) {
-    blocks.push({
-      type: "divider",
-    });
-
-    const contextLines: string[] = [];
+    const contextParts: string[] = [];
     if (cascadeContext.barrierCount > 0) {
-      contextLines.push(`*${cascadeContext.barrierCount}* target barrier${cascadeContext.barrierCount !== 1 ? 's' : ''} to validate`);
+      contextParts.push(`${cascadeContext.barrierCount} barrier${cascadeContext.barrierCount !== 1 ? 's' : ''}`);
     }
     if (cascadeContext.questionCount > 0) {
-      contextLines.push(`*${cascadeContext.questionCount}* research question${cascadeContext.questionCount !== 1 ? 's' : ''} to address`);
+      contextParts.push(`${cascadeContext.questionCount} question${cascadeContext.questionCount !== 1 ? 's' : ''}`);
     }
     if (cascadeContext.methodology) {
-      contextLines.push(`Method: ${cascadeContext.methodology}`);
+      contextParts.push(cascadeContext.methodology);
     }
 
-    blocks.push({
-      type: "section",
-      block_id: "cascade_context_section",
-      text: {
-        type: "mrkdwn",
-        text: `*Cascade Context*\n\nBrief approved — analyzing against:\n${contextLines.map(l => `  •  ${l}`).join('\n')}\n\nSession summary will reference these upstream inputs.`,
-      },
-    });
+    if (contextParts.length > 0) {
+      blocks.push(
+        { type: "divider" },
+        {
+          type: "context",
+          block_id: "grounding_context",
+          elements: [{
+            type: "mrkdwn",
+            text: `*Analyzing against:*  ${contextParts.join(' • ')}`,
+          }],
+        }
+      );
+    }
   }
 
   // Section 2: Select Session (shown when showSession is true)
   if (showSession) {
     blocks.push({
       type: "divider",
-    });
-
-    blocks.push({
-      type: "section",
-      block_id: "session_header",
-      text: {
-        type: "mrkdwn",
-        text: "*Session*",
-      },
     });
 
     const sessionSelectElement: Record<string, unknown> = {

--- a/backend/src/helpers/slack/ui/cascadeRegistry.generated.ts
+++ b/backend/src/helpers/slack/ui/cascadeRegistry.generated.ts
@@ -46,7 +46,7 @@ export const TEMPLATE_CONSUMES: Record<string, ConsumeSpec[]> = {
   designer_readout: [
     { key: 'prioritized_findings', required: true, label: 'Prioritized Findings', source_hint: 'Run research readout first' },
     { key: 'prioritized_recommendations', required: true, label: 'Prioritized Recommendations', source_hint: 'Run research readout first' },
-    { key: 'personas', required: true, label: 'Personas', source_hint: 'Run persona generation first' },
+    { key: 'personas', required: false, label: 'Personas', source_hint: 'Run persona generation first' },
     { key: 'journey_stages', required: false, label: 'Journey Stages', source_hint: 'Complete journey mapping first' },
     { key: 'validated_themes', required: false, label: 'Validated Themes', source_hint: 'Run affinity mapping first' },
     { key: 'target_barriers', required: false, label: 'Target Barriers', source_hint: 'Create research brief first' },

--- a/backend/src/helpers/slack/ui/markChangesCompleteModal.ts
+++ b/backend/src/helpers/slack/ui/markChangesCompleteModal.ts
@@ -62,7 +62,7 @@ const markChangesCompleteModal = (fileName: string, filePath: string, statusId: 
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `<${filePath}|:github: View on GitHub>`,
+        text: `<${filePath}|View on GitHub>`,
       },
     },
     {

--- a/backend/src/helpers/slack/ui/observerGuideDM.ts
+++ b/backend/src/helpers/slack/ui/observerGuideDM.ts
@@ -35,7 +35,7 @@ export const sendObserverGuideDM = async (
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `<${githubUrl}|:github: View Participant Tracker on GitHub>`,
+        text: `<${githubUrl}|View Participant Tracker on GitHub>`,
       },
     });
   }

--- a/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
+++ b/backend/src/helpers/slack/ui/researchBriefEntryModal.ts
@@ -202,7 +202,7 @@ export async function buildBriefEntryModal(options: BuildBriefEntryModalOptions)
     elements: [
       {
         type: "mrkdwn",
-        text: `:file_folder: Creating research brief for project *${projectName}*`,
+        text: `Creating research brief for project *${projectName}*`,
       },
     ],
   };
@@ -242,7 +242,7 @@ export async function buildBriefEntryModal(options: BuildBriefEntryModalOptions)
       elements: [
         {
           type: "mrkdwn",
-          text: `:bust_in_silhouette: *Approver:* ${approverDisplay} (${approverRoleLabel} — approves this brief)`,
+          text: `*Approver:* ${approverDisplay} (${approverRoleLabel} — approves this brief)`,
         },
       ],
     };
@@ -312,8 +312,8 @@ export async function buildBriefEntryModal(options: BuildBriefEntryModalOptions)
         const displaySlug = a.slug.length > maxSlugDisplay
           ? a.slug.substring(0, maxSlugDisplay - 1) + '…'
           : a.slug;
-        // Build compact display: "📊 *slug* · label · date"
-        const baseText = `${a.icon} *${displaySlug}* · ${a.label} · ${a.date}`;
+        // Build compact display: "*slug* · label · date"
+        const baseText = `*${displaySlug}* · ${a.label} · ${a.date}`;
         const displayText = baseText.length > 150
           ? baseText.substring(0, 147) + '…'
           : baseText;
@@ -333,7 +333,7 @@ export async function buildBriefEntryModal(options: BuildBriefEntryModalOptions)
         elements: [
           {
             type: "mrkdwn",
-            text: `✅ ${artifacts.length} discovery source${artifacts.length === 1 ? '' : 's'} available — auto-selected`,
+            text: `${artifacts.length} discovery source${artifacts.length === 1 ? '' : 's'} available — auto-selected`,
           },
         ],
       };

--- a/backend/src/helpers/slack/ui/researchBriefModal.ts
+++ b/backend/src/helpers/slack/ui/researchBriefModal.ts
@@ -216,7 +216,7 @@ export const researchBriefModal = {
       optional: true,
       label: {
         type: "plain_text",
-        text: "Custom method (optional)",
+        text: "Custom method",
       },
       element: {
         type: "plain_text_input",

--- a/backend/src/helpers/slack/ui/researchSynthesisModal.ts
+++ b/backend/src/helpers/slack/ui/researchSynthesisModal.ts
@@ -87,40 +87,48 @@ export const researchSynthesisModal = (
     selectedAnalysisMethod,
   } satisfies SynthesisModalMetadata);
 
-  // Build session data blocks (R10: subordinate context blocks)
-  const sessionDataBlocks: Record<string, unknown>[] = [];
+  // Build grounding block — merged session data + enrichments (R10: one subordinate context block)
+  const groundingBlocks: Record<string, unknown>[] = [];
   if (cascadeData && isCascadeAware) {
     if (cascadeData.sessionStats && cascadeData.sessionStats.totalSessions > 0) {
-      // Session data available — R5: researcher language, R10: context block
       const stats = cascadeData.sessionStats;
-      const participantList = stats.participantBreakdown
-        .slice(0, 8)
-        .map(p => `• ${p.participantId}${p.sessionDate ? ` (${p.sessionDate})` : ''} — ${p.nuggetCount} nuggets`)
-        .join('\n');
-      const moreCount = stats.participantBreakdown.length > 8 ? stats.participantBreakdown.length - 8 : 0;
 
-      sessionDataBlocks.push(
+      // Session summary line
+      const sessionLine = `${stats.totalSessions} session${stats.totalSessions !== 1 ? 's' : ''} • ${stats.totalNuggets} nuggets`;
+
+      // R5: Translate enrichment labels to researcher language
+      // "participant metadata" → "participant", drop system suffixes
+      const translateLabel = (label: string): string => {
+        return label
+          .toLowerCase()
+          .replace(/ metadata$/, '')  // "participant metadata" → "participant"
+          .replace(/_/g, ' ');        // snake_case → spaces
+      };
+
+      // Build enrichments list if any
+      const enrichmentItems = cascadeData.enrichments.length > 0
+        ? cascadeData.enrichments.map(e => `${e.count} ${translateLabel(e.label)}`).join(' • ')
+        : '';
+
+      // Combine into one grounding line
+      const groundingLine = enrichmentItems
+        ? `${sessionLine} • ${enrichmentItems}`
+        : sessionLine;
+
+      groundingBlocks.push(
         { type: "divider" },
         {
           type: "context",
-          block_id: "session_data_status",
+          block_id: "grounding_info",
           elements: [{
             type: "mrkdwn",
-            text: `*Session Data*  ${stats.totalSessions} session${stats.totalSessions !== 1 ? 's' : ''} • ${stats.totalNuggets} nuggets`,
-          }],
-        },
-        {
-          type: "context",
-          block_id: "session_data_breakdown",
-          elements: [{
-            type: "mrkdwn",
-            text: participantList + (moreCount > 0 ? `\n_... and ${moreCount} more_` : ''),
+            text: `*Using:*  ${groundingLine}`,
           }],
         }
       );
     } else if (!cascadeData.readyToRun) {
       // No session data — hard fail state
-      sessionDataBlocks.push(
+      groundingBlocks.push(
         { type: "divider" },
         {
           type: "context",
@@ -132,26 +140,6 @@ export const researchSynthesisModal = (
         }
       );
     }
-  }
-
-  // Build enrichments blocks (R5: researcher language, R10: context blocks)
-  const enrichmentBlocks: Record<string, unknown>[] = [];
-  if (cascadeData && isCascadeAware && cascadeData.enrichments.length > 0) {
-    // R5: Translate to researcher language — "5 target barriers" not "Target barriers — 5 items from research_brief"
-    const enrichmentList = cascadeData.enrichments
-      .map(e => `• ${e.count} ${e.label.toLowerCase()}`)
-      .join('\n');
-
-    enrichmentBlocks.push(
-      {
-        type: "context",
-        block_id: "enrichments_header",
-        elements: [{
-          type: "mrkdwn",
-          text: `*Using from your brief and sessions:*\n${enrichmentList}`,
-        }],
-      }
-    );
   }
 
   // Build missing required warning (R10: context blocks)
@@ -276,11 +264,8 @@ export const researchSynthesisModal = (
         };
       })(),
 
-      // Session data status (cascade-aware)
-      ...sessionDataBlocks,
-
-      // Enrichments (opt-out checkboxes)
-      ...enrichmentBlocks,
+      // Grounding info — merged session data + enrichments (subordinate)
+      ...groundingBlocks,
 
       // Missing required warnings
       ...missingRequiredBlocks,

--- a/backend/src/helpers/slack/ui/researchSynthesisModal.ts
+++ b/backend/src/helpers/slack/ui/researchSynthesisModal.ts
@@ -87,11 +87,11 @@ export const researchSynthesisModal = (
     selectedAnalysisMethod,
   } satisfies SynthesisModalMetadata);
 
-  // Build session data blocks
+  // Build session data blocks (R10: subordinate context blocks)
   const sessionDataBlocks: Record<string, unknown>[] = [];
   if (cascadeData && isCascadeAware) {
     if (cascadeData.sessionStats && cascadeData.sessionStats.totalSessions > 0) {
-      // Session data available
+      // Session data available — R5: researcher language, R10: context block
       const stats = cascadeData.sessionStats;
       const participantList = stats.participantBreakdown
         .slice(0, 8)
@@ -102,12 +102,12 @@ export const researchSynthesisModal = (
       sessionDataBlocks.push(
         { type: "divider" },
         {
-          type: "section",
+          type: "context",
           block_id: "session_data_status",
-          text: {
+          elements: [{
             type: "mrkdwn",
-            text: `📊 *Session Data Available*\n${stats.totalSessions} session${stats.totalSessions !== 1 ? 's' : ''} analyzed • ${stats.totalNuggets} atomic nuggets`,
-          },
+            text: `*Session Data*  ${stats.totalSessions} session${stats.totalSessions !== 1 ? 's' : ''} • ${stats.totalNuggets} nuggets`,
+          }],
         },
         {
           type: "context",
@@ -123,84 +123,58 @@ export const researchSynthesisModal = (
       sessionDataBlocks.push(
         { type: "divider" },
         {
-          type: "section",
-          block_id: "session_data_missing",
-          text: {
-            type: "mrkdwn",
-            text: `:warning: *Cannot run synthesis — no session data*`,
-          },
-        },
-        {
           type: "context",
-          block_id: "session_data_hint",
+          block_id: "session_data_missing",
           elements: [{
             type: "mrkdwn",
-            text: `Run \`/qori-analyze\` on session transcripts first to build the nugget pool.\nSynthesis requires atomic nuggets extracted from analyzed sessions.`,
+            text: `:warning: *No session data* — run \`/qori-analyze\` first`,
           }],
         }
       );
     }
   }
 
-  // Build enrichments blocks (read-only display — ADR 0018 amendment: no opt-out)
+  // Build enrichments blocks (R5: researcher language, R10: context blocks)
   const enrichmentBlocks: Record<string, unknown>[] = [];
   if (cascadeData && isCascadeAware && cascadeData.enrichments.length > 0) {
+    // R5: Translate to researcher language — "5 target barriers" not "Target barriers — 5 items from research_brief"
     const enrichmentList = cascadeData.enrichments
-      .map(e => `• *${e.label}* — ${e.count} item${e.count !== 1 ? 's' : ''} from ${e.source}`)
+      .map(e => `• ${e.count} ${e.label.toLowerCase()}`)
       .join('\n');
 
     enrichmentBlocks.push(
-      { type: "divider" },
-      {
-        type: "section",
-        block_id: "enrichments_header",
-        text: {
-          type: "mrkdwn",
-          text: `✅ *Cascade Enrichments* (feeding this synthesis)`,
-        },
-      },
       {
         type: "context",
-        block_id: "enrichments_list",
+        block_id: "enrichments_header",
         elements: [{
           type: "mrkdwn",
-          text: enrichmentList,
+          text: `*Using from your brief and sessions:*\n${enrichmentList}`,
         }],
       }
     );
   }
 
-  // Build missing required warning
+  // Build missing required warning (R10: context blocks)
   const missingRequiredBlocks: Record<string, unknown>[] = [];
   if (cascadeData && cascadeData.missingRequired.length > 0) {
     const missingList = cascadeData.missingRequired
-      .map(m => `:warning: *${m.label}* — ${m.hint}`)
+      .map(m => `• ${m.label} — ${m.hint}`)
       .join('\n');
 
     missingRequiredBlocks.push(
       { type: "divider" },
       {
-        type: "section",
-        block_id: "missing_required_header",
-        text: {
+        type: "context",
+        block_id: "missing_required_info",
+        elements: [{
           type: "mrkdwn",
-          text: `:warning: *Missing required inputs*`,
-        },
-      },
-      {
-        type: "context",
-        block_id: "missing_required_list",
-        elements: [{ type: "mrkdwn", text: missingList }],
-      },
-      {
-        type: "context",
-        block_id: "missing_required_action",
-        elements: [{ type: "mrkdwn", text: `_Complete the upstream steps above, then re-open this modal._` }],
+          text: `:warning: *Missing required inputs*\n${missingList}\n_Complete these steps, then re-open this modal._`,
+        }],
       }
     );
   }
 
-  // Build legacy method notice
+  // Build legacy method notice (R1: no decorative emoji, R10: context block)
   const legacyNoticeBlocks: Record<string, unknown>[] = [];
   if (isLegacyMethod) {
     legacyNoticeBlocks.push(
@@ -210,7 +184,7 @@ export const researchSynthesisModal = (
         block_id: "legacy_method_notice",
         elements: [{
           type: "mrkdwn",
-          text: `⚠️ *Service Blueprint* uses legacy file-based input. This synthesis method will be upgraded in a future release.`,
+          text: `*Service Blueprint* uses legacy file-based input. This method will be upgraded in a future release.`,
         }],
       }
     );
@@ -225,7 +199,7 @@ export const researchSynthesisModal = (
     },
     submit: {
       type: "plain_text",
-      text: "Run Analysis",
+      text: "Generate",  // R2: "Run Analysis" → "Generate"
     },
     close: {
       type: "plain_text",
@@ -233,12 +207,11 @@ export const researchSynthesisModal = (
     },
     private_metadata: privateMetadata,
     blocks: [
-      // Study Selection Section
-      { type: "section", text: { type: "mrkdwn", text: "📁 *Study*" } },
+      // Study Selection — PRIMARY (R1: no emoji, R7: required marking, R10: prominent)
       {
         type: "input",
         block_id: "study_select_block",
-        label: { type: "plain_text", text: "Study" },
+        label: { type: "plain_text", text: "Study *" },
         element: {
           type: "static_select",
           action_id: "study_select_synthesize",
@@ -255,55 +228,49 @@ export const researchSynthesisModal = (
 
       { type: "divider" },
 
-      // Analysis Type Section
-      { type: "section", text: { type: "mrkdwn", text: "🎯 *Analysis Type*" } },
-      { type: "context", elements: [{ type: "mrkdwn", text: "Choose the type of synthesis" }] },
+      // Synthesis Type — PRIMARY (R1: no emoji, R4: "Synthesis" not "Analysis", R7: required, R10: prominent)
       (() => {
-        const analysisMethodOptions = [
+        // R1: Remove ALL decorative emoji from options
+        const synthesisMethodOptions = [
           {
-            text: { type: "plain_text", text: "🗂️ Affinity Mapping • Group findings" },
+            text: { type: "plain_text", text: "Affinity Mapping • Group findings" },
             value: "affinity_mapping",
           },
           {
-            text: { type: "plain_text", text: "🗺️ Journey Mapping • Map experiences" },
+            text: { type: "plain_text", text: "Journey Mapping • Map experiences" },
             value: "journey_mapping",
           },
           {
-            text: { type: "plain_text", text: "👤 Persona Generation • Create personas" },
+            text: { type: "plain_text", text: "Persona Generation • Create personas" },
             value: "persona_generation",
           },
           {
-            text: { type: "plain_text", text: "🎯 Jobs to Be Done • Extract user jobs" },
+            text: { type: "plain_text", text: "Jobs to Be Done • Extract user jobs" },
             value: "jobs_to_be_done",
           },
           {
-            text: { type: "plain_text", text: "⚠️ Usability Issues • Prioritize problems" },
+            text: { type: "plain_text", text: "Usability Issues • Prioritize problems" },
             value: "usability_issues",
           },
           {
-            text: { type: "plain_text", text: "💡 Design Opportunities • Generate HMWs" },
+            text: { type: "plain_text", text: "Design Opportunities • Generate HMWs" },
             value: "design_opportunities",
           },
-          // Service blueprint excluded from cascade-aware modal per ADR 0018
-          // {
-          //   text: { type: "plain_text", text: "🔧 Service Blueprint • Map backstage" },
-          //   value: "service_blueprint",
-          // },
         ];
 
         const methodValue = selectedAnalysisMethod || "affinity_mapping";
-        const matchingOption = analysisMethodOptions.find(opt => opt.value === methodValue);
-        const initialOption = matchingOption || analysisMethodOptions[0];
+        const matchingOption = synthesisMethodOptions.find(opt => opt.value === methodValue);
+        const initialOption = matchingOption || synthesisMethodOptions[0];
 
         return {
           type: "input",
           block_id: "analysis_method_selection",
           dispatch_action: true, // Fire action on radio change to update enrichments
-          label: { type: "plain_text", text: "Analysis method" },
+          label: { type: "plain_text", text: "Synthesis method *" },  // R4 & R7
           element: {
             type: "radio_buttons",
             action_id: "analysis_method",
-            options: analysisMethodOptions,
+            options: synthesisMethodOptions,
             initial_option: initialOption,
           },
         };

--- a/backend/src/helpers/slack/ui/studyResultBlocks.ts
+++ b/backend/src/helpers/slack/ui/studyResultBlocks.ts
@@ -105,7 +105,7 @@ export const generateStudyResultBlocks = (
     type: 'section',
     text: {
       type: 'mrkdwn',
-      text: `<${url}|:github: View on GitHub>`,
+      text: `<${url}|View on GitHub>`,
     },
   });
 
@@ -152,7 +152,7 @@ const generateChannelBlocks = (studyName: string, study: StudyWithRoles | null, 
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `<${url}|:github: View on GitHub>`,
+        text: `<${url}|View on GitHub>`,
       },
     },
     {

--- a/backend/src/helpers/variableExtractor.ts
+++ b/backend/src/helpers/variableExtractor.ts
@@ -221,8 +221,135 @@ ${variableDescriptions.map(v => {
 // ─── Response parsing and validation ─────────────────────────────────
 
 /**
+ * Attempt to repair truncated or malformed JSON.
+ * Handles common LLM output issues:
+ * - Truncated responses (unclosed brackets/braces)
+ * - Trailing commas
+ * - Unescaped control characters in strings
+ */
+function repairJson(text: string): string {
+  let repaired = text;
+
+  // Remove trailing commas before closing brackets/braces
+  repaired = repaired.replace(/,(\s*[\]}])/g, '$1');
+
+  // Escape unescaped newlines and tabs within strings
+  // This regex finds strings and escapes control chars within them
+  repaired = repaired.replace(/"([^"\\]*(\\.[^"\\]*)*)"/g, (match) => {
+    return match
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/\t/g, '\\t');
+  });
+
+  // Count brackets and braces to detect truncation
+  let braceCount = 0;
+  let bracketCount = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (const char of repaired) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+
+    if (char === '{') braceCount++;
+    else if (char === '}') braceCount--;
+    else if (char === '[') bracketCount++;
+    else if (char === ']') bracketCount--;
+  }
+
+  // If we ended inside a string, try to close it
+  if (inString) {
+    // Find last unclosed quote and truncate there, then close
+    const lastQuote = repaired.lastIndexOf('"');
+    if (lastQuote > 0) {
+      // Check if this quote is the start of an unfinished string value
+      const beforeQuote = repaired.slice(0, lastQuote);
+      const afterQuote = repaired.slice(lastQuote + 1);
+      // If afterQuote has content but no closing quote, truncate the string
+      if (afterQuote.length > 0 && !afterQuote.includes('"')) {
+        repaired = beforeQuote + '""';
+        // Recount after repair
+        braceCount = 0;
+        bracketCount = 0;
+        inString = false;
+        escaped = false;
+        for (const char of repaired) {
+          if (escaped) { escaped = false; continue; }
+          if (char === '\\') { escaped = true; continue; }
+          if (char === '"') { inString = !inString; continue; }
+          if (inString) continue;
+          if (char === '{') braceCount++;
+          else if (char === '}') braceCount--;
+          else if (char === '[') bracketCount++;
+          else if (char === ']') bracketCount--;
+        }
+      }
+    }
+  }
+
+  // Remove trailing partial content after last complete value
+  // Look for patterns like: `"key": "incomplete` or `, "key"` at the end
+  if (braceCount > 0 || bracketCount > 0) {
+    // Try to find a safe truncation point
+    const patterns = [
+      /,\s*"[^"]*"?\s*:?\s*"?[^"]*$/,  // Trailing incomplete key-value
+      /,\s*\{[^}]*$/,                    // Trailing incomplete object
+      /,\s*\[[^\]]*$/,                   // Trailing incomplete array
+      /,\s*$/,                           // Trailing comma
+    ];
+
+    for (const pattern of patterns) {
+      const match = repaired.match(pattern);
+      if (match && match.index !== undefined) {
+        repaired = repaired.slice(0, match.index);
+        // Recount
+        braceCount = 0;
+        bracketCount = 0;
+        inString = false;
+        escaped = false;
+        for (const char of repaired) {
+          if (escaped) { escaped = false; continue; }
+          if (char === '\\') { escaped = true; continue; }
+          if (char === '"') { inString = !inString; continue; }
+          if (inString) continue;
+          if (char === '{') braceCount++;
+          else if (char === '}') braceCount--;
+          else if (char === '[') bracketCount++;
+          else if (char === ']') bracketCount--;
+        }
+        break;
+      }
+    }
+  }
+
+  // Close unclosed brackets and braces
+  while (bracketCount > 0) {
+    repaired += ']';
+    bracketCount--;
+  }
+  while (braceCount > 0) {
+    repaired += '}';
+    braceCount--;
+  }
+
+  return repaired;
+}
+
+/**
  * Parse the Haiku response into structured variables.
- * Handles common LLM JSON formatting issues.
+ * Handles common LLM JSON formatting issues with repair logic.
  */
 function parseExtractionResponse(responseText: string): Record<string, unknown> | null {
   // Strip markdown code fences if present
@@ -237,12 +364,30 @@ function parseExtractionResponse(responseText: string): Record<string, unknown> 
   }
   cleaned = cleaned.trim();
 
+  // First attempt: parse as-is
   try {
     return JSON.parse(cleaned) as Record<string, unknown>;
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('❌ Failed to parse extraction JSON:', message);
+  } catch (firstError: unknown) {
+    const firstMessage = firstError instanceof Error ? firstError.message : String(firstError);
+    console.warn(`⚠️ Initial JSON parse failed: ${firstMessage}`);
+
+    // Second attempt: repair and retry
+    try {
+      const repaired = repairJson(cleaned);
+      if (repaired !== cleaned) {
+        console.log(`🔧 Attempting JSON repair (truncated/malformed response)...`);
+        const result = JSON.parse(repaired) as Record<string, unknown>;
+        console.log(`✅ JSON repair succeeded`);
+        return result;
+      }
+    } catch (repairError: unknown) {
+      const repairMessage = repairError instanceof Error ? repairError.message : String(repairError);
+      console.error(`❌ JSON repair also failed: ${repairMessage}`);
+    }
+
+    console.error('❌ Failed to parse extraction JSON:', firstMessage);
     console.error('Raw response (first 500 chars):', cleaned.slice(0, 500));
+    console.error('Raw response (last 200 chars):', cleaned.slice(-200));
     return null;
   }
 }

--- a/config/prompts/designer_readout.yaml
+++ b/config/prompts/designer_readout.yaml
@@ -55,9 +55,9 @@ consumes:
     description: "Recommendations — designer translates into design work"
   - key: personas
     source: persona_generator
-    required: true
+    required: false
     inject_as: reference
-    description: "Personas — designer needs to know who they're designing for"
+    description: "Personas — designer references for user context (optional)"
   - key: journey_stages
     source: journey_mapping
     required: false

--- a/docs/product-backlog.md
+++ b/docs/product-backlog.md
@@ -221,6 +221,14 @@ Plus newly filed during template restructure work:
 
 These items don't block product work or federal go-to-market. They make the codebase more robust over time. Worth picking up opportunistically when touching related code.
 
+### Modal design standard findings (2026-07-09)
+
+Filed from `backend/docs/qori-modal-design-standard.md` §6.10:
+
+- **Structured discovery provenance:** Store discovery artifact IDs used at brief generation on the brief's DB record. Currently traceability exists only in rendered markdown (`research_brief.yaml:534-543`). Enables audit trail, regeneration with same context, and impact analysis when discovery is re-run.
+
+- **Discovery naming-layer consolidation:** Three identifier layers per discovery type exist with a manual mapping table (`studyVariables.ts:18-29`): YAML template ID (`desk_research`), storage type (`desk-research`), loader ID (same as storage type). This is the substrate the PR #170 filter bug grew in. Consolidate to a single canonical identifier per discovery type.
+
 ---
 
 ## Federal go-to-market


### PR DESCRIPTION
## Summary

Three fixes to sessionNotesHandler transcript upload path per modal design standard §6.8:

- **(a) Inline errors:** Convert `ack()+DM` rejection to `response_action:"errors"` — modal stays open, user input preserved
- **(b) Trim validation:** Whitespace-only paste content fails validation, but **raw content preserved for storage** (both paste and file paths save unmodified input)
- **(c) Content gate:** Validate non-empty content AFTER file download — empty/corrupted files rejected before reaching quarantine

## Raw content preservation

**Explicitly verified:** Both paths save raw, unmodified user input:
- **File path:** `rawContent = processedFiles.map(f => f.content).join(...)` — no trim
- **Paste path:** `rawContent = pastedTextRaw` — raw value, trim used only for validation check

## Retrospective audit

Verified no empty content exists in dev or prod before this fix:
- Dev: 8 transcripts (5 approved), 0 empty content
- Prod: 0 transcripts
- Git: All 4 committed transcripts have 8-12KB content
- Note: Approved rows have `pending_content = NULL` (cleared on approval); verification used Git file sizes

## Test plan

- [ ] Upload empty text file → inline error, modal stays open
- [ ] Paste only whitespace → inline error, modal stays open  
- [ ] Submit with neither file nor paste → inline error, modal stays open
- [ ] Upload valid file → proceeds to PII review
- [ ] Paste valid content → proceeds to PII review

🤖 Generated with [Claude Code](https://claude.ai/code)