### PR TITLE
docs: token isolation rule from 2026-07-28 incident

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ docker-compose up    # Starts app (3000), postgres (5432), redis (6379)
 
 **Sam agent** — `sam/requirements.txt` was generated from imports (versions unpinned, need verification). Run directly: `python sam/sam-agent.py`
 
-**Environment:** Copy `backend/.env.example` to `backend/.env`. Required variables: Slack tokens (`SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN`), `GITHUB_TOKEN`/`GITHUB_OWNER`/`GITHUB_REPO`, `ANTHROPIC_API_KEY`, database credentials. See `.env.example` for the full list with descriptions. **Critical:** `SLACK_APP_TOKEN` must be the **dev app's** token for local development — never the prod app token. See Railway Deployment section for the token isolation rule.
+**Environment:** Copy `backend/.env.example` to `backend/.env`. Required variables: Slack tokens (`SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN`), `GITHUB_TOKEN`/`GITHUB_OWNER`/`GITHUB_REPO`, `ANTHROPIC_API_KEY`, database credentials. See `.env.example` for the full list with descriptions. **Critical:** All Slack credentials (`SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `QORI_ALERTS_CHANNEL_ID`) must be from the **dev app and dev workspace** for local development — never prod values. See Railway Deployment section for the token isolation rule.
 
 ## Railway Deployment
 
@@ -81,7 +81,9 @@ docker-compose up    # Starts app (3000), postgres (5432), redis (6379)
 | Production | `main` | `Qori` | `A08U0FLM4AG` | Research team workspace |
 | Development | `dev` | `Qori Dev` | *(see dev app page)* | Dev/test workspace |
 
-**Token isolation rule (incident 2026-07-28):** Each environment's `SLACK_APP_TOKEN` must belong to **that environment's Slack app only**. The prod app token (`A08U0FLM4AG`) lives in exactly one place: Railway prod variables. Cross-environment token sharing causes Socket Mode to open multiple websocket connections to the same app; Slack round-robins commands across all connections, and connections without running handlers never ack — producing total, persistent "app did not respond" failure. This caused a 3-day outage. Local `.env` and Railway dev must use the Qori-dev app's own app-level token.
+**Token isolation rule (incident 2026-07-28):** **All Slack credentials are workspace-scoped and must match the environment's own Slack app.** This covers `SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `QORI_ALERTS_CHANNEL_ID`, and any future workspace-scoped ID. Prod credentials live in exactly one place: Railway prod variables. Local `.env` and Railway dev use the Qori-dev app's own credentials and dev-workspace channel IDs.
+
+Cross-environment credential sharing caused a 3-day outage: Railway dev held the prod app token, opening zombie Socket Mode connections; Slack round-robined commands across all connections, and connections without running handlers never acked — total, persistent "app did not respond." The same leak class applies to bot tokens (API calls target the wrong workspace), channel IDs (`channel_not_found`), and user IDs (`user_not_found` when DMing error reports).
 
 **Migrations run automatically on deploy.** The Dockerfile CMD is `scripts/start.sh`, which:
 1. Waits for database connection
@@ -106,7 +108,7 @@ This ensures code and schema always deploy together — the root cause of the Ju
 
 3. **Postgres public URL for manual migrations.** Use the public URL (`railway.app` hostname) from the Postgres Connect tab, not the internal URL (`postgres.railway.internal`).
 
-4. **`SLACK_APP_TOKEN` must match the environment's Slack app.** Never copy the prod token into dev or local `.env`. See "Token isolation rule" above.
+4. **All Slack credentials must match the environment's own app and workspace.** `SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `QORI_ALERTS_CHANNEL_ID` — never copy any of these from prod into dev or local `.env`. See "Token isolation rule" above.
 
 **Deploy flow:**
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,16 +70,18 @@ docker-compose up    # Starts app (3000), postgres (5432), redis (6379)
 
 **Sam agent** — `sam/requirements.txt` was generated from imports (versions unpinned, need verification). Run directly: `python sam/sam-agent.py`
 
-**Environment:** Copy `backend/.env.example` to `backend/.env`. Required variables: Slack tokens (`SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN`), `GITHUB_TOKEN`/`GITHUB_OWNER`/`GITHUB_REPO`, `ANTHROPIC_API_KEY`, database credentials. See `.env.example` for the full list with descriptions.
+**Environment:** Copy `backend/.env.example` to `backend/.env`. Required variables: Slack tokens (`SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN`), `GITHUB_TOKEN`/`GITHUB_OWNER`/`GITHUB_REPO`, `ANTHROPIC_API_KEY`, database credentials. See `.env.example` for the full list with descriptions. **Critical:** `SLACK_APP_TOKEN` must be the **dev app's** token for local development — never the prod app token. See Railway Deployment section for the token isolation rule.
 
 ## Railway Deployment
 
-**Two environments:** Production (`main` branch) and Development (`dev` branch). Each has its own Postgres, Redis, and Slack app.
+**Two environments:** Production (`main` branch) and Development (`dev` branch). Each has its own Postgres, Redis, **and its own Slack app with separate app-level tokens**.
 
-| Environment | Branch | Slack App | Workspace |
-|-------------|--------|-----------|-----------|
-| Production | `main` | `Qori` | Research team workspace |
-| Development | `dev` | `Qori Dev` | Dev/test workspace |
+| Environment | Branch | Slack App | App ID | Workspace |
+|-------------|--------|-----------|--------|-----------|
+| Production | `main` | `Qori` | `A08U0FLM4AG` | Research team workspace |
+| Development | `dev` | `Qori Dev` | *(see dev app page)* | Dev/test workspace |
+
+**Token isolation rule (incident 2026-07-28):** Each environment's `SLACK_APP_TOKEN` must belong to **that environment's Slack app only**. The prod app token (`A08U0FLM4AG`) lives in exactly one place: Railway prod variables. Cross-environment token sharing causes Socket Mode to open multiple websocket connections to the same app; Slack round-robins commands across all connections, and connections without running handlers never ack — producing total, persistent "app did not respond" failure. This caused a 3-day outage. Local `.env` and Railway dev must use the Qori-dev app's own app-level token.
 
 **Migrations run automatically on deploy.** The Dockerfile CMD is `scripts/start.sh`, which:
 1. Waits for database connection
@@ -103,6 +105,8 @@ This ensures code and schema always deploy together — the root cause of the Ju
 2. **Token values can get truncated/malformed on paste.** Verify character count matches source.
 
 3. **Postgres public URL for manual migrations.** Use the public URL (`railway.app` hostname) from the Postgres Connect tab, not the internal URL (`postgres.railway.internal`).
+
+4. **`SLACK_APP_TOKEN` must match the environment's Slack app.** Never copy the prod token into dev or local `.env`. See "Token isolation rule" above.
 
 **Deploy flow:**
 ```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,17 +10,21 @@
 # Before running, verify you're using the correct environment:
 #
 # PRODUCTION indicators (STOP if you see these in local dev):
-#   - SLACK_APP_TOKEN starts with: xapp-1-A0... (prod app ID)
+#   - SLACK_APP_TOKEN contains A08U0FLM4AG (the PROD app ID)
 #   - DB_HOST contains: railway.app or .railway.internal
 #   - NODE_ENV=production
 #
 # DEVELOPMENT indicators (correct for local/dev work):
-#   - SLACK_APP_TOKEN starts with: xapp-1-A0... (different app ID than prod)
+#   - SLACK_APP_TOKEN contains the DEV app ID (NOT A08U0FLM4AG)
 #   - DB_HOST: localhost OR dev.railway.app
 #   - NODE_ENV=development
 #
 # If you're doing local development and see prod indicators, STOP.
 # You're about to run against production. Check your .env file.
+#
+# INCIDENT 2026-07-28: Cross-environment token sharing caused a 3-day
+# prod outage. The prod app-level token must ONLY exist in Railway prod.
+# Local dev and Railway dev use the Qori-dev app's own token.
 
 # ============================================
 # Application Configuration


### PR DESCRIPTION
## Summary
- CLAUDE.md: token isolation rule, prod app ID in env table, gotcha #4
- .env.example: name prod app ID in safety guard, incident note

Documentation only — no runtime changes. Part of the 11:00 CST merge window with #233, #234, #235.

## Context
Cross-environment `SLACK_APP_TOKEN` sharing caused a 3-day prod outage. Railway dev and local `.env` held the prod app token, opening zombie Socket Mode connections that stole commands via round-robin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)