### PR TITLE
fix: Socket Mode incident remediation (token isolation + observability)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ docker-compose up    # Starts app (3000), postgres (5432), redis (6379)
 
 **Sam agent** — `sam/requirements.txt` was generated from imports (versions unpinned, need verification). Run directly: `python sam/sam-agent.py`
 
-**Environment:** Copy `backend/.env.example` to `backend/.env`. Required variables: Slack tokens (`SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN`), `GITHUB_TOKEN`/`GITHUB_OWNER`/`GITHUB_REPO`, `ANTHROPIC_API_KEY`, database credentials. See `.env.example` for the full list with descriptions. **Critical:** `SLACK_APP_TOKEN` must be the **dev app's** token for local development — never the prod app token. See Railway Deployment section for the token isolation rule.
+**Environment:** Copy `backend/.env.example` to `backend/.env`. Required variables: Slack tokens (`SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN`), `GITHUB_TOKEN`/`GITHUB_OWNER`/`GITHUB_REPO`, `ANTHROPIC_API_KEY`, database credentials. See `.env.example` for the full list with descriptions. **Critical:** All Slack credentials (`SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `QORI_ALERTS_CHANNEL_ID`) must be from the **dev app and dev workspace** for local development — never prod values. See Railway Deployment section for the token isolation rule.
 
 ## Railway Deployment
 
@@ -81,7 +81,9 @@ docker-compose up    # Starts app (3000), postgres (5432), redis (6379)
 | Production | `main` | `Qori` | `A08U0FLM4AG` | Research team workspace |
 | Development | `dev` | `Qori Dev` | *(see dev app page)* | Dev/test workspace |
 
-**Token isolation rule (incident 2026-07-28):** Each environment's `SLACK_APP_TOKEN` must belong to **that environment's Slack app only**. The prod app token (`A08U0FLM4AG`) lives in exactly one place: Railway prod variables. Cross-environment token sharing causes Socket Mode to open multiple websocket connections to the same app; Slack round-robins commands across all connections, and connections without running handlers never ack — producing total, persistent "app did not respond" failure. This caused a 3-day outage. Local `.env` and Railway dev must use the Qori-dev app's own app-level token.
+**Token isolation rule (incident 2026-07-28):** **All Slack credentials are workspace-scoped and must match the environment's own Slack app.** This covers `SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `QORI_ALERTS_CHANNEL_ID`, and any future workspace-scoped ID. Prod credentials live in exactly one place: Railway prod variables. Local `.env` and Railway dev use the Qori-dev app's own credentials and dev-workspace channel IDs.
+
+Cross-environment credential sharing caused a 3-day outage: Railway dev held the prod app token, opening zombie Socket Mode connections; Slack round-robined commands across all connections, and connections without running handlers never acked — total, persistent "app did not respond." The same leak class applies to bot tokens (API calls target the wrong workspace), channel IDs (`channel_not_found`), and user IDs (`user_not_found` when DMing error reports).
 
 **Migrations run automatically on deploy.** The Dockerfile CMD is `scripts/start.sh`, which:
 1. Waits for database connection
@@ -106,7 +108,7 @@ This ensures code and schema always deploy together — the root cause of the Ju
 
 3. **Postgres public URL for manual migrations.** Use the public URL (`railway.app` hostname) from the Postgres Connect tab, not the internal URL (`postgres.railway.internal`).
 
-4. **`SLACK_APP_TOKEN` must match the environment's Slack app.** Never copy the prod token into dev or local `.env`. See "Token isolation rule" above.
+4. **All Slack credentials must match the environment's own app and workspace.** `SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `QORI_ALERTS_CHANNEL_ID` — never copy any of these from prod into dev or local `.env`. See "Token isolation rule" above.
 
 **Deploy flow:**
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,16 +70,18 @@ docker-compose up    # Starts app (3000), postgres (5432), redis (6379)
 
 **Sam agent** — `sam/requirements.txt` was generated from imports (versions unpinned, need verification). Run directly: `python sam/sam-agent.py`
 
-**Environment:** Copy `backend/.env.example` to `backend/.env`. Required variables: Slack tokens (`SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN`), `GITHUB_TOKEN`/`GITHUB_OWNER`/`GITHUB_REPO`, `ANTHROPIC_API_KEY`, database credentials. See `.env.example` for the full list with descriptions.
+**Environment:** Copy `backend/.env.example` to `backend/.env`. Required variables: Slack tokens (`SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN`), `GITHUB_TOKEN`/`GITHUB_OWNER`/`GITHUB_REPO`, `ANTHROPIC_API_KEY`, database credentials. See `.env.example` for the full list with descriptions. **Critical:** `SLACK_APP_TOKEN` must be the **dev app's** token for local development — never the prod app token. See Railway Deployment section for the token isolation rule.
 
 ## Railway Deployment
 
-**Two environments:** Production (`main` branch) and Development (`dev` branch). Each has its own Postgres, Redis, and Slack app.
+**Two environments:** Production (`main` branch) and Development (`dev` branch). Each has its own Postgres, Redis, **and its own Slack app with separate app-level tokens**.
 
-| Environment | Branch | Slack App | Workspace |
-|-------------|--------|-----------|-----------|
-| Production | `main` | `Qori` | Research team workspace |
-| Development | `dev` | `Qori Dev` | Dev/test workspace |
+| Environment | Branch | Slack App | App ID | Workspace |
+|-------------|--------|-----------|--------|-----------|
+| Production | `main` | `Qori` | `A08U0FLM4AG` | Research team workspace |
+| Development | `dev` | `Qori Dev` | *(see dev app page)* | Dev/test workspace |
+
+**Token isolation rule (incident 2026-07-28):** Each environment's `SLACK_APP_TOKEN` must belong to **that environment's Slack app only**. The prod app token (`A08U0FLM4AG`) lives in exactly one place: Railway prod variables. Cross-environment token sharing causes Socket Mode to open multiple websocket connections to the same app; Slack round-robins commands across all connections, and connections without running handlers never ack — producing total, persistent "app did not respond" failure. This caused a 3-day outage. Local `.env` and Railway dev must use the Qori-dev app's own app-level token.
 
 **Migrations run automatically on deploy.** The Dockerfile CMD is `scripts/start.sh`, which:
 1. Waits for database connection
@@ -103,6 +105,8 @@ This ensures code and schema always deploy together — the root cause of the Ju
 2. **Token values can get truncated/malformed on paste.** Verify character count matches source.
 
 3. **Postgres public URL for manual migrations.** Use the public URL (`railway.app` hostname) from the Postgres Connect tab, not the internal URL (`postgres.railway.internal`).
+
+4. **`SLACK_APP_TOKEN` must match the environment's Slack app.** Never copy the prod token into dev or local `.env`. See "Token isolation rule" above.
 
 **Deploy flow:**
 ```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,17 +10,21 @@
 # Before running, verify you're using the correct environment:
 #
 # PRODUCTION indicators (STOP if you see these in local dev):
-#   - SLACK_APP_TOKEN starts with: xapp-1-A0... (prod app ID)
+#   - SLACK_APP_TOKEN contains A08U0FLM4AG (the PROD app ID)
 #   - DB_HOST contains: railway.app or .railway.internal
 #   - NODE_ENV=production
 #
 # DEVELOPMENT indicators (correct for local/dev work):
-#   - SLACK_APP_TOKEN starts with: xapp-1-A0... (different app ID than prod)
+#   - SLACK_APP_TOKEN contains the DEV app ID (NOT A08U0FLM4AG)
 #   - DB_HOST: localhost OR dev.railway.app
 #   - NODE_ENV=development
 #
 # If you're doing local development and see prod indicators, STOP.
 # You're about to run against production. Check your .env file.
+#
+# INCIDENT 2026-07-28: Cross-environment token sharing caused a 3-day
+# prod outage. The prod app-level token must ONLY exist in Railway prod.
+# Local dev and Railway dev use the Qori-dev app's own token.
 
 # ============================================
 # Application Configuration

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -13,7 +13,7 @@
  */
 
 import express from 'express';
-import { App, LogLevel } from '@slack/bolt';
+import { App, LogLevel, SocketModeReceiver } from '@slack/bolt';
 import * as Sentry from '@sentry/node';
 import { scrubPII } from '../../config/sentry';
 import type { View } from '@slack/types';
@@ -130,6 +130,33 @@ const slackApp = new App({
 // ── Alerts channel configuration ─────────────────────────────────
 
 const ALERTS_CHANNEL_ID = process.env.QORI_ALERTS_CHANNEL_ID;
+
+// ── num_connections tripwire (incident 2026-07-28) ─────────────
+// Socket Mode hello frame reports how many active websocket connections
+// exist for this app token. If >1, another process shares the token and
+// Slack round-robins commands — most will never be acked.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- receiver is private in Bolt's types but accessible at runtime
+const socketModeReceiver = (slackApp as any).receiver as SocketModeReceiver;
+socketModeReceiver.client.on('hello', (event: { num_connections: number; debug_info?: { host?: string }; connection_info?: { app_id?: string } }) => {
+  if (event.num_connections > 1) {
+    console.warn(
+      `[CRITICAL] Socket Mode hello: num_connections=${event.num_connections} — ` +
+      `expected 1. Another process is sharing this app token. ` +
+      `Commands will be lost. (host=${event.debug_info?.host || 'unknown'}, app=${event.connection_info?.app_id || 'unknown'})`
+    );
+    // Also post to alerts channel if configured
+    if (ALERTS_CHANNEL_ID) {
+      slackApp.client.chat.postMessage({
+        channel: ALERTS_CHANNEL_ID,
+        text: `:rotating_light: *Socket Mode: ${event.num_connections} connections detected* — expected 1. Another process is sharing the prod app token. Commands will be round-robined and most will fail. Check Railway dev environment and local .env files for the prod app token (A08U0FLM4AG).`,
+      }).catch((err: Error) => {
+        console.error('Failed to post num_connections alert:', err.message);
+      });
+    }
+  } else {
+    console.log(`Socket Mode hello: num_connections=${event.num_connections} (healthy)`);
+  }
+});
 
 /**
  * Post an error alert to the #qori-alerts channel.

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -13,7 +13,7 @@
  */
 
 import express from 'express';
-import { App, LogLevel } from '@slack/bolt';
+import { App, LogLevel, SocketModeReceiver } from '@slack/bolt';
 import * as Sentry from '@sentry/node';
 import { scrubPII } from '../../config/sentry';
 import type { View } from '@slack/types';
@@ -126,6 +126,32 @@ const slackApp = new App({
   // SLACK_LOG_LEVEL=DEBUG to see every Socket Mode envelope
   logLevel: (process.env.SLACK_LOG_LEVEL === 'DEBUG' ? LogLevel.DEBUG : LogLevel.INFO),
 });
+
+// ── Graceful shutdown (incident 2026-07-28) ────────────────────
+// Explicitly disconnect Socket Mode on SIGTERM/SIGINT so the websocket
+// closes cleanly and Slack removes this connection immediately, instead
+// of leaving a zombie that steals command envelopes via round-robin.
+function gracefulShutdown(signal: string): void {
+  console.log(`Received ${signal} — disconnecting Socket Mode...`);
+  // receiver is private on App — cast through unknown to access it
+  const receiver = (slackApp as unknown as { receiver: SocketModeReceiver }).receiver;
+  // SocketModeClient.disconnect() sends a close frame and resolves
+  receiver.client.disconnect().then(() => {
+    console.log('Socket Mode disconnected cleanly.');
+    process.exit(0);
+  }).catch((err: Error) => {
+    console.error('Socket Mode disconnect error:', err.message);
+    process.exit(1);
+  });
+  // Force exit after 5s if disconnect hangs
+  setTimeout(() => {
+    console.error('Graceful shutdown timed out after 5s, forcing exit.');
+    process.exit(1);
+  }, 5000).unref();
+}
+
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 
 // ── Alerts channel configuration ─────────────────────────────────
 

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -124,7 +124,7 @@ const slackApp = new App({
   socketMode: true,
   extendedErrorHandler: true,
   // SLACK_LOG_LEVEL=DEBUG to see every Socket Mode envelope
-  logLevel: (process.env.SLACK_LOG_LEVEL === 'DEBUG' ? LogLevel.DEBUG : LogLevel.INFO),
+  logLevel: (process.env.SLACK_LOG_LEVEL?.toUpperCase() === 'DEBUG' ? LogLevel.DEBUG : LogLevel.INFO),
 });
 
 // ── Alerts channel configuration ─────────────────────────────────

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -161,8 +161,8 @@ const ALERTS_CHANNEL_ID = process.env.QORI_ALERTS_CHANNEL_ID;
 // Socket Mode hello frame reports how many active websocket connections
 // exist for this app token. If >1, another process shares the token and
 // Slack round-robins commands — most will never be acked.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- receiver is private in Bolt's types but accessible at runtime
-const socketModeReceiver = (slackApp as any).receiver as SocketModeReceiver;
+// receiver is private in Bolt's types but accessible at runtime — cast through unknown (not as-any)
+const socketModeReceiver = (slackApp as unknown as { receiver: SocketModeReceiver }).receiver;
 socketModeReceiver.client.on('hello', (event: { num_connections: number; debug_info?: { host?: string }; connection_info?: { app_id?: string } }) => {
   if (event.num_connections > 1) {
     console.warn(


### PR DESCRIPTION
## Summary
Remediation for the 2026-07-28 prod outage where all slash commands returned "app did not respond" for 3 days.

**Root cause:** Railway dev and local `.env` held the prod app token (`A08U0FLM4AG`). Multiple processes opened Socket Mode connections to the prod app; Slack round-robined commands across all connections, and connections without handlers never acked.

## Changes (4 PRs)
- **#233** — `SLACK_LOG_LEVEL` comparison case-insensitive (lowercase `debug` silently no-oped, cost 3 boot attempts)
- **#234** — `num_connections` tripwire: WARN log + `#qori-alerts` post when hello frame reports >1 connection (turns a 3-day hunt into one log line)
- **#235** — SIGTERM graceful shutdown: explicitly disconnect Socket Mode on SIGTERM so Railway deploy overlap doesn't create zombie connections
- **#236** — CLAUDE.md + `.env.example`: token isolation rule generalized to all Slack credentials (app token, bot token, signing secret, channel IDs)

## Test plan
- [ ] Prod hello frame shows `num_connections: 1` after deploy
- [ ] Invoke `/qori-plan`, `/qori-brief`, `/qori-admin` — all respond
- [ ] Kill the deploy (Railway redeploy) — verify clean `Socket Mode disconnected cleanly.` in logs
- [ ] Set `SLACK_LOG_LEVEL=debug` (lowercase) — verify DEBUG output appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)