### PR TITLE
fix(modals): 5f-plan audit — R1/R2/R9 violations

### DIFF
--- a/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
+++ b/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
@@ -228,7 +228,7 @@ async function openDiscussionGuideModal({ ack, body, client }: SlackActionMiddle
           elements: [
             {
               type: "mrkdwn",
-              text: `:speech_balloon: *${preselectStudyName}*`,
+              text: `*${preselectStudyName}*`,
             },
           ],
         },
@@ -260,7 +260,7 @@ async function openDiscussionGuideModal({ ack, body, client }: SlackActionMiddle
         elements: [
           {
             type: "mrkdwn",
-            text: `:speech_balloon: *${preselectStudyName}*\nBuilding a session guide from your approved brief.`,
+            text: `*${preselectStudyName}*\nBuilding a session guide from your approved brief.`,
           },
         ],
       };

--- a/backend/src/helpers/slack/commands/modal-openers/planModalOpener.ts
+++ b/backend/src/helpers/slack/commands/modal-openers/planModalOpener.ts
@@ -166,7 +166,7 @@ async function openResearchPlanModal({ ack, body, client }: SlackActionMiddlewar
           elements: [
             {
               type: "mrkdwn",
-              text: `:clipboard: *${preselectStudyName}*`,
+              text: `*${preselectStudyName}*`,
             },
           ],
         },
@@ -201,7 +201,7 @@ async function openResearchPlanModal({ ack, body, client }: SlackActionMiddlewar
         elements: [
           {
             type: "mrkdwn",
-            text: `:clipboard: *${preselectStudyName}*\nGenerating an execution plan from your approved brief.`,
+            text: `*${preselectStudyName}*\nGenerating an execution plan from your approved brief.`,
           },
         ],
       };

--- a/backend/src/helpers/slack/ui/discussionGuideModal.ts
+++ b/backend/src/helpers/slack/ui/discussionGuideModal.ts
@@ -75,7 +75,7 @@ const discussionGuideModal = {
       elements: [
         {
           type: "mrkdwn",
-          text: ":speech_balloon: *{{study_name}}*\nBuilding a session guide from your approved brief.",
+          text: "*{{study_name}}*\nBuilding a session guide from your approved brief.",
         },
       ],
     },

--- a/backend/src/helpers/slack/ui/researchPlanGeneratorModal.ts
+++ b/backend/src/helpers/slack/ui/researchPlanGeneratorModal.ts
@@ -43,7 +43,7 @@ export const researchPlanGeneratorModal = {
       elements: [
         {
           type: "mrkdwn",
-          text: ":clipboard: *{{study_name}}*\nGenerating an execution plan from your approved brief.",
+          text: "*{{study_name}}*\nGenerating an execution plan from your approved brief.",
         },
       ],
     },

--- a/backend/src/helpers/slack/ui/studySetupModal.ts
+++ b/backend/src/helpers/slack/ui/studySetupModal.ts
@@ -45,13 +45,9 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
       type: "plain_text",
       text: "Plan your study",
     },
-    submit: {
-      type: "plain_text",
-      text: "Done",
-    },
     close: {
       type: "plain_text",
-      text: "Close",
+      text: "Cancel",
     },
     blocks: [
       {
@@ -90,7 +86,7 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
         type: "section",
         text: {
           type: "mrkdwn",
-          text: ":clipboard: *Research plan*\nTurns your brief into a stakeholder-ready plan",
+          text: "*Research plan*\nTurns your brief into a stakeholder-ready plan",
         },
         accessory: {
           type: "button",
@@ -106,7 +102,7 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
         type: "section",
         text: {
           type: "mrkdwn",
-          text: ":speech_balloon: *Discussion guide*\nSession script grounded in your objectives",
+          text: "*Discussion guide*\nSession script grounded in your objectives",
         },
         accessory: {
           type: "button",


### PR DESCRIPTION
## Summary

Fixes three modal design standard violations found in the 5f-plan modal audit:

- **R1 — No emoji in text blocks:** Removed `:clipboard:` from research plan context blocks (modal, opener warning, opener normal) and `:speech_balloon:` from discussion guide context blocks (modal, opener warning, opener normal)
- **R2 — No vestigial submit on launcher modals:** Removed the `submit: { text: "Done" }` block from `studySetupModal` — it is a pure launcher whose submit handler (`handlePlanStudyNoop`) is a no-op. Handler registration kept as safety net.
- **R9 — Close → Cancel on launcher modals:** Changed close button text from "Close" to "Cancel" on `studySetupModal`

**Files changed (5):**
1. `backend/src/helpers/slack/ui/studySetupModal.ts` — R1, R2, R9
2. `backend/src/helpers/slack/ui/researchPlanGeneratorModal.ts` — R1
3. `backend/src/helpers/slack/commands/modal-openers/planModalOpener.ts` — R1
4. `backend/src/helpers/slack/ui/discussionGuideModal.ts` — R1
5. `backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts` — R1

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (141 tests)
- [ ] Verify `/qori-plan` opens the launcher modal without a submit button and with "Cancel" as the close text
- [ ] Verify "Create" → research plan modal shows study name without clipboard emoji
- [ ] Verify "Create" → discussion guide modal shows study name without speech balloon emoji
- [ ] Verify cascade-gated warning views show study name without emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)