### PR TITLE
fix: make SLACK_LOG_LEVEL comparison case-insensitive

### DIFF
--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -124,7 +124,7 @@ const slackApp = new App({
   socketMode: true,
   extendedErrorHandler: true,
   // SLACK_LOG_LEVEL=DEBUG to see every Socket Mode envelope
-  logLevel: (process.env.SLACK_LOG_LEVEL === 'DEBUG' ? LogLevel.DEBUG : LogLevel.INFO),
+  logLevel: (process.env.SLACK_LOG_LEVEL?.toUpperCase() === 'DEBUG' ? LogLevel.DEBUG : LogLevel.INFO),
 });
 
 // ── Alerts channel configuration ─────────────────────────────────


### PR DESCRIPTION
## Summary
- During the 2026-07-28 prod incident, lowercase `debug` silently fell through to INFO because the check was `=== 'DEBUG'`. Cost three boot attempts.
- Now uses `.toUpperCase()` so it accepts `debug`, `DEBUG`, `Debug`, etc.

## Test plan
- [ ] Set `SLACK_LOG_LEVEL=debug` (lowercase) and verify DEBUG-level Socket Mode logs appear
- [ ] Set `SLACK_LOG_LEVEL=DEBUG` (uppercase) and verify same behavior
- [ ] Unset `SLACK_LOG_LEVEL` and verify default INFO level

🤖 Generated with [Claude Code](https://claude.com/claude-code)