### PR TITLE
fix: configurable Socket Mode log level for prod diagnosis

### DIFF
--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -123,8 +123,8 @@ const slackApp = new App({
   appToken: process.env.SLACK_APP_TOKEN,
   socketMode: true,
   extendedErrorHandler: true,
-  // Enable INFO logging in production to see Socket Mode connection status
-  logLevel: LogLevel.INFO,
+  // SLACK_LOG_LEVEL=DEBUG to see every Socket Mode envelope
+  logLevel: (process.env.SLACK_LOG_LEVEL === 'DEBUG' ? LogLevel.DEBUG : LogLevel.INFO),
 });
 
 // ── Alerts channel configuration ─────────────────────────────────


### PR DESCRIPTION
## Summary

Promotes #231 from dev to main to deploy debug logging for prod command dispatch investigation.

- Makes Bolt's `logLevel` configurable via `SLACK_LOG_LEVEL` env var
- Set `SLACK_LOG_LEVEL=DEBUG` in Railway to see every Socket Mode envelope
- Defaults to `INFO` — zero behavior change unless explicitly set

## Context

Mid-incident: all prod slash commands return "app did not respond" despite clean boot and one active Socket Mode connection. Need DEBUG logs to determine if envelopes reach the handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)