### PR TITLE
style(modals): apply R14/R15 modal design standard

### DIFF
--- a/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
+++ b/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
@@ -835,13 +835,11 @@ export async function handleDeleteStudySelect({
           },
           { type: 'divider' },
           {
-            type: 'context',
-            elements: [
-              {
-                type: 'mrkdwn',
-                text: ':warning: *This action cannot be undone.*',
-              },
-            ],
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: ':warning: *This action cannot be undone.*',
+            },
           },
           {
             type: 'input',

--- a/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
+++ b/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
@@ -835,6 +835,15 @@ export async function handleDeleteStudySelect({
           },
           { type: 'divider' },
           {
+            type: 'context',
+            elements: [
+              {
+                type: 'mrkdwn',
+                text: ':warning: *This action cannot be undone.*',
+              },
+            ],
+          },
+          {
             type: 'input',
             block_id: 'confirm_block',
             label: { type: 'plain_text', text: 'Confirmation' },

--- a/backend/src/helpers/slack/ui/adminCenterModal.ts
+++ b/backend/src/helpers/slack/ui/adminCenterModal.ts
@@ -101,7 +101,6 @@ export function buildAdminCenterModal(project: Project, stakeholder: Stakeholder
           type: 'button',
           text: { type: 'plain_text', text: 'Open' },
           action_id: 'admin-dsar-open',
-          style: 'primary',
         },
       },
       {
@@ -126,7 +125,7 @@ export function buildAdminCenterModal(project: Project, stakeholder: Stakeholder
         elements: [
           {
             type: 'mrkdwn',
-            text: ':warning: *Actions here cannot be undone.* All actions are logged for compliance.',
+            text: 'All actions are logged for compliance.',
           },
         ],
       },

--- a/backend/src/helpers/slack/ui/discoverHubModal.ts
+++ b/backend/src/helpers/slack/ui/discoverHubModal.ts
@@ -44,7 +44,7 @@ export const discoverHubModal = {
         type: "button",
         text: {
           type: "plain_text",
-          text: "Start",
+          text: "Open",
         },
         action_id: "discover_desk_research",
         value: "desk_research",
@@ -60,7 +60,7 @@ export const discoverHubModal = {
         type: "button",
         text: {
           type: "plain_text",
-          text: "Start",
+          text: "Open",
         },
         action_id: "discover_stakeholder_synthesis",
         value: "stakeholder_synthesis",
@@ -76,7 +76,7 @@ export const discoverHubModal = {
         type: "button",
         text: {
           type: "plain_text",
-          text: "Start",
+          text: "Open",
         },
         action_id: "discover_survey_synthesis",
         value: "survey_synthesis",


### PR DESCRIPTION
## Summary

- Admin Center footer: keep only audit log message, remove "cannot be undone" warning
- Delete Study confirmation: add warning context block with "cannot be undone" at full strength
- Participant Data button: remove `style: 'primary'` (R15: danger styling exclusive to destructive actions)
- Discovery hub launchers: change "Start" → "Open" (R14: hub launcher verb)

## Test plan

- [ ] Open `/qori-admin` — footer shows only "All actions are logged for compliance"
- [ ] Participant Data "Open" button is outlined (default), not filled
- [ ] Delete Study "Open" button remains danger-red
- [ ] Click Delete Study → confirmation modal shows `:warning: *This action cannot be undone.*`
- [ ] Open `/qori-discover` — all three launcher buttons say "Open", not "Start"

🤖 Generated with [Claude Code](https://claude.com/claude-code)