### PR TITLE
feat(audit): add audit logging to Change Stakeholder action

### DIFF
--- a/backend/docs/qori-modal-design-standard.md
+++ b/backend/docs/qori-modal-design-standard.md
@@ -24,6 +24,14 @@ Submit button text should describe the action, not just "Submit". Examples:
 - "Generate" (for synthesis modal)
 - "Create Brief" (for brief modal)
 
+**Verb table by action type:**
+
+| Action type | Verb |
+|-------------|------|
+| Primary generation | "Generate", "Create", "Analyze" |
+| Continue to next step | "Continue" |
+| Launches a sub-modal | "Open" (see R14) |
+
 **Status:** Enforced.
 
 ---
@@ -172,39 +180,61 @@ Use correct singular/plural forms:
 
 ---
 
+### R14: Hub Launcher Verb
+
+Rows in a hub modal that open a sub-modal use ONE verb product-wide: **"Open"**. This applies to:
+- Admin Center rows (Participant Data, Delete Study, etc.)
+- Discovery launcher rows
+
+Do not use "Start", "Launch", "View", or other verbs for sub-modal launchers.
+
+**Status:** Pending. Discovery launcher uses "Start" (violation). Admin Center rows use "Open" (conforms).
+
+---
+
+### R15: Danger Styling is Exclusive
+
+Destructive actions get Slack's `danger` (red) style. **Only** destructive actions get a filled style in a multi-action surface; all non-destructive launchers/buttons alongside them use `default` (outlined) style.
+
+One loud thing per surface.
+
+**Status:** Pending. Admin Center "Participant Data" row uses filled style alongside Delete Study (violation).
+
+---
+
 ## §5: Conformance Checklist
 
 Per-modal audit state. ✓ = conforms, — = violation found, ? = not audited, N/A = not applicable.
 
 Scores reflect CURRENT code state, not intended state. A cell flips to ✓ with PR number when the fix ships.
 
-| Modal | R1 | R2 | R3 | R4 | R5 | R6 | R7 | R8 | R9 | R10 | R11 | R12 | R13 |
-|-------|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:---:|:---:|:---:|:---:|
-| Research Brief | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | — | ? | ✓ | ✓ | ? | ✓ | ✓ |
-| Analyze Session | — | ✓ | ✓ | ✓ | ✓ | N/A | — | ? | ✓ | ✓ | ? | ✓ | ✓ |
-| Research Synthesis | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | ✓ | ? | ✓ | ✓ | ? | ✓ | ✓ |
-| Readout | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
-| Discussion Guide | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
-| Research Plan | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
-| Discovery Launcher | — | ? | ? | ? | ? | N/A | ? | — | ? | ? | — | ? | ? |
-| Discover: Desk Research | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
-| Discover: Stakeholder | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
-| Discover: Survey | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
-| Project Creation | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
-| Add Participant | — | ? | — | ? | ? | N/A | — | — | ? | ? | — | ? | ? |
-| Update Participant | — | ? | ? | ? | ? | N/A | — | ? | ? | — | ? | ? | ? |
-| Add Observer | — | — | ? | ? | ? | N/A | ✓ | ? | ? | ? | ? | ? | ? |
-| Session Notes | ✓ | — | — | ? | ? | N/A | ? | ? | ? | — | — | ? | ? |
-| Participant Outreach | — | — | — | ? | ? | N/A | — | — | ? | ? | ? | ? | ? |
-| Session Confirmation | — | — | ? | ? | ? | N/A | — | ? | ? | ? | ? | ? | ? |
-| Tickets | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | ? | ? | ✓ | ✓ | ? | ✓ | ✓ |
-| PII Review (transcript) | — | ✓ | ✓ | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
-| PII Review (manual notes) | — | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
-| Fieldwork Dashboard | ? | ✓ | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
-| Join Observer | — | ✓ | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
-| Admin Center Hub | ? | — | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
-| Admin — Delete Study | ? | — | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
-| Admin — Manage Stakeholder | ? | ✓ | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? |
+| Modal | R1 | R2 | R3 | R4 | R5 | R6 | R7 | R8 | R9 | R10 | R11 | R12 | R13 | R14 | R15 |
+|-------|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Research Brief | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | — | ? | ✓ | ✓ | ? | ✓ | ✓ | N/A | N/A |
+| Analyze Session | — | ✓ | ✓ | ✓ | ✓ | N/A | — | ? | ✓ | ✓ | ? | ✓ | ✓ | N/A | N/A |
+| Research Synthesis | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | ✓ | ? | ✓ | ✓ | ? | ✓ | ✓ | N/A | N/A |
+| Readout | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Discussion Guide | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Research Plan | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Discovery Launcher | — | ? | ? | ? | ? | N/A | ? | — | ? | ? | — | ? | ? | — | N/A |
+| Discover: Desk Research | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Discover: Stakeholder | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Discover: Survey | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Project Creation | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Add Participant | — | ? | — | ? | ? | N/A | — | — | ? | ? | — | ? | ? | N/A | N/A |
+| Update Participant | — | ? | ? | ? | ? | N/A | — | ? | ? | — | ? | ? | ? | N/A | N/A |
+| Add Observer | — | — | ? | ? | ? | N/A | ✓ | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Session Notes | ✓ | — | — | ? | ? | N/A | ? | ? | ? | — | — | ? | ? | N/A | N/A |
+| Participant Outreach | — | — | — | ? | ? | N/A | — | — | ? | ? | ? | ? | ? | N/A | N/A |
+| Session Confirmation | — | — | ? | ? | ? | N/A | — | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Tickets | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | ? | ? | ✓ | ✓ | ? | ✓ | ✓ | N/A | N/A |
+| PII Review (transcript) | — | ✓ | ✓ | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| PII Review (manual notes) | — | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Fieldwork Dashboard | ? | ✓ | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Join Observer | — | ✓ | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Admin Center Hub | ? | — | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | ✓ | — |
+| Admin — Delete Study | ? | — | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Admin — Manage Stakeholder | ? | ✓ | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
 
 **Legend:**
 - ✓ Conforms

--- a/backend/docs/qori-modal-design-standard.md
+++ b/backend/docs/qori-modal-design-standard.md
@@ -709,6 +709,7 @@ Track specific violations found during audit, with fix status.
 
 | Date | Version | Changes |
 |------|---------|---------|
+| 2026-07-10 | 1.9 | Session Notes input preservation fix shipped (`37f50e43`): tab switches no longer clear typed inputs. PII scrubbing fix shipped (`15c0a49f`): participant name now correctly extracted and scrubbed. Whitespace behavior documented (`7b1f31c1`): Slack API strips leading/trailing whitespace from plain_text_input (not fixable). Merged to main as `e454740a`. |
 | 2026-07-09 | 1.8 | 5f fix spec implemented in sessionNotesHandler.ts: (a) inline errors, (b) trim paste, (c) validate content after download. Pending manual test. |
 | 2026-07-09 | 1.7 | §6.0.2 ID matching verified — SELECT confirms `desk_research`, `stakeholder_synthesis` only, no `_processor` values. |
 | 2026-07-09 | 1.6 | §6.8 full code context (lines 438-465), check semantics (presence vs content), 5f design finding (convert ack+DM to inline errors). §6.0.2 conclusion held open pending SELECT query. §6.10 moved to product-backlog.md. |

--- a/backend/src/database/models/disposition_audit_log.ts
+++ b/backend/src/database/models/disposition_audit_log.ts
@@ -19,6 +19,7 @@ export type AuditAction =
   | 'delete_participant'
   | 'delete_study'
   | 'export_participant'
+  | 'change_stakeholder'
   | 'deletion_denied'
   | 'deletion_error';
 

--- a/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
+++ b/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
@@ -1231,12 +1231,59 @@ export async function handleStakeholderSubmit({
 
     console.log(`[ADMIN] Stakeholder submit: newStakeholderId=${newStakeholderId}, clearChecked=${clearChecked}, currentStakeholder=${metadata.currentStakeholderId}`);
 
+    // Capture before state for audit (with display name for readability)
+    const previousStakeholderId = metadata.currentStakeholderId || null;
+    const previousStakeholderName = metadata.currentStakeholderName || null;
+    const changeType = clearChecked ? 'cleared' : newStakeholderId ? 'assigned' : 'none';
+
+    // Helper to format staff identity for audit log: "Display Name (USLACKID)"
+    const formatStaffIdentity = (name: string | null, id: string | null): string => {
+      if (!id) return 'none';
+      return name ? `${name} (${id})` : id;
+    };
+
     if (clearChecked && metadata.currentStakeholderId) {
       // Clear stakeholder flag (doesn't affect role — owner stays owner)
       await setProjectStakeholder(metadata.projectId, null);
     } else if (newStakeholderId) {
       // Set new stakeholder (clears old, sets flag on new — doesn't affect roles)
       await setProjectStakeholder(metadata.projectId, newStakeholderId);
+    }
+
+    // Fetch new stakeholder display name for audit (if assigned)
+    let newStakeholderName: string | null = null;
+    if (newStakeholderId) {
+      try {
+        const userInfo = await client.users.info({ user: newStakeholderId });
+        const user = userInfo.user as Record<string, unknown> | undefined;
+        const profile = user?.profile as Record<string, unknown> | undefined;
+        newStakeholderName = (user?.real_name || profile?.display_name || user?.name || null) as string | null;
+      } catch {
+        // Slack lookup failed; ID-only is acceptable
+      }
+    }
+
+    // Log audit entry for stakeholder change
+    // Format: "Stakeholder assigned: Jane Doe (U0123ABC) (was: John Smith (U0456DEF))"
+    if (changeType !== 'none') {
+      const previousIdentity = formatStaffIdentity(previousStakeholderName, previousStakeholderId);
+      const newIdentity = formatStaffIdentity(newStakeholderName, newStakeholderId);
+
+      await logDispositionAction({
+        action: 'change_stakeholder',
+        record_type: 'project_stakeholder',
+        target_id: metadata.projectId,
+        target_identifier: metadata.projectName,
+        project_id: metadata.projectId,
+        project_name: metadata.projectName,
+        actor_user_id: userId,
+        actor_role: 'owner',
+        authorization_basis: 'Project owner per ADR 0025',
+        outcome: 'success',
+        outcome_detail: changeType === 'cleared'
+          ? `Stakeholder cleared (was: ${previousIdentity})`
+          : `Stakeholder assigned: ${newIdentity} (was: ${previousIdentity})`,
+      });
     }
 
     // Fetch updated stakeholder for confirmation display
@@ -1301,6 +1348,24 @@ export async function handleStakeholderSubmit({
     console.log(`[ADMIN] Stakeholder submit: completed, modal closed`);
   } catch (error) {
     console.error('[ADMIN] Error updating stakeholder:', error);
+
+    // Log audit entry for failed stakeholder change
+    const changeType = clearChecked ? 'cleared' : newStakeholderId ? 'assigned' : 'none';
+    if (changeType !== 'none') {
+      await logDispositionAction({
+        action: 'change_stakeholder',
+        record_type: 'project_stakeholder',
+        target_id: metadata.projectId,
+        target_identifier: metadata.projectName,
+        project_id: metadata.projectId,
+        project_name: metadata.projectName,
+        actor_user_id: userId,
+        actor_role: 'owner',
+        authorization_basis: 'Project owner per ADR 0025',
+        outcome: error instanceof AuthorizationError ? 'denied' : 'error',
+        outcome_detail: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
 
     await ack({
       response_action: 'update',

--- a/docs/product-backlog.md
+++ b/docs/product-backlog.md
@@ -229,6 +229,10 @@ Filed from `backend/docs/qori-modal-design-standard.md` §6.10:
 
 - **Discovery naming-layer consolidation:** Three identifier layers per discovery type exist with a manual mapping table (`studyVariables.ts:18-29`): YAML template ID (`desk_research`), storage type (`desk-research`), loader ID (same as storage type). This is the substrate the PR #170 filter bug grew in. Consolidate to a single canonical identifier per discovery type.
 
+### Modal design standard findings (2026-07-10)
+
+- **Project name display split:** Admin Center shows pretty name (`projects.name`: "Testing Mobile Design"), all study surfaces show slug (`research_studies.name`: "testing-mobile-design"). This is the Phase 2D architectural choice — `briefHandler.ts:238` sets `studyName = projectSlug`. Decision needed: standardize on one form or document the split as intentional. No code change now.
+
 ---
 
 ## Federal go-to-market


### PR DESCRIPTION
## Summary
- Add `change_stakeholder` to AuditAction type
- Log success with outcome_detail showing old→new stakeholder with display names + Slack IDs
- Log errors/denials with appropriate outcome type
- Add R14 (hub launcher verb) and R15 (danger styling) to modal standard
- Document slug/display split finding in product backlog
- Update §5 changelog with Session Notes/PII fixes

Audit log records staff display names + Slack IDs for governance actions (e.g., "Stakeholder assigned: Jane Doe (U0123ABC)"); participant identity never appears in this log.

**IMPORTANT:** Stakeholder changes prior to this commit are NOT in the audit log. This is an unrecoverable gap affecting test data only — no production stakeholder assignments existed before this fix.

## Verification
Tested on dev: both clear and assign operations logged correctly to `disposition_audit_log` table with proper display name + Slack ID format.

🤖 Generated with [Claude Code](https://claude.ai/code)