### PR TITLE
fix: graceful Socket Mode shutdown on SIGTERM

### DIFF
--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -13,7 +13,7 @@
  */
 
 import express from 'express';
-import { App, LogLevel } from '@slack/bolt';
+import { App, LogLevel, SocketModeReceiver } from '@slack/bolt';
 import * as Sentry from '@sentry/node';
 import { scrubPII } from '../../config/sentry';
 import type { View } from '@slack/types';
@@ -126,6 +126,32 @@ const slackApp = new App({
   // SLACK_LOG_LEVEL=DEBUG to see every Socket Mode envelope
   logLevel: (process.env.SLACK_LOG_LEVEL === 'DEBUG' ? LogLevel.DEBUG : LogLevel.INFO),
 });
+
+// ── Graceful shutdown (incident 2026-07-28) ────────────────────
+// Explicitly disconnect Socket Mode on SIGTERM/SIGINT so the websocket
+// closes cleanly and Slack removes this connection immediately, instead
+// of leaving a zombie that steals command envelopes via round-robin.
+function gracefulShutdown(signal: string): void {
+  console.log(`Received ${signal} — disconnecting Socket Mode...`);
+  // receiver is private on App — cast through unknown to access it
+  const receiver = (slackApp as unknown as { receiver: SocketModeReceiver }).receiver;
+  // SocketModeClient.disconnect() sends a close frame and resolves
+  receiver.client.disconnect().then(() => {
+    console.log('Socket Mode disconnected cleanly.');
+    process.exit(0);
+  }).catch((err: Error) => {
+    console.error('Socket Mode disconnect error:', err.message);
+    process.exit(1);
+  });
+  // Force exit after 5s if disconnect hangs
+  setTimeout(() => {
+    console.error('Graceful shutdown timed out after 5s, forcing exit.');
+    process.exit(1);
+  }, 5000).unref();
+}
+
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 
 // ── Alerts channel configuration ─────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Add SIGTERM/SIGINT signal handlers to explicitly disconnect Socket Mode before the process exits
- Prevents zombie websocket connections that steal command envelopes from the new deployment via Slack's round-robin routing
- Includes a 5-second timeout safety net in case `disconnect()` hangs

## Context

When Railway deploys a new version, SIGTERM is sent to the old container. Without an explicit `SocketModeClient.disconnect()` call, the websocket lingers on Slack's side as a zombie until Slack's own timeout kills it (which can take hours). During that window, Slack round-robins command envelopes to both the live and dead connections — commands routed to the dead connection produce "app did not respond" errors for users.

This contributed to the 3-day production outage starting 2026-07-28.

## Test plan

- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Unit tests pass (`npm test`)
- [ ] Deploy to dev, verify Socket Mode connects normally
- [ ] Redeploy dev and confirm no "app did not respond" errors during the transition
- [ ] Check Railway logs for "Socket Mode disconnected cleanly." on the old container

🤖 Generated with [Claude Code](https://claude.com/claude-code)