### PR TITLE
fix(handlers): R1 emoji sweep — decorative emoji removal from handlers/DMs

### DIFF
--- a/backend/docs/qori-modal-design-standard.md
+++ b/backend/docs/qori-modal-design-standard.md
@@ -727,9 +727,9 @@ Track specific violations found during audit, with fix status.
 | Participant Outreach | R7 | Trailing asterisk | Pending |
 | Discovery Launcher | R1 | Emoji in option rows | Pending |
 | Discovery Launcher | R8 | Italics in help text | Pending |
-| PII Review (transcript) | R1 | Emoji in header (🔍), stats (✅⚠️), button (📄), footer (✅❌) | Pending |
-| PII Review (manual notes) | R1 | Emoji in DM message (🔍✅⚠️) | Pending |
-| Join Observer | R1 | Emoji in role options (📝👁️📊🏛️) | Pending |
+| PII Review (transcript) | R1 | Decorative 🔍 removed from header; ✅⚠️📄❌ kept (functional) | Partial fix (emoji-sweep-handlers) |
+| PII Review (manual notes) | R1 | Decorative 🔍 removed; ✅⚠️ kept (functional) | Fixed (emoji-sweep-handlers) |
+| Join Observer | R1 | Emoji in role options (📝👁️📊🏛️) | Fixed (emoji-sweep-handlers) |
 | Admin Center Hub | R2 | "Open" button label (lines 102, 115) not action-oriented | Pending |
 | Admin — Delete Study | R2 | "Open" button label not action-oriented | Pending |
 

--- a/backend/src/helpers/slack/commands/addObserverHandler.ts
+++ b/backend/src/helpers/slack/commands/addObserverHandler.ts
@@ -20,10 +20,10 @@ import { getConfigRepo, YAML_TEMPLATE_PATH, fetchFileFromRepo } from '../../gith
 // ── Helpers ────────────────────────────────────────────────
 
 const ROLE_DISPLAY: Record<string, string> = {
-  note_taker: '📝 Note-taker',
-  silent_observer: '👁️ Silent Observer',
-  pm_observer: '📊 PM Observer',
-  stakeholder: '🏛️ Stakeholder',
+  note_taker: 'Note-taker',
+  silent_observer: 'Silent Observer',
+  pm_observer: 'PM Observer',
+  stakeholder: 'Stakeholder',
 };
 
 /**

--- a/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
+++ b/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
@@ -1345,7 +1345,7 @@ export async function handleStakeholderSubmit({
       try {
         await client.chat.postMessage({
           channel: stakeholderInfo.userId,
-          text: `:clipboard: *${assignerName}* assigned you as stakeholder for *${metadata.projectName}*. You'll receive brief approval requests for studies in this project.`,
+          text: `*${assignerName}* assigned you as stakeholder for *${metadata.projectName}*. You'll receive brief approval requests for studies in this project.`,
         });
       } catch {
         // DM to stakeholder failed, not critical

--- a/backend/src/helpers/slack/commands/analyzeNotesHandler.ts
+++ b/backend/src/helpers/slack/commands/analyzeNotesHandler.ts
@@ -262,7 +262,7 @@ const handleAnalyzeNotesSubmission = async ({ ack, body, view, client }: SlackVi
     await client.chat.postEphemeral({
       channel: body.user.id,
       user: body.user.id,
-      text: '🔄 *Analyzing session* — this takes a minute or two. You\'ll see a confirmation when it\'s done.',
+      text: '*Analyzing session* — this takes a minute or two. You\'ll see a confirmation when it\'s done.',
     });
 
     if (!studyId || studyId === "no_studies") {

--- a/backend/src/helpers/slack/commands/briefHandler.ts
+++ b/backend/src/helpers/slack/commands/briefHandler.ts
@@ -242,7 +242,7 @@ async function handleBriefSubmission({ ack, body, view, client }: SlackViewMiddl
   try {
     await client.chat.postMessage({
       channel: body.user.id,
-      text: `:hourglass_flowing_sand: Creating research brief for *${studyName}*... This may take a moment.`,
+      text: `Creating research brief for *${studyName}*... This may take a moment.`,
     });
   } catch (err) {
     const progressErr = err instanceof Error ? err.message : String(err);

--- a/backend/src/helpers/slack/commands/discoverHandler.ts
+++ b/backend/src/helpers/slack/commands/discoverHandler.ts
@@ -418,7 +418,7 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
 
   await client.chat.postMessage({
     channel: userId,
-    text: `🔍 Running ${typeConfig.label} for "${topic}"... This may take a minute.`,
+    text: `Running ${typeConfig.label} for "${topic}"... This may take a minute.`,
   });
 
   try {

--- a/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
+++ b/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
@@ -228,7 +228,7 @@ async function openDiscussionGuideModal({ ack, body, client }: SlackActionMiddle
           elements: [
             {
               type: "mrkdwn",
-              text: `:speech_balloon: *${preselectStudyName}*`,
+              text: `*${preselectStudyName}*`,
             },
           ],
         },
@@ -260,7 +260,7 @@ async function openDiscussionGuideModal({ ack, body, client }: SlackActionMiddle
         elements: [
           {
             type: "mrkdwn",
-            text: `:speech_balloon: *${preselectStudyName}*\nBuilding a session guide from your approved brief.`,
+            text: `*${preselectStudyName}*\nBuilding a session guide from your approved brief.`,
           },
         ],
       };
@@ -419,7 +419,7 @@ async function handleDiscussionGuideSubmission({ ack, body, view, client }: Slac
   try {
     await client.chat.postMessage({
       channel: body.user.id,
-      text: `:hourglass_flowing_sand: Generating discussion guide for *${studyName}*... This may take a moment.`,
+      text: `Generating discussion guide for *${studyName}*... This may take a moment.`,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/backend/src/helpers/slack/commands/fieldworkHandler.ts
+++ b/backend/src/helpers/slack/commands/fieldworkHandler.ts
@@ -231,7 +231,7 @@ async function handleFieldworkAddParticipant({ ack, body, client }: SlackActionM
         block_id: "code_preview_block",
         elements: [{
           type: "mrkdwn",
-          text: `✨ Will be assigned: *${nextCode}*`
+          text: `Will be assigned: *${nextCode}*`
         }]
       };
     }

--- a/backend/src/helpers/slack/commands/modal-openers/briefToStudyHandler.ts
+++ b/backend/src/helpers/slack/commands/modal-openers/briefToStudyHandler.ts
@@ -108,7 +108,7 @@ async function openPlanFromBrief({ ack, body, client }: SlackActionMiddlewareArg
         elements: [
           {
             type: "mrkdwn",
-            text: `:clipboard: *${studyName}*\nGenerating an execution plan from your approved brief.`,
+            text: `*${studyName}*\nGenerating an execution plan from your approved brief.`,
           },
         ],
       };
@@ -163,7 +163,7 @@ async function openPlanFromBrief({ ack, body, client }: SlackActionMiddlewareArg
           elements: [
             {
               type: "mrkdwn",
-              text: `:clipboard: *${studyName}*`,
+              text: `*${studyName}*`,
             },
           ],
         },

--- a/backend/src/helpers/slack/commands/modal-openers/planModalOpener.ts
+++ b/backend/src/helpers/slack/commands/modal-openers/planModalOpener.ts
@@ -166,7 +166,7 @@ async function openResearchPlanModal({ ack, body, client }: SlackActionMiddlewar
           elements: [
             {
               type: "mrkdwn",
-              text: `:clipboard: *${preselectStudyName}*`,
+              text: `*${preselectStudyName}*`,
             },
           ],
         },
@@ -201,7 +201,7 @@ async function openResearchPlanModal({ ack, body, client }: SlackActionMiddlewar
         elements: [
           {
             type: "mrkdwn",
-            text: `:clipboard: *${preselectStudyName}*\nGenerating an execution plan from your approved brief.`,
+            text: `*${preselectStudyName}*\nGenerating an execution plan from your approved brief.`,
           },
         ],
       };

--- a/backend/src/helpers/slack/commands/participantHandler.ts
+++ b/backend/src/helpers/slack/commands/participantHandler.ts
@@ -63,7 +63,7 @@ async function participantHandler({ ack, body, client, command }: SlackCommandMi
           elements: [
             {
               type: "mrkdwn",
-              text: `🏷️ *Will be assigned:* \`${nextCode}\``
+              text: `*Will be assigned:* \`${nextCode}\``
             }
           ]
         };
@@ -441,7 +441,7 @@ async function handleAddParticipantStudySelect({ ack, body, client }: SlackActio
         elements: [
           {
             type: "mrkdwn",
-            text: `🏷️ *Will be assigned:* \`${nextCode}\``
+            text: `*Will be assigned:* \`${nextCode}\``
           }
         ]
       };

--- a/backend/src/helpers/slack/commands/participantOutreachHandler.ts
+++ b/backend/src/helpers/slack/commands/participantOutreachHandler.ts
@@ -1060,13 +1060,13 @@ async function handleAddParticipantSubmit({ ack, body, view, client }: SlackView
     if (milestoneCheck.hasReachedMilestone) {
       // Generate a milestone message for the channel
       const milestoneMessage = {
-        text: `:tada: *Milestone reached!* The study *${milestoneCheck.studyName}* now has ${milestoneCheck.currentCount} participants.`,
+        text: `*Milestone reached!* The study *${milestoneCheck.studyName}* now has ${milestoneCheck.currentCount} participants.`,
         blocks: [
           {
             type: "section",
             text: {
               type: "mrkdwn",
-              text: `:tada: *Milestone reached!*\n\nThe study *${milestoneCheck.studyName}* now has *${milestoneCheck.currentCount}* participants.`
+              text: `*Milestone reached!*\n\nThe study *${milestoneCheck.studyName}* now has *${milestoneCheck.currentCount}* participants.`
             }
           },
           {
@@ -1109,13 +1109,13 @@ async function handleAddParticipantSubmit({ ack, body, view, client }: SlackView
     const assignedCode = savedParticipant.participant_code;
     await client.chat.postMessage({
       channel: userId, // Use original Slack user ID for DM channel
-      text: `:busts_in_silhouette: *New Participant Added*\n\n*Code:* ${assignedCode}\n*Name:* ${participant_name}\n*Study:* ${study_name}\n*Status:* ${status_select}`,
+      text: `*New Participant Added*\n\n*Code:* ${assignedCode}\n*Name:* ${participant_name}\n*Study:* ${study_name}\n*Status:* ${status_select}`,
       blocks: [
         {
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `:busts_in_silhouette: *New Participant Added*\n\n*Code:* \`${assignedCode}\`\n*Name:* ${participant_name}\n*Study:* ${study_name}\n*Status:* ${status_select}\n*Recruitment Source:* ${recruitment_source}`
+            text: `*New Participant Added*\n\n*Code:* \`${assignedCode}\`\n*Name:* ${participant_name}\n*Study:* ${study_name}\n*Status:* ${status_select}\n*Recruitment Source:* ${recruitment_source}`
           }
         },
         {

--- a/backend/src/helpers/slack/commands/planHandler.ts
+++ b/backend/src/helpers/slack/commands/planHandler.ts
@@ -87,7 +87,7 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
   try {
     await client.chat.postMessage({
       channel: body.user.id,
-      text: `:hourglass_flowing_sand: Creating research plan for *${studyName}*... This may take a moment.`,
+      text: `Creating research plan for *${studyName}*... This may take a moment.`,
     });
   } catch (err) {
     const progressErr = err instanceof Error ? err.message : String(err);

--- a/backend/src/helpers/slack/commands/qoriMainHandler.ts
+++ b/backend/src/helpers/slack/commands/qoriMainHandler.ts
@@ -19,7 +19,7 @@ async function qoriMainHandler({ ack, command, client }: SlackCommandMiddlewareA
       type: 'header',
       text: {
         type: 'plain_text',
-        text: '📚 Qori Commands Reference'
+        text: 'Qori Commands Reference'
       }
     },
     {
@@ -110,7 +110,7 @@ async function qoriMainHandler({ ack, command, client }: SlackCommandMiddlewareA
       elements: [
         {
           type: 'mrkdwn',
-          text: '💡 Need more details? Use `/qori-learn` for an interactive tutorial.'
+          text: 'Need more details? Use `/qori-learn` for an interactive tutorial.'
         }
       ]
     }
@@ -118,7 +118,7 @@ async function qoriMainHandler({ ack, command, client }: SlackCommandMiddlewareA
 
   await client.chat.postMessage({
     channel: channelId,
-    text: '📚 Qori Commands Reference',
+    text: 'Qori Commands Reference',
     blocks: commandBlocks
   });
 }

--- a/backend/src/helpers/slack/commands/readoutHandler.ts
+++ b/backend/src/helpers/slack/commands/readoutHandler.ts
@@ -544,7 +544,7 @@ const handleReadoutModalSubmission = async ({ ack, body, view, client }: SlackVi
 
       await client.chat.postMessage({
         channel: body.user.id,
-        text: `🔄 Generating ${selectedAudiences.length} targeted readout(s) for *${selectedStudyName}*... You'll receive a notification as each completes.`,
+        text: `Generating ${selectedAudiences.length} targeted readout(s) for *${selectedStudyName}*... You'll receive a notification as each completes.`,
       });
 
       // Background IIFE so the modal closes immediately
@@ -614,13 +614,13 @@ const handleReadoutModalSubmission = async ({ ack, body, view, client }: SlackVi
           const links = succeeded.map(r => `• <${r.url}|${r.audience}>`).join('\n');
           await client.chat.postMessage({
             channel: body.user.id,
-            text: `📊 *All targeted readouts complete* (${succeeded.length}/${results.length})`,
+            text: `*All targeted readouts complete* (${succeeded.length}/${results.length})`,
             blocks: [
               {
                 type: 'section',
                 text: {
                   type: 'mrkdwn',
-                  text: `📊 *All targeted readouts complete* (${succeeded.length}/${results.length})\n\n${links}${failed.length > 0 ? `\n\n❌ ${failed.length} failed: ${failed.map(r => r.audience).join(', ')}` : ''}`,
+                  text: `*All targeted readouts complete* (${succeeded.length}/${results.length})\n\n${links}${failed.length > 0 ? `\n\n❌ ${failed.length} failed: ${failed.map(r => r.audience).join(', ')}` : ''}`,
                 },
               },
             ],
@@ -632,7 +632,7 @@ const handleReadoutModalSubmission = async ({ ack, body, view, client }: SlackVi
       // Research readout (existing flow)
       await client.chat.postMessage({
         channel: body.user.id,
-        text: `🔄 Generating research readout for *${selectedStudyName}*... This may take a few minutes.`,
+        text: `Generating research readout for *${selectedStudyName}*... This may take a few minutes.`,
       });
 
       const yamlTemplateName = 'research_readout.yaml';
@@ -662,7 +662,7 @@ const handleReadoutModalSubmission = async ({ ack, body, view, client }: SlackVi
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: `📊 *Report ready:*\n<${renderedYaml.result.url}|View Full Report on GitHub>`,
+              text: `*Report ready:*\n<${renderedYaml.result.url}|View Full Report on GitHub>`,
             },
           },
           { type: 'divider' },

--- a/backend/src/helpers/slack/commands/sessionNotesHandler.ts
+++ b/backend/src/helpers/slack/commands/sessionNotesHandler.ts
@@ -738,11 +738,11 @@ ${scrubResult.content}`;
     // DB-held quarantine: content shown inline, no GitHub link (not committed yet)
     await client.chat.postMessage({
       channel: body.user.id,
-      text: `🔍 PII Review Required: ${templateData.study_name} - ${templateData.participant_id}`,
+      text: `PII Review Required: ${templateData.study_name} - ${templateData.participant_id}`,
       blocks: [
         {
           type: 'header',
-          text: { type: 'plain_text', text: '🔍 PII Review Required', emoji: true }
+          text: { type: 'plain_text', text: 'PII Review Required', emoji: true }
         },
         {
           type: 'context',

--- a/backend/src/helpers/slack/commands/ticketHandler.ts
+++ b/backend/src/helpers/slack/commands/ticketHandler.ts
@@ -200,9 +200,9 @@ function buildStep1Modal(
           action_id: 'audience_select_action',
           placeholder: { type: 'plain_text', text: 'Choose audience...' },
           options: [
-            { text: { type: 'plain_text', text: '🎨 Designer' }, value: 'designer' },
-            { text: { type: 'plain_text', text: '⚙️ Engineering' }, value: 'engineering' },
-            { text: { type: 'plain_text', text: '♿ Accessibility' }, value: 'accessibility' },
+            { text: { type: 'plain_text', text: 'Designer' }, value: 'designer' },
+            { text: { type: 'plain_text', text: 'Engineering' }, value: 'engineering' },
+            { text: { type: 'plain_text', text: 'Accessibility' }, value: 'accessibility' },
           ],
         },
       },
@@ -443,7 +443,7 @@ const handleStep2Submit = async ({ ack, body, view, client }: SlackViewMiddlewar
 
   await client.chat.postMessage({
     channel: userId,
-    text: `🔄 Creating ${tickets.length} GitHub Issue(s) for *${config.label}* audience...`,
+    text: `Creating ${tickets.length} GitHub Issue(s) for *${config.label}* audience...`,
   });
 
   // Create issues sequentially

--- a/backend/src/helpers/slack/resubmitBriefHandler.ts
+++ b/backend/src/helpers/slack/resubmitBriefHandler.ts
@@ -136,7 +136,7 @@ export async function handleBriefResubmit({
       type: 'header',
       text: {
         type: 'plain_text',
-        text: `📝 Brief Resubmitted — ${studyName}`,
+        text: `Brief Resubmitted — ${studyName}`,
         emoji: true,
       },
     },
@@ -195,7 +195,7 @@ export async function handleBriefResubmit({
 
       await client.chat.postMessage({
         channel: im.channel.id,
-        text: `📝 Brief resubmitted for *${studyName}* — please re-review`,
+        text: `Brief resubmitted for *${studyName}* — please re-review`,
         blocks: messageBlocks as KnownBlock[],
       });
 

--- a/backend/src/services/github-webhook.service.ts
+++ b/backend/src/services/github-webhook.service.ts
@@ -98,10 +98,10 @@ class GithubWebhookService {
 
           // Compose Slack message blocks
           const blocks = [
-            { type: 'section', text: { type: 'mrkdwn', text: `📝 *Change Request from* <@${requestedBy || 'unknown'}>` } },
+            { type: 'section', text: { type: 'mrkdwn', text: `*Change Request from* <@${requestedBy || 'unknown'}>` } },
             { type: 'section', text: { type: 'mrkdwn', text: previousReason } },
             { type: 'divider' },
-            { type: 'section', text: { type: 'mrkdwn', text: '🔄 *GitHub Activity Detected:*' } },
+            { type: 'section', text: { type: 'mrkdwn', text: '*GitHub Activity Detected:*' } },
             { type: 'section', text: { type: 'mrkdwn', text: `• ${commitMsg}` } },
             { type: 'divider' },
             {


### PR DESCRIPTION
## Summary

- Remove decorative emoji from 18 handler and service files (`:clipboard:`, `:hourglass_flowing_sand:`, `:speech_balloon:`, `:tada:`, `:busts_in_silhouette:`, `📝`, `📊`, `🔄`, `🔍`, `💡`, `📚`, `🎨`, `⚙️`, `♿`, `✨`, `🏷️`, `🏛️`, `👁️`)
- Preserve all functional emoji (✅❌⚠️🗑️ and their Slack shortcode equivalents `:white_check_mark:`, `:x:`, `:warning:`, `:lock:`)
- Update §7 Violation Log in `qori-modal-design-standard.md` for PII Review and Join Observer R1 rows

## Files changed (19)

**Handlers with dynamic modal building:**
- `planModalOpener.ts` — removed `:clipboard:` from context text (2 locations)
- `discussionGuideHandler.ts` — removed `:speech_balloon:` (2) and `:hourglass_flowing_sand:` (1)
- `briefToStudyHandler.ts` — removed `:clipboard:` from context text (2 locations)
- `addObserverHandler.ts` — removed `📝👁️📊🏛️` from ROLE_DISPLAY mapping (4 entries)

**DM/message builders:**
- `briefHandler.ts` — removed `:hourglass_flowing_sand:` from progress DM
- `planHandler.ts` — removed `:hourglass_flowing_sand:` from progress DM
- `participantOutreachHandler.ts` — removed `:tada:` (2) and `:busts_in_silhouette:` (2)
- `participantHandler.ts` — removed `🏷️` from code preview (2 locations)
- `fieldworkHandler.ts` — removed `✨` from code preview
- `analyzeNotesHandler.ts` — removed `🔄` from progress DM
- `readoutHandler.ts` — removed `📊` (2) and `🔄` (2) from DMs; kept ✅❌⚠️
- `ticketHandler.ts` — removed `🎨⚙️♿` from audience options (3) and `🔄` from progress; kept ✅❌
- `qoriMainHandler.ts` — removed `📚` from header (2) and `💡` from context tip
- `sessionNotesHandler.ts` — removed `🔍` from DM text and header; kept ✅❌⚠️🗑️
- `resubmitBriefHandler.ts` — removed `📝` from header and DM text; kept ✅
- `adminActionsHandler.ts` — removed `:clipboard:` from stakeholder DM; kept `:white_check_mark:`, `:x:`, `:warning:`, `:lock:`
- `github-webhook.service.ts` — removed `📝` and `🔄` from section text; kept ✅
- `discoverHandler.ts` — removed `🔍` from DM text; kept ✅❌

**Docs:**
- `qori-modal-design-standard.md` — updated §7 Violation Log

## Template literal care

All removals are clean "emoji-space prefix" patterns. No concatenation, no orphaned newlines, no double spaces introduced. Every edit is `emoji + space + text` → `text`.

## Test plan

- [x] `npm run typecheck` passes (0 errors)
- [x] `npm test` passes (141 tests, 12 suites)
- [x] Verified functional emoji preserved in all handlers
- [ ] Manual spot-check: run `/qori` and verify header renders without `📚`

🤖 Generated with [Claude Code](https://claude.com/claude-code)