### PR TITLE
fix: R1 emoji sweep — decorative emoji removal product-wide

### DIFF
--- a/backend/docs/qori-modal-design-standard.md
+++ b/backend/docs/qori-modal-design-standard.md
@@ -704,56 +704,56 @@ Track specific violations found during audit, with fix status.
 |-------|--------|-----------|--------|
 | Research Brief | R7 | out_of_scope, start_date, decision_deadline hard-required but should be optional | Pending |
 | Analyze Session | R7 | "Study *" label uses asterisk (line 151) | Pending |
-| Add Participant | R1 | Emoji section headers (📝🗓️📊) | Fixed (PR #XXX) |
+| Add Participant | R1 | Emoji section headers (📝🗓️📊) | Fixed (PR #241) |
 | Add Participant | R3 | "Research study" → "Study" | Pending |
 | Add Participant | R7 | Trailing asterisks on required fields | Pending |
 | Add Participant | R8 | CAPS emphasis in help text | Pending |
 | Add Participant | R11 | Duplicative help text | Pending |
-| Update Participant | R1 | Emoji in labels | Fixed (PR #XXX) |
+| Update Participant | R1 | Emoji in labels | Fixed (PR #241) |
 | Update Participant | R7 | "Update Notes* (optional)" contradiction | Pending |
 | Update Participant | R10 | Two primary-style buttons | Pending |
-| Add Observer | R1 | Emoji in role options (📝👁️📊🏛️) | Fixed (PR #XXX) |
+| Add Observer | R1 | Emoji in role options (📝👁️📊🏛️) | Fixed (PR #241) |
 | Add Observer | R2 | Button "Done" not action-oriented | Pending |
 | Session Notes | R2 | Button "Process & Submit" not action-oriented | Pending |
 | Session Notes | R3 | Nested header structure | Pending |
 | Session Notes | R10 | Tab renders as green primary | Pending |
 | Session Notes | R11 | Duplicative PII scrubbing help | Pending |
-| Session Confirmation | R1 | Emoji in section header (📅) | Fixed (PR #XXX) |
+| Session Confirmation | R1 | Emoji in section header (📅) | Fixed (PR #241) |
 | Session Confirmation | R2 | Has "Generate" but form has asterisks on labels | Pending |
 | Session Confirmation | R7 | Asterisks in labels ("Session date *", "Session time *", "Meeting link *") | Pending |
-| Participant Outreach | R1 | Emoji in radio options | Fixed (PR #XXX) |
+| Participant Outreach | R1 | Emoji in radio options | Fixed (PR #241) |
 | Participant Outreach | R2 | Button "Next" not action-oriented | Pending |
 | Participant Outreach | R3 | "Select an existing study:" imperative | Pending |
 | Participant Outreach | R7 | Trailing asterisk | Pending |
-| Discovery Launcher | R1 | Emoji in option rows | Fixed (PR #XXX) |
+| Discovery Launcher | R1 | Emoji in option rows | Fixed (PR #241) |
 | Discovery Launcher | R8 | Italics in help text | Pending |
-| PII Review (transcript) | R1 | Decorative emoji in header (🔍) and button (📄); functional ✅⚠️❌ preserved | Fixed (PR #XXX) |
+| PII Review (transcript) | R1 | Decorative emoji in header (🔍) and button (📄); functional ✅⚠️❌ preserved | Fixed (PR #241) |
 | PII Review (manual notes) | R1 | Emoji in DM message (🔍✅⚠️) | Pending |
 | Join Observer | R1 | Emoji in role options (📝👁️📊🏛️) | Pending |
 | Admin Center Hub | R2 | "Open" button label (lines 102, 115) not action-oriented | Pending |
 | Admin — Delete Study | R2 | "Open" button label not action-oriented | Pending |
-| Plan Launcher | R1 | Emoji in section rows (:clipboard: :speech_balloon:) | Fixed (PR #XXX) |
-| Plan Launcher | R2 | Submit "Done" on launcher modal (no-op) | Fixed (PR #XXX) |
-| Plan Launcher | R9 | Close→Cancel for consistency | Fixed (PR #XXX) |
-| Research Plan Generator | R1 | :clipboard: in context block | Fixed (PR #XXX) |
-| Discussion Guide Modal | R1 | :speech_balloon: in context block | Fixed (PR #XXX) |
-| Readout Modal | R1 | Emoji in report type context and audience checkboxes (📄🎯🎨⚙️♿👔) | Fixed (PR #XXX) |
-| Upload Notes | R1 | Emoji in submit (📤), header (📂), button (📝), section (🤖), context (📁) | Fixed (PR #XXX) |
-| Session Notes | R1 | 💡 in tips context | Fixed (PR #XXX) |
-| Analyze Session | R1 | 📄 in auto-selected transcript context | Fixed (PR #XXX) |
-| Request Changes | R1 | 📝 in section header, 💡 in tip context | Fixed (PR #XXX) |
-| Mark Changes Complete | R1 | 🐛 in GitHub section, ☑️ in notification rows | Fixed (PR #XXX) |
-| Observer Guide DM | R1 | :book: in guidelines link | Fixed (PR #XXX) |
-| Study Result Blocks | R1 | 🗓️ in header, 🔔 in DM text | Fixed (PR #XXX) |
-| Research Shareout | R1 | Emoji in type options (🎯📊👥📄🏛️📐), headers (📋📑📤), tip (💡) | Fixed (PR #XXX) |
-| Copy Email | R1 | 📄 in section text | Fixed (PR #XXX) |
-| Email Preview | R1 | 📄 in button label | Fixed (PR #XXX) |
-| Session Reminder | R1 | 📅 in section header | Fixed (PR #XXX) |
-| Initial Recruitment | R1 | 📋 in section header | Fixed (PR #XXX) |
-| Rescheduling Request | R1 | 🔄 in section header | Fixed (PR #XXX) |
-| Discover: Desk Research | R1 | :page_facing_up: in context | Fixed (PR #XXX) |
-| Discover: Stakeholder | R1 | :studio_microphone: in context | Fixed (PR #XXX) |
-| Discover: Survey | R1 | :bar_chart: in context | Fixed (PR #XXX) |
+| Plan Launcher | R1 | Emoji in section rows (:clipboard: :speech_balloon:) | Fixed (PR #241) |
+| Plan Launcher | R2 | Submit "Done" on launcher modal (no-op) | Fixed (PR #241) |
+| Plan Launcher | R9 | Close→Cancel for consistency | Fixed (PR #241) |
+| Research Plan Generator | R1 | :clipboard: in context block | Fixed (PR #241) |
+| Discussion Guide Modal | R1 | :speech_balloon: in context block | Fixed (PR #241) |
+| Readout Modal | R1 | Emoji in report type context and audience checkboxes (📄🎯🎨⚙️♿👔) | Fixed (PR #241) |
+| Upload Notes | R1 | Emoji in submit (📤), header (📂), button (📝), section (🤖), context (📁) | Fixed (PR #241) |
+| Session Notes | R1 | 💡 in tips context | Fixed (PR #241) |
+| Analyze Session | R1 | 📄 in auto-selected transcript context | Fixed (PR #241) |
+| Request Changes | R1 | 📝 in section header, 💡 in tip context | Fixed (PR #241) |
+| Mark Changes Complete | R1 | 🐛 in GitHub section, ☑️ in notification rows | Fixed (PR #241) |
+| Observer Guide DM | R1 | :book: in guidelines link | Fixed (PR #241) |
+| Study Result Blocks | R1 | 🗓️ in header, 🔔 in DM text | Fixed (PR #241) |
+| Research Shareout | R1 | Emoji in type options (🎯📊👥📄🏛️📐), headers (📋📑📤), tip (💡) | Fixed (PR #241) |
+| Copy Email | R1 | 📄 in section text | Fixed (PR #241) |
+| Email Preview | R1 | 📄 in button label | Fixed (PR #241) |
+| Session Reminder | R1 | 📅 in section header | Fixed (PR #241) |
+| Initial Recruitment | R1 | 📋 in section header | Fixed (PR #241) |
+| Rescheduling Request | R1 | 🔄 in section header | Fixed (PR #241) |
+| Discover: Desk Research | R1 | :page_facing_up: in context | Fixed (PR #241) |
+| Discover: Stakeholder | R1 | :studio_microphone: in context | Fixed (PR #241) |
+| Discover: Survey | R1 | :bar_chart: in context | Fixed (PR #241) |
 
 ---
 

--- a/backend/docs/qori-modal-design-standard.md
+++ b/backend/docs/qori-modal-design-standard.md
@@ -727,9 +727,9 @@ Track specific violations found during audit, with fix status.
 | Participant Outreach | R7 | Trailing asterisk | Pending |
 | Discovery Launcher | R1 | Emoji in option rows | Pending |
 | Discovery Launcher | R8 | Italics in help text | Pending |
-| PII Review (transcript) | R1 | Emoji in header (🔍), stats (✅⚠️), button (📄), footer (✅❌) | Pending |
-| PII Review (manual notes) | R1 | Emoji in DM message (🔍✅⚠️) | Pending |
-| Join Observer | R1 | Emoji in role options (📝👁️📊🏛️) | Pending |
+| PII Review (transcript) | R1 | Decorative 🔍 removed from header; ✅⚠️📄❌ kept (functional) | Partial fix (emoji-sweep-handlers) |
+| PII Review (manual notes) | R1 | Decorative 🔍 removed; ✅⚠️ kept (functional) | Fixed (emoji-sweep-handlers) |
+| Join Observer | R1 | Emoji in role options (📝👁️📊🏛️) | Fixed (emoji-sweep-handlers) |
 | Admin Center Hub | R2 | "Open" button label (lines 102, 115) not action-oriented | Pending |
 | Admin — Delete Study | R2 | "Open" button label not action-oriented | Pending |
 

--- a/backend/docs/qori-modal-design-standard.md
+++ b/backend/docs/qori-modal-design-standard.md
@@ -211,27 +211,27 @@ Scores reflect CURRENT code state, not intended state. A cell flips to ✓ with 
 | Modal | R1 | R2 | R3 | R4 | R5 | R6 | R7 | R8 | R9 | R10 | R11 | R12 | R13 | R14 | R15 |
 |-------|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:---:|:---:|:---:|:---:|:---:|:---:|
 | Research Brief | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | — | ? | ✓ | ✓ | ? | ✓ | ✓ | N/A | N/A |
-| Analyze Session | — | ✓ | ✓ | ✓ | ✓ | N/A | — | ? | ✓ | ✓ | ? | ✓ | ✓ | N/A | N/A |
+| Analyze Session | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | — | ? | ✓ | ✓ | ? | ✓ | ✓ | N/A | N/A |
 | Research Synthesis | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | ✓ | ? | ✓ | ✓ | ? | ✓ | ✓ | N/A | N/A |
 | Readout | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
 | Discussion Guide | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
 | Research Plan | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
-| Discovery Launcher | — | ? | ? | ? | ? | N/A | ? | — | ? | ? | — | ? | ? | — | N/A |
+| Discovery Launcher | ✓ | ? | ? | ? | ? | N/A | ? | — | ? | ? | — | ? | ? | — | N/A |
 | Discover: Desk Research | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
 | Discover: Stakeholder | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
 | Discover: Survey | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
 | Project Creation | ? | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
-| Add Participant | — | ? | — | ? | ? | N/A | — | — | ? | ? | — | ? | ? | N/A | N/A |
-| Update Participant | — | ? | ? | ? | ? | N/A | — | ? | ? | — | ? | ? | ? | N/A | N/A |
-| Add Observer | — | — | ? | ? | ? | N/A | ✓ | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Add Participant | ✓ | ? | — | ? | ? | N/A | — | — | ? | ? | — | ? | ? | N/A | N/A |
+| Update Participant | ✓ | ? | ? | ? | ? | N/A | — | ? | ? | — | ? | ? | ? | N/A | N/A |
+| Add Observer | ✓ | — | ? | ? | ? | N/A | ✓ | ? | ? | ? | ? | ? | ? | N/A | N/A |
 | Session Notes | ✓ | — | — | ? | ? | N/A | ? | ? | ? | — | — | ? | ? | N/A | N/A |
-| Participant Outreach | — | — | — | ? | ? | N/A | — | — | ? | ? | ? | ? | ? | N/A | N/A |
-| Session Confirmation | — | — | ? | ? | ? | N/A | — | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Participant Outreach | ✓ | — | — | ? | ? | N/A | — | — | ? | ? | ? | ? | ? | N/A | N/A |
+| Session Confirmation | ✓ | — | ? | ? | ? | N/A | — | ? | ? | ? | ? | ? | ? | N/A | N/A |
 | Tickets | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | ? | ? | ✓ | ✓ | ? | ✓ | ✓ | N/A | N/A |
-| PII Review (transcript) | — | ✓ | ✓ | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| PII Review (transcript) | ✓ | ✓ | ✓ | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
 | PII Review (manual notes) | — | ? | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
 | Fieldwork Dashboard | ? | ✓ | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
-| Join Observer | — | ✓ | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
+| Join Observer | ✓ | ✓ | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
 | Admin Center Hub | ? | — | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | ✓ | — |
 | Admin — Delete Study | ? | — | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
 | Admin — Manage Stakeholder | ? | ✓ | ? | ? | ? | N/A | ? | ? | ? | ? | ? | ? | ? | N/A | N/A |
@@ -704,34 +704,56 @@ Track specific violations found during audit, with fix status.
 |-------|--------|-----------|--------|
 | Research Brief | R7 | out_of_scope, start_date, decision_deadline hard-required but should be optional | Pending |
 | Analyze Session | R7 | "Study *" label uses asterisk (line 151) | Pending |
-| Add Participant | R1 | Emoji section headers (📝🗓️📊) | Pending |
+| Add Participant | R1 | Emoji section headers (📝🗓️📊) | Fixed (PR #XXX) |
 | Add Participant | R3 | "Research study" → "Study" | Pending |
 | Add Participant | R7 | Trailing asterisks on required fields | Pending |
 | Add Participant | R8 | CAPS emphasis in help text | Pending |
 | Add Participant | R11 | Duplicative help text | Pending |
-| Update Participant | R1 | Emoji in labels | Pending |
+| Update Participant | R1 | Emoji in labels | Fixed (PR #XXX) |
 | Update Participant | R7 | "Update Notes* (optional)" contradiction | Pending |
 | Update Participant | R10 | Two primary-style buttons | Pending |
-| Add Observer | R1 | Emoji in role options (📝👁️📊🏛️) | Pending |
+| Add Observer | R1 | Emoji in role options (📝👁️📊🏛️) | Fixed (PR #XXX) |
 | Add Observer | R2 | Button "Done" not action-oriented | Pending |
 | Session Notes | R2 | Button "Process & Submit" not action-oriented | Pending |
 | Session Notes | R3 | Nested header structure | Pending |
 | Session Notes | R10 | Tab renders as green primary | Pending |
 | Session Notes | R11 | Duplicative PII scrubbing help | Pending |
-| Session Confirmation | R1 | Emoji in section header (📅) | Pending |
+| Session Confirmation | R1 | Emoji in section header (📅) | Fixed (PR #XXX) |
 | Session Confirmation | R2 | Has "Generate" but form has asterisks on labels | Pending |
 | Session Confirmation | R7 | Asterisks in labels ("Session date *", "Session time *", "Meeting link *") | Pending |
-| Participant Outreach | R1 | Emoji in radio options | Pending |
+| Participant Outreach | R1 | Emoji in radio options | Fixed (PR #XXX) |
 | Participant Outreach | R2 | Button "Next" not action-oriented | Pending |
 | Participant Outreach | R3 | "Select an existing study:" imperative | Pending |
 | Participant Outreach | R7 | Trailing asterisk | Pending |
-| Discovery Launcher | R1 | Emoji in option rows | Pending |
+| Discovery Launcher | R1 | Emoji in option rows | Fixed (PR #XXX) |
 | Discovery Launcher | R8 | Italics in help text | Pending |
-| PII Review (transcript) | R1 | Emoji in header (🔍), stats (✅⚠️), button (📄), footer (✅❌) | Pending |
+| PII Review (transcript) | R1 | Decorative emoji in header (🔍) and button (📄); functional ✅⚠️❌ preserved | Fixed (PR #XXX) |
 | PII Review (manual notes) | R1 | Emoji in DM message (🔍✅⚠️) | Pending |
 | Join Observer | R1 | Emoji in role options (📝👁️📊🏛️) | Pending |
 | Admin Center Hub | R2 | "Open" button label (lines 102, 115) not action-oriented | Pending |
 | Admin — Delete Study | R2 | "Open" button label not action-oriented | Pending |
+| Plan Launcher | R1 | Emoji in section rows (:clipboard: :speech_balloon:) | Fixed (PR #XXX) |
+| Plan Launcher | R2 | Submit "Done" on launcher modal (no-op) | Fixed (PR #XXX) |
+| Plan Launcher | R9 | Close→Cancel for consistency | Fixed (PR #XXX) |
+| Research Plan Generator | R1 | :clipboard: in context block | Fixed (PR #XXX) |
+| Discussion Guide Modal | R1 | :speech_balloon: in context block | Fixed (PR #XXX) |
+| Readout Modal | R1 | Emoji in report type context and audience checkboxes (📄🎯🎨⚙️♿👔) | Fixed (PR #XXX) |
+| Upload Notes | R1 | Emoji in submit (📤), header (📂), button (📝), section (🤖), context (📁) | Fixed (PR #XXX) |
+| Session Notes | R1 | 💡 in tips context | Fixed (PR #XXX) |
+| Analyze Session | R1 | 📄 in auto-selected transcript context | Fixed (PR #XXX) |
+| Request Changes | R1 | 📝 in section header, 💡 in tip context | Fixed (PR #XXX) |
+| Mark Changes Complete | R1 | 🐛 in GitHub section, ☑️ in notification rows | Fixed (PR #XXX) |
+| Observer Guide DM | R1 | :book: in guidelines link | Fixed (PR #XXX) |
+| Study Result Blocks | R1 | 🗓️ in header, 🔔 in DM text | Fixed (PR #XXX) |
+| Research Shareout | R1 | Emoji in type options (🎯📊👥📄🏛️📐), headers (📋📑📤), tip (💡) | Fixed (PR #XXX) |
+| Copy Email | R1 | 📄 in section text | Fixed (PR #XXX) |
+| Email Preview | R1 | 📄 in button label | Fixed (PR #XXX) |
+| Session Reminder | R1 | 📅 in section header | Fixed (PR #XXX) |
+| Initial Recruitment | R1 | 📋 in section header | Fixed (PR #XXX) |
+| Rescheduling Request | R1 | 🔄 in section header | Fixed (PR #XXX) |
+| Discover: Desk Research | R1 | :page_facing_up: in context | Fixed (PR #XXX) |
+| Discover: Stakeholder | R1 | :studio_microphone: in context | Fixed (PR #XXX) |
+| Discover: Survey | R1 | :bar_chart: in context | Fixed (PR #XXX) |
 
 ---
 
@@ -739,6 +761,7 @@ Track specific violations found during audit, with fix status.
 
 | Date | Version | Changes |
 |------|---------|---------|
+| 2026-07-31 | 2.0 | R1 emoji sweep: removed all decorative emoji from ~28 modal builder files. Functional emoji (✅❌⚠️:warning:🔴🟡🟢:lock:🗑️) preserved. Plan launcher (studySetupModal): removed vestigial submit block (R2), Close→Cancel (R9). Added new violation log rows for modals found during sweep. |
 | 2026-07-10 | 1.9 | Session Notes input preservation fix shipped (`37f50e43`): tab switches no longer clear typed inputs. PII scrubbing fix shipped (`15c0a49f`): participant name now correctly extracted and scrubbed. Whitespace behavior documented (`7b1f31c1`): Slack API strips leading/trailing whitespace from plain_text_input (not fixable). Merged to main as `e454740a`. |
 | 2026-07-09 | 1.8 | 5f fix spec implemented in sessionNotesHandler.ts: (a) inline errors, (b) trim paste, (c) validate content after download. Pending manual test. |
 | 2026-07-09 | 1.7 | §6.0.2 ID matching verified — SELECT confirms `desk_research`, `stakeholder_synthesis` only, no `_processor` values. |

--- a/backend/src/helpers/slack/commands/addObserverHandler.ts
+++ b/backend/src/helpers/slack/commands/addObserverHandler.ts
@@ -20,10 +20,10 @@ import { getConfigRepo, YAML_TEMPLATE_PATH, fetchFileFromRepo } from '../../gith
 // ── Helpers ────────────────────────────────────────────────
 
 const ROLE_DISPLAY: Record<string, string> = {
-  note_taker: '📝 Note-taker',
-  silent_observer: '👁️ Silent Observer',
-  pm_observer: '📊 PM Observer',
-  stakeholder: '🏛️ Stakeholder',
+  note_taker: 'Note-taker',
+  silent_observer: 'Silent Observer',
+  pm_observer: 'PM Observer',
+  stakeholder: 'Stakeholder',
 };
 
 /**

--- a/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
+++ b/backend/src/helpers/slack/commands/admin/adminActionsHandler.ts
@@ -1345,7 +1345,7 @@ export async function handleStakeholderSubmit({
       try {
         await client.chat.postMessage({
           channel: stakeholderInfo.userId,
-          text: `:clipboard: *${assignerName}* assigned you as stakeholder for *${metadata.projectName}*. You'll receive brief approval requests for studies in this project.`,
+          text: `*${assignerName}* assigned you as stakeholder for *${metadata.projectName}*. You'll receive brief approval requests for studies in this project.`,
         });
       } catch {
         // DM to stakeholder failed, not critical

--- a/backend/src/helpers/slack/commands/analyzeNotesHandler.ts
+++ b/backend/src/helpers/slack/commands/analyzeNotesHandler.ts
@@ -262,7 +262,7 @@ const handleAnalyzeNotesSubmission = async ({ ack, body, view, client }: SlackVi
     await client.chat.postEphemeral({
       channel: body.user.id,
       user: body.user.id,
-      text: '🔄 *Analyzing session* — this takes a minute or two. You\'ll see a confirmation when it\'s done.',
+      text: '*Analyzing session* — this takes a minute or two. You\'ll see a confirmation when it\'s done.',
     });
 
     if (!studyId || studyId === "no_studies") {

--- a/backend/src/helpers/slack/commands/briefHandler.ts
+++ b/backend/src/helpers/slack/commands/briefHandler.ts
@@ -242,7 +242,7 @@ async function handleBriefSubmission({ ack, body, view, client }: SlackViewMiddl
   try {
     await client.chat.postMessage({
       channel: body.user.id,
-      text: `:hourglass_flowing_sand: Creating research brief for *${studyName}*... This may take a moment.`,
+      text: `Creating research brief for *${studyName}*... This may take a moment.`,
     });
   } catch (err) {
     const progressErr = err instanceof Error ? err.message : String(err);

--- a/backend/src/helpers/slack/commands/discoverHandler.ts
+++ b/backend/src/helpers/slack/commands/discoverHandler.ts
@@ -418,7 +418,7 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
 
   await client.chat.postMessage({
     channel: userId,
-    text: `🔍 Running ${typeConfig.label} for "${topic}"... This may take a minute.`,
+    text: `Running ${typeConfig.label} for "${topic}"... This may take a minute.`,
   });
 
   try {

--- a/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
+++ b/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
@@ -228,7 +228,7 @@ async function openDiscussionGuideModal({ ack, body, client }: SlackActionMiddle
           elements: [
             {
               type: "mrkdwn",
-              text: `:speech_balloon: *${preselectStudyName}*`,
+              text: `*${preselectStudyName}*`,
             },
           ],
         },
@@ -260,7 +260,7 @@ async function openDiscussionGuideModal({ ack, body, client }: SlackActionMiddle
         elements: [
           {
             type: "mrkdwn",
-            text: `:speech_balloon: *${preselectStudyName}*\nBuilding a session guide from your approved brief.`,
+            text: `*${preselectStudyName}*\nBuilding a session guide from your approved brief.`,
           },
         ],
       };
@@ -419,7 +419,7 @@ async function handleDiscussionGuideSubmission({ ack, body, view, client }: Slac
   try {
     await client.chat.postMessage({
       channel: body.user.id,
-      text: `:hourglass_flowing_sand: Generating discussion guide for *${studyName}*... This may take a moment.`,
+      text: `Generating discussion guide for *${studyName}*... This may take a moment.`,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/backend/src/helpers/slack/commands/fieldworkHandler.ts
+++ b/backend/src/helpers/slack/commands/fieldworkHandler.ts
@@ -231,7 +231,7 @@ async function handleFieldworkAddParticipant({ ack, body, client }: SlackActionM
         block_id: "code_preview_block",
         elements: [{
           type: "mrkdwn",
-          text: `✨ Will be assigned: *${nextCode}*`
+          text: `Will be assigned: *${nextCode}*`
         }]
       };
     }

--- a/backend/src/helpers/slack/commands/modal-openers/briefToStudyHandler.ts
+++ b/backend/src/helpers/slack/commands/modal-openers/briefToStudyHandler.ts
@@ -108,7 +108,7 @@ async function openPlanFromBrief({ ack, body, client }: SlackActionMiddlewareArg
         elements: [
           {
             type: "mrkdwn",
-            text: `:clipboard: *${studyName}*\nGenerating an execution plan from your approved brief.`,
+            text: `*${studyName}*\nGenerating an execution plan from your approved brief.`,
           },
         ],
       };
@@ -163,7 +163,7 @@ async function openPlanFromBrief({ ack, body, client }: SlackActionMiddlewareArg
           elements: [
             {
               type: "mrkdwn",
-              text: `:clipboard: *${studyName}*`,
+              text: `*${studyName}*`,
             },
           ],
         },

--- a/backend/src/helpers/slack/commands/modal-openers/planModalOpener.ts
+++ b/backend/src/helpers/slack/commands/modal-openers/planModalOpener.ts
@@ -166,7 +166,7 @@ async function openResearchPlanModal({ ack, body, client }: SlackActionMiddlewar
           elements: [
             {
               type: "mrkdwn",
-              text: `:clipboard: *${preselectStudyName}*`,
+              text: `*${preselectStudyName}*`,
             },
           ],
         },
@@ -201,7 +201,7 @@ async function openResearchPlanModal({ ack, body, client }: SlackActionMiddlewar
         elements: [
           {
             type: "mrkdwn",
-            text: `:clipboard: *${preselectStudyName}*\nGenerating an execution plan from your approved brief.`,
+            text: `*${preselectStudyName}*\nGenerating an execution plan from your approved brief.`,
           },
         ],
       };

--- a/backend/src/helpers/slack/commands/participantHandler.ts
+++ b/backend/src/helpers/slack/commands/participantHandler.ts
@@ -63,7 +63,7 @@ async function participantHandler({ ack, body, client, command }: SlackCommandMi
           elements: [
             {
               type: "mrkdwn",
-              text: `🏷️ *Will be assigned:* \`${nextCode}\``
+              text: `*Will be assigned:* \`${nextCode}\``
             }
           ]
         };
@@ -441,7 +441,7 @@ async function handleAddParticipantStudySelect({ ack, body, client }: SlackActio
         elements: [
           {
             type: "mrkdwn",
-            text: `🏷️ *Will be assigned:* \`${nextCode}\``
+            text: `*Will be assigned:* \`${nextCode}\``
           }
         ]
       };

--- a/backend/src/helpers/slack/commands/participantOutreachHandler.ts
+++ b/backend/src/helpers/slack/commands/participantOutreachHandler.ts
@@ -1060,13 +1060,13 @@ async function handleAddParticipantSubmit({ ack, body, view, client }: SlackView
     if (milestoneCheck.hasReachedMilestone) {
       // Generate a milestone message for the channel
       const milestoneMessage = {
-        text: `:tada: *Milestone reached!* The study *${milestoneCheck.studyName}* now has ${milestoneCheck.currentCount} participants.`,
+        text: `*Milestone reached!* The study *${milestoneCheck.studyName}* now has ${milestoneCheck.currentCount} participants.`,
         blocks: [
           {
             type: "section",
             text: {
               type: "mrkdwn",
-              text: `:tada: *Milestone reached!*\n\nThe study *${milestoneCheck.studyName}* now has *${milestoneCheck.currentCount}* participants.`
+              text: `*Milestone reached!*\n\nThe study *${milestoneCheck.studyName}* now has *${milestoneCheck.currentCount}* participants.`
             }
           },
           {
@@ -1109,13 +1109,13 @@ async function handleAddParticipantSubmit({ ack, body, view, client }: SlackView
     const assignedCode = savedParticipant.participant_code;
     await client.chat.postMessage({
       channel: userId, // Use original Slack user ID for DM channel
-      text: `:busts_in_silhouette: *New Participant Added*\n\n*Code:* ${assignedCode}\n*Name:* ${participant_name}\n*Study:* ${study_name}\n*Status:* ${status_select}`,
+      text: `*New Participant Added*\n\n*Code:* ${assignedCode}\n*Name:* ${participant_name}\n*Study:* ${study_name}\n*Status:* ${status_select}`,
       blocks: [
         {
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `:busts_in_silhouette: *New Participant Added*\n\n*Code:* \`${assignedCode}\`\n*Name:* ${participant_name}\n*Study:* ${study_name}\n*Status:* ${status_select}\n*Recruitment Source:* ${recruitment_source}`
+            text: `*New Participant Added*\n\n*Code:* \`${assignedCode}\`\n*Name:* ${participant_name}\n*Study:* ${study_name}\n*Status:* ${status_select}\n*Recruitment Source:* ${recruitment_source}`
           }
         },
         {

--- a/backend/src/helpers/slack/commands/planHandler.ts
+++ b/backend/src/helpers/slack/commands/planHandler.ts
@@ -87,7 +87,7 @@ async function handlePlanSubmission({ ack, body, view, client }: SlackViewMiddle
   try {
     await client.chat.postMessage({
       channel: body.user.id,
-      text: `:hourglass_flowing_sand: Creating research plan for *${studyName}*... This may take a moment.`,
+      text: `Creating research plan for *${studyName}*... This may take a moment.`,
     });
   } catch (err) {
     const progressErr = err instanceof Error ? err.message : String(err);

--- a/backend/src/helpers/slack/commands/qoriMainHandler.ts
+++ b/backend/src/helpers/slack/commands/qoriMainHandler.ts
@@ -19,7 +19,7 @@ async function qoriMainHandler({ ack, command, client }: SlackCommandMiddlewareA
       type: 'header',
       text: {
         type: 'plain_text',
-        text: '📚 Qori Commands Reference'
+        text: 'Qori Commands Reference'
       }
     },
     {
@@ -110,7 +110,7 @@ async function qoriMainHandler({ ack, command, client }: SlackCommandMiddlewareA
       elements: [
         {
           type: 'mrkdwn',
-          text: '💡 Need more details? Use `/qori-learn` for an interactive tutorial.'
+          text: 'Need more details? Use `/qori-learn` for an interactive tutorial.'
         }
       ]
     }
@@ -118,7 +118,7 @@ async function qoriMainHandler({ ack, command, client }: SlackCommandMiddlewareA
 
   await client.chat.postMessage({
     channel: channelId,
-    text: '📚 Qori Commands Reference',
+    text: 'Qori Commands Reference',
     blocks: commandBlocks
   });
 }

--- a/backend/src/helpers/slack/commands/readoutHandler.ts
+++ b/backend/src/helpers/slack/commands/readoutHandler.ts
@@ -544,7 +544,7 @@ const handleReadoutModalSubmission = async ({ ack, body, view, client }: SlackVi
 
       await client.chat.postMessage({
         channel: body.user.id,
-        text: `🔄 Generating ${selectedAudiences.length} targeted readout(s) for *${selectedStudyName}*... You'll receive a notification as each completes.`,
+        text: `Generating ${selectedAudiences.length} targeted readout(s) for *${selectedStudyName}*... You'll receive a notification as each completes.`,
       });
 
       // Background IIFE so the modal closes immediately
@@ -614,13 +614,13 @@ const handleReadoutModalSubmission = async ({ ack, body, view, client }: SlackVi
           const links = succeeded.map(r => `• <${r.url}|${r.audience}>`).join('\n');
           await client.chat.postMessage({
             channel: body.user.id,
-            text: `📊 *All targeted readouts complete* (${succeeded.length}/${results.length})`,
+            text: `*All targeted readouts complete* (${succeeded.length}/${results.length})`,
             blocks: [
               {
                 type: 'section',
                 text: {
                   type: 'mrkdwn',
-                  text: `📊 *All targeted readouts complete* (${succeeded.length}/${results.length})\n\n${links}${failed.length > 0 ? `\n\n❌ ${failed.length} failed: ${failed.map(r => r.audience).join(', ')}` : ''}`,
+                  text: `*All targeted readouts complete* (${succeeded.length}/${results.length})\n\n${links}${failed.length > 0 ? `\n\n❌ ${failed.length} failed: ${failed.map(r => r.audience).join(', ')}` : ''}`,
                 },
               },
             ],
@@ -632,7 +632,7 @@ const handleReadoutModalSubmission = async ({ ack, body, view, client }: SlackVi
       // Research readout (existing flow)
       await client.chat.postMessage({
         channel: body.user.id,
-        text: `🔄 Generating research readout for *${selectedStudyName}*... This may take a few minutes.`,
+        text: `Generating research readout for *${selectedStudyName}*... This may take a few minutes.`,
       });
 
       const yamlTemplateName = 'research_readout.yaml';
@@ -662,7 +662,7 @@ const handleReadoutModalSubmission = async ({ ack, body, view, client }: SlackVi
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: `📊 *Report ready:*\n<${renderedYaml.result.url}|View Full Report on GitHub>`,
+              text: `*Report ready:*\n<${renderedYaml.result.url}|View Full Report on GitHub>`,
             },
           },
           { type: 'divider' },

--- a/backend/src/helpers/slack/commands/sessionNotesHandler.ts
+++ b/backend/src/helpers/slack/commands/sessionNotesHandler.ts
@@ -738,11 +738,11 @@ ${scrubResult.content}`;
     // DB-held quarantine: content shown inline, no GitHub link (not committed yet)
     await client.chat.postMessage({
       channel: body.user.id,
-      text: `🔍 PII Review Required: ${templateData.study_name} - ${templateData.participant_id}`,
+      text: `PII Review Required: ${templateData.study_name} - ${templateData.participant_id}`,
       blocks: [
         {
           type: 'header',
-          text: { type: 'plain_text', text: '🔍 PII Review Required', emoji: true }
+          text: { type: 'plain_text', text: 'PII Review Required', emoji: true }
         },
         {
           type: 'context',

--- a/backend/src/helpers/slack/commands/ticketHandler.ts
+++ b/backend/src/helpers/slack/commands/ticketHandler.ts
@@ -200,9 +200,9 @@ function buildStep1Modal(
           action_id: 'audience_select_action',
           placeholder: { type: 'plain_text', text: 'Choose audience...' },
           options: [
-            { text: { type: 'plain_text', text: '🎨 Designer' }, value: 'designer' },
-            { text: { type: 'plain_text', text: '⚙️ Engineering' }, value: 'engineering' },
-            { text: { type: 'plain_text', text: '♿ Accessibility' }, value: 'accessibility' },
+            { text: { type: 'plain_text', text: 'Designer' }, value: 'designer' },
+            { text: { type: 'plain_text', text: 'Engineering' }, value: 'engineering' },
+            { text: { type: 'plain_text', text: 'Accessibility' }, value: 'accessibility' },
           ],
         },
       },
@@ -443,7 +443,7 @@ const handleStep2Submit = async ({ ack, body, view, client }: SlackViewMiddlewar
 
   await client.chat.postMessage({
     channel: userId,
-    text: `🔄 Creating ${tickets.length} GitHub Issue(s) for *${config.label}* audience...`,
+    text: `Creating ${tickets.length} GitHub Issue(s) for *${config.label}* audience...`,
   });
 
   // Create issues sequentially

--- a/backend/src/helpers/slack/resubmitBriefHandler.ts
+++ b/backend/src/helpers/slack/resubmitBriefHandler.ts
@@ -136,7 +136,7 @@ export async function handleBriefResubmit({
       type: 'header',
       text: {
         type: 'plain_text',
-        text: `📝 Brief Resubmitted — ${studyName}`,
+        text: `Brief Resubmitted — ${studyName}`,
         emoji: true,
       },
     },
@@ -195,7 +195,7 @@ export async function handleBriefResubmit({
 
       await client.chat.postMessage({
         channel: im.channel.id,
-        text: `📝 Brief resubmitted for *${studyName}* — please re-review`,
+        text: `Brief resubmitted for *${studyName}* — please re-review`,
         blocks: messageBlocks as KnownBlock[],
       });
 

--- a/backend/src/helpers/slack/ui/addObserverModal.ts
+++ b/backend/src/helpers/slack/ui/addObserverModal.ts
@@ -55,12 +55,12 @@ const buildAddObserverModal = (sessions: SessionOption[], channelName: string) =
         action_id: 'observer_role',
         placeholder: { type: 'plain_text', text: 'Select a role...' },
         options: [
-          { text: { type: 'plain_text', text: '📝 Note-taker' }, value: 'note_taker' },
-          { text: { type: 'plain_text', text: '👁️ Silent Observer' }, value: 'silent_observer' },
-          { text: { type: 'plain_text', text: '📊 PM Observer' }, value: 'pm_observer' },
-          { text: { type: 'plain_text', text: '🏛️ Stakeholder' }, value: 'stakeholder' },
+          { text: { type: 'plain_text', text: 'Note-taker' }, value: 'note_taker' },
+          { text: { type: 'plain_text', text: 'Silent Observer' }, value: 'silent_observer' },
+          { text: { type: 'plain_text', text: 'PM Observer' }, value: 'pm_observer' },
+          { text: { type: 'plain_text', text: 'Stakeholder' }, value: 'stakeholder' },
         ],
-        initial_option: { text: { type: 'plain_text', text: '👁️ Silent Observer' }, value: 'silent_observer' },
+        initial_option: { text: { type: 'plain_text', text: 'Silent Observer' }, value: 'silent_observer' },
       },
     },
     {

--- a/backend/src/helpers/slack/ui/addParticipantModal.ts
+++ b/backend/src/helpers/slack/ui/addParticipantModal.ts
@@ -50,7 +50,7 @@ const addParticipantModal = {
     { type: "divider" },
 
     // Participant Information
-    { type: "section", text: { type: "mrkdwn", text: "📝 *Participant Information*" } },
+    { type: "section", text: { type: "mrkdwn", text: "*Participant Information*" } },
     // Participant alias (optional memory aid)
     {
       type: "input",
@@ -75,11 +75,11 @@ const addParticipantModal = {
         action_id: "recruitment_method",
         placeholder: { type: "plain_text", text: "Select recruitment source" },
         options: [
-          { text: { type: "plain_text", text: "🗂️ Internal panel" }, value: "internal_panel" },
-          { text: { type: "plain_text", text: "📧 Email outreach" }, value: "email_outreach" },
-          { text: { type: "plain_text", text: "🏢 Recruitment agency" }, value: "recruitment_agency" },
-          { text: { type: "plain_text", text: "🤝 Referral" }, value: "referral" },
-          { text: { type: "plain_text", text: "🌐 Social/Website" }, value: "online" },
+          { text: { type: "plain_text", text: "Internal panel" }, value: "internal_panel" },
+          { text: { type: "plain_text", text: "Email outreach" }, value: "email_outreach" },
+          { text: { type: "plain_text", text: "Recruitment agency" }, value: "recruitment_agency" },
+          { text: { type: "plain_text", text: "Referral" }, value: "referral" },
+          { text: { type: "plain_text", text: "Social/Website" }, value: "online" },
         ],
       },
     },
@@ -87,7 +87,7 @@ const addParticipantModal = {
     { type: "divider" },
 
     // Session Details
-    { type: "section", text: { type: "mrkdwn", text: "📅 *Session Details*" } },
+    { type: "section", text: { type: "mrkdwn", text: "*Session Details*" } },
     // Scheduled date
     {
       type: "input",
@@ -127,7 +127,7 @@ const addParticipantModal = {
     { type: "divider" },
 
     // Demographics
-    { type: "section", text: { type: "mrkdwn", text: "📊 *Demographics*" } },
+    { type: "section", text: { type: "mrkdwn", text: "*Demographics*" } },
     // Race/Ethnicity
     {
       type: "input",
@@ -213,7 +213,7 @@ const addParticipantModal = {
     { type: "divider" },
 
     // Notes & Accommodations
-    { type: "section", text: { type: "mrkdwn", text: "📝 *Additional Info" } },
+    { type: "section", text: { type: "mrkdwn", text: "*Additional Info*" } },
     {
       type: "input",
       block_id: "notes_accommodations_block",

--- a/backend/src/helpers/slack/ui/analyzeNotesModal.ts
+++ b/backend/src/helpers/slack/ui/analyzeNotesModal.ts
@@ -316,7 +316,7 @@ export const analyzeNotesModal = (
         elements: [
           {
             type: "mrkdwn",
-            text: `📄 *Analyzing:* \`${transcript.filename || 'Unknown'}\``,
+            text: `*Analyzing:* \`${transcript.filename || 'Unknown'}\``,
           },
         ],
       });

--- a/backend/src/helpers/slack/ui/discoverHubModal.ts
+++ b/backend/src/helpers/slack/ui/discoverHubModal.ts
@@ -38,7 +38,7 @@ export const discoverHubModal = {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: ":page_facing_up: *Desk research*\nReports, competitive analysis, background docs",
+        text: "*Desk research*\nReports, competitive analysis, background docs",
       },
       accessory: {
         type: "button",
@@ -54,7 +54,7 @@ export const discoverHubModal = {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: ":studio_microphone: *Stakeholder synthesis*\nInterview transcripts and stakeholder notes",
+        text: "*Stakeholder synthesis*\nInterview transcripts and stakeholder notes",
       },
       accessory: {
         type: "button",
@@ -70,7 +70,7 @@ export const discoverHubModal = {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: ":bar_chart: *Survey synthesis*\nSurvey exports (CSV, Excel)",
+        text: "*Survey synthesis*\nSurvey exports (CSV, Excel)",
       },
       accessory: {
         type: "button",

--- a/backend/src/helpers/slack/ui/discoverTypeModals.ts
+++ b/backend/src/helpers/slack/ui/discoverTypeModals.ts
@@ -27,7 +27,7 @@ export const discoverDeskResearchModal = {
       elements: [
         {
           type: "mrkdwn",
-          text: ":page_facing_up: Upload reports, competitive analysis, or background docs. Qori extracts barriers, metrics, and knowledge gaps.",
+          text: "Upload reports, competitive analysis, or background docs. Qori extracts barriers, metrics, and knowledge gaps.",
         },
       ],
     },
@@ -117,7 +117,7 @@ export const discoverStakeholderModal = {
       elements: [
         {
           type: "mrkdwn",
-          text: ":studio_microphone: Upload interview transcripts or stakeholder notes. Qori extracts constraints, priorities, and alignment gaps.",
+          text: "Upload interview transcripts or stakeholder notes. Qori extracts constraints, priorities, and alignment gaps.",
         },
       ],
     },
@@ -207,7 +207,7 @@ export const discoverSurveyModal = {
       elements: [
         {
           type: "mrkdwn",
-          text: ":bar_chart: Upload survey exports. Qori identifies themes, findings, and demographic patterns.",
+          text: "Upload survey exports. Qori identifies themes, findings, and demographic patterns.",
         },
       ],
     },

--- a/backend/src/helpers/slack/ui/discussionGuideModal.ts
+++ b/backend/src/helpers/slack/ui/discussionGuideModal.ts
@@ -75,7 +75,7 @@ const discussionGuideModal = {
       elements: [
         {
           type: "mrkdwn",
-          text: ":speech_balloon: *{{study_name}}*\nBuilding a session guide from your approved brief.",
+          text: "*{{study_name}}*\nBuilding a session guide from your approved brief.",
         },
       ],
     },

--- a/backend/src/helpers/slack/ui/markChangesCompleteModal.ts
+++ b/backend/src/helpers/slack/ui/markChangesCompleteModal.ts
@@ -55,7 +55,7 @@ const markChangesCompleteModal = (fileName: string, filePath: string, statusId: 
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `🐛 *GitHub:* ${fileName}`,
+        text: `*GitHub:* ${fileName}`,
       },
     },
     {
@@ -69,14 +69,14 @@ const markChangesCompleteModal = (fileName: string, filePath: string, statusId: 
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: requestedBy ? `☑️ Notify ${requestedBy} changes are complete` : '☑️ Notify the user who requested changes',
+        text: requestedBy ? `Notify ${requestedBy} changes are complete` : 'Notify the user who requested changes',
       },
     },
     {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: '☑️ Include link to view updated files',
+        text: 'Include link to view updated files',
       },
     },
     {

--- a/backend/src/helpers/slack/ui/observerGuideDM.ts
+++ b/backend/src/helpers/slack/ui/observerGuideDM.ts
@@ -45,7 +45,7 @@ export const sendObserverGuideDM = async (
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `<${OBSERVER_GUIDELINES_URL}|:book: View Observer Guidelines>`,
+        text: `<${OBSERVER_GUIDELINES_URL}|View Observer Guidelines>`,
       },
     },
     {

--- a/backend/src/helpers/slack/ui/outreach/copyEmailModal.ts
+++ b/backend/src/helpers/slack/ui/outreach/copyEmailModal.ts
@@ -24,7 +24,7 @@ export const copyEmailModal = (params: CopyEmailParams = {}) => {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: "*📄 Email Message Body*\nClick the text below and press Ctrl+A (or Cmd+A) to select all, then Ctrl+C (or Cmd+C) to copy.",
+          text: "*Email Message Body*\nClick the text below and press Ctrl+A (or Cmd+A) to select all, then Ctrl+C (or Cmd+C) to copy.",
         },
       },
       {

--- a/backend/src/helpers/slack/ui/outreach/emailModal.ts
+++ b/backend/src/helpers/slack/ui/outreach/emailModal.ts
@@ -89,7 +89,7 @@ export const emailModal = (params: EmailModalParams = {}) => {
             type: "button",
             text: {
               type: "plain_text",
-              text: "📄 Copy Email (Formatted)",
+              text: "Copy Email (Formatted)",
             },
             action_id: "copy_email_formatted",
             style: "primary",

--- a/backend/src/helpers/slack/ui/outreach/initialRecruitmentModal.ts
+++ b/backend/src/helpers/slack/ui/outreach/initialRecruitmentModal.ts
@@ -50,7 +50,7 @@ export const initialRecruitmentModal = {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*📋 Signup details*",
+        text: "*Signup details*",
       },
     },
     {

--- a/backend/src/helpers/slack/ui/outreach/participantOutreachModal.ts
+++ b/backend/src/helpers/slack/ui/outreach/participantOutreachModal.ts
@@ -38,7 +38,7 @@ export const participantOutreachModal = {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*📬 Message type*",
+        text: "*Message type*",
       },
     },
     {
@@ -55,42 +55,42 @@ export const participantOutreachModal = {
           {
             text: {
               type: "plain_text",
-              text: "📧 Initial recruitment",
+              text: "Initial recruitment",
             },
             value: "initial_recruitment",
           },
           {
             text: {
               type: "plain_text",
-              text: "📅 Session confirmation",
+              text: "Session confirmation",
             },
             value: "session_confirmation",
           },
           {
             text: {
               type: "plain_text",
-              text: "⏰ Session reminder",
+              text: "Session reminder",
             },
             value: "session_reminder",
           },
           {
             text: {
               type: "plain_text",
-              text: "🔄 Rescheduling request",
+              text: "Rescheduling request",
             },
             value: "rescheduling_request",
           },
           {
             text: {
               type: "plain_text",
-              text: "🔔 Follow-up",
+              text: "Follow-up",
             },
             value: "follow_up",
           },
           {
             text: {
               type: "plain_text",
-              text: "🙏 Thank you",
+              text: "Thank you",
             },
             value: "thank_you",
           },

--- a/backend/src/helpers/slack/ui/outreach/reschedulingRequestModal.ts
+++ b/backend/src/helpers/slack/ui/outreach/reschedulingRequestModal.ts
@@ -50,7 +50,7 @@ export const reschedulingRequestModal = {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*🔄 Rescheduling*",
+        text: "*Rescheduling*",
       },
     },
     {

--- a/backend/src/helpers/slack/ui/outreach/sessionConfirmationModal.ts
+++ b/backend/src/helpers/slack/ui/outreach/sessionConfirmationModal.ts
@@ -50,7 +50,7 @@ export const sessionConfirmationModal = {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*📅 Session details*",
+        text: "*Session details*",
       },
     },
     {

--- a/backend/src/helpers/slack/ui/outreach/sessionReminderModal.ts
+++ b/backend/src/helpers/slack/ui/outreach/sessionReminderModal.ts
@@ -50,7 +50,7 @@ export const sessionReminderModal = {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*📅 Session details*",
+        text: "*Session details*",
       },
     },
     {

--- a/backend/src/helpers/slack/ui/outreach/updateParticipantStatusModal.ts
+++ b/backend/src/helpers/slack/ui/outreach/updateParticipantStatusModal.ts
@@ -106,7 +106,7 @@ export const updateParticipantStatusModal = {
       },
       label: {
         type: "plain_text",
-        text: "*👤 Participant*",
+        text: "*Participant*",
       },
       hint: {
         type: "plain_text",
@@ -118,7 +118,7 @@ export const updateParticipantStatusModal = {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*🔄 Update*",
+        text: "*Update*",
       },
     },
     {
@@ -153,7 +153,7 @@ export const updateParticipantStatusModal = {
       },
       label: {
         type: "plain_text",
-        text: "*📝 Update Notes*",
+        text: "*Update Notes*",
       },
     },
     {

--- a/backend/src/helpers/slack/ui/readoutModal.ts
+++ b/backend/src/helpers/slack/ui/readoutModal.ts
@@ -91,8 +91,8 @@ export const buildReadoutModal = (state: ReadoutModalState = {}) => {
           {
             type: 'mrkdwn',
             text: reportType === 'research_readout'
-              ? '📄 *Research Readout* — Comprehensive findings, recommendations, and decisions from all research data'
-              : '🎯 *Targeted Readouts* — Generate audience-specific reports from an existing research readout'
+              ? '*Research Readout* — Comprehensive findings, recommendations, and decisions from all research data'
+              : '*Targeted Readouts* — Generate audience-specific reports from an existing research readout'
           }
         ]
       }
@@ -144,22 +144,22 @@ export const buildReadoutModal = (state: ReadoutModalState = {}) => {
           action_id: 'audience_checkboxes',
           options: [
             {
-              text: { type: 'mrkdwn', text: '*🎨 Designer* — design challenges + ticket candidates' },
+              text: { type: 'mrkdwn', text: '*Designer* — design challenges + ticket candidates' },
               description: { type: 'plain_text', text: 'Creates GitHub Issues after review' },
               value: 'Design Team'
             },
             {
-              text: { type: 'mrkdwn', text: '*⚙️ Engineering* — technical challenges + ticket candidates' },
+              text: { type: 'mrkdwn', text: '*Engineering* — technical challenges + ticket candidates' },
               description: { type: 'plain_text', text: 'Creates GitHub Issues after review' },
               value: 'Engineering Team'
             },
             {
-              text: { type: 'mrkdwn', text: '*♿ Accessibility* — WCAG compliance + ticket candidates' },
+              text: { type: 'mrkdwn', text: '*Accessibility* — WCAG compliance + ticket candidates' },
               description: { type: 'plain_text', text: 'Creates GitHub Issues after review' },
               value: 'Accessibility Team'
             },
             {
-              text: { type: 'mrkdwn', text: '*👔 Leadership* — executive brief (BLUF style)' },
+              text: { type: 'mrkdwn', text: '*Leadership* — executive brief (BLUF style)' },
               description: { type: 'plain_text', text: 'Document only — no tickets' },
               value: 'Executive Leadership'
             }

--- a/backend/src/helpers/slack/ui/requestStudyChangesModal.ts
+++ b/backend/src/helpers/slack/ui/requestStudyChangesModal.ts
@@ -25,7 +25,7 @@ export const requestStudyChangesModal = (fileOptionsArray: FileOption[]) => ({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*📝 Request Changes*\nPlease provide specific feedback about what needs to be changed.",
+        text: "*Request Changes*\nPlease provide specific feedback about what needs to be changed.",
       },
     },
     {
@@ -119,7 +119,7 @@ export const requestStudyChangesModal = (fileOptionsArray: FileOption[]) => ({
       elements: [
         {
           type: "mrkdwn",
-          text: "💡 *Tip:* Be specific about what needs changing. The researcher will receive your feedback and can ask questions if needed.",
+          text: "*Tip:* Be specific about what needs changing. The researcher will receive your feedback and can ask questions if needed.",
         },
       ],
     },

--- a/backend/src/helpers/slack/ui/researchPlanGeneratorModal.ts
+++ b/backend/src/helpers/slack/ui/researchPlanGeneratorModal.ts
@@ -43,7 +43,7 @@ export const researchPlanGeneratorModal = {
       elements: [
         {
           type: "mrkdwn",
-          text: ":clipboard: *{{study_name}}*\nGenerating an execution plan from your approved brief.",
+          text: "*{{study_name}}*\nGenerating an execution plan from your approved brief.",
         },
       ],
     },

--- a/backend/src/helpers/slack/ui/researchShareoutModal.ts
+++ b/backend/src/helpers/slack/ui/researchShareoutModal.ts
@@ -40,42 +40,42 @@ export const researchShareoutModal = {
           {
             text: {
               type: "plain_text",
-              text: "🎯 Stakeholder Summary – 1-minute TL;DR for executives",
+              text: "Stakeholder Summary – 1-minute TL;DR for executives",
             },
             value: "stakeholder_summary",
           },
           {
             text: {
               type: "plain_text",
-              text: "📊 Executive Readout – High-level findings presentation",
+              text: "Executive Readout – High-level findings presentation",
             },
             value: "executive_readout",
           },
           {
             text: {
               type: "plain_text",
-              text: "👥 Team Shareout – Internal research presentation",
+              text: "Team Shareout – Internal research presentation",
             },
             value: "team_shareout",
           },
           {
             text: {
               type: "plain_text",
-              text: "📄 Research Report – Detailed findings document",
+              text: "Research Report – Detailed findings document",
             },
             value: "research_report",
           },
           {
             text: {
               type: "plain_text",
-              text: "🏛️ Policy Brief – Recommendations for government",
+              text: "Policy Brief – Recommendations for government",
             },
             value: "policy_brief",
           },
           {
             text: {
               type: "plain_text",
-              text: "📐 Design Requirements – Product specifications",
+              text: "Design Requirements – Product specifications",
             },
             value: "design_requirements",
           },
@@ -89,7 +89,7 @@ export const researchShareoutModal = {
       type: "header",
       text: {
         type: "plain_text",
-        text: "📋 Study Context",
+        text: "Study Context",
       },
     },
     {
@@ -146,7 +146,7 @@ export const researchShareoutModal = {
       type: "header",
       text: {
         type: "plain_text",
-        text: "📑 Research Findings",
+        text: "Research Findings",
       },
     },
     {
@@ -174,7 +174,7 @@ export const researchShareoutModal = {
       type: "header",
       text: {
         type: "plain_text",
-        text: "📤 Delivery",
+        text: "Delivery",
       },
     },
     {
@@ -215,7 +215,7 @@ export const researchShareoutModal = {
       elements: [
         {
           type: "mrkdwn",
-          text: "💡 *Key Difference:* Shareouts are for *already-analyzed* findings, not raw data. Use `/run-template` for synthesis, then return here to share.",
+          text: "*Key Difference:* Shareouts are for *already-analyzed* findings, not raw data. Use `/run-template` for synthesis, then return here to share.",
         },
       ],
     },

--- a/backend/src/helpers/slack/ui/sessionNotesModal.ts
+++ b/backend/src/helpers/slack/ui/sessionNotesModal.ts
@@ -170,7 +170,7 @@ const manualBlocks = (preserved?: PreservedInputs) => {
       elements: [
         {
           type: "mrkdwn",
-          text: "💡 *Tips for better notes:*\n• Quote reactions: `\"This is confusing\"`\n• Note timestamps: `Minute 5: User struggled`\n• Describe tasks: `Task 1 - Find benefits (3 min)`\n• Flag issues: `VoiceOver didn't announce button`\n• Capture emotions: `User sighed, frustrated`"
+          text: "*Tips for better notes:*\n• Quote reactions: `\"This is confusing\"`\n• Note timestamps: `Minute 5: User struggled`\n• Describe tasks: `Task 1 - Find benefits (3 min)`\n• Flag issues: `VoiceOver didn't announce button`\n• Capture emotions: `User sighed, frustrated`"
         }
       ]
     },

--- a/backend/src/helpers/slack/ui/studyResultBlocks.ts
+++ b/backend/src/helpers/slack/ui/studyResultBlocks.ts
@@ -82,7 +82,7 @@ export const generateStudyResultBlocks = (
       type: 'header',
       text: {
         type: 'plain_text',
-        text: `🗓️ ${studyName}${documentTypeLabel ? ` - ${documentTypeLabel}` : ''}`,
+        text: `${studyName}${documentTypeLabel ? ` - ${documentTypeLabel}` : ''}`,
         emoji: true,
       },
     },
@@ -128,7 +128,7 @@ const generateChannelBlocks = (studyName: string, study: StudyWithRoles | null, 
       type: 'header',
       text: {
         type: 'plain_text',
-        text: `🗓️ ${studyName} - ${documentType.charAt(0).toUpperCase() + documentType.slice(1)} Created`,
+        text: `${studyName} - ${documentType.charAt(0).toUpperCase() + documentType.slice(1)} Created`,
         emoji: true,
       },
     },
@@ -235,7 +235,7 @@ export const sendStudyResultMessage = async (
 
           await client.chat.postMessage({
             channel: im.channel.id,
-            text: `🔔 New ${documentType} for *${studyName}* - Please review and take action`,
+            text: `New ${documentType} for *${studyName}* - Please review and take action`,
             blocks: blocksWithContext as unknown as KnownBlock[],
           });
           console.log(`✅ Sent approval request to ${roleLabel} ${approver.userId}`);

--- a/backend/src/helpers/slack/ui/studySetupModal.ts
+++ b/backend/src/helpers/slack/ui/studySetupModal.ts
@@ -45,13 +45,9 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
       type: "plain_text",
       text: "Plan your study",
     },
-    submit: {
-      type: "plain_text",
-      text: "Done",
-    },
     close: {
       type: "plain_text",
-      text: "Close",
+      text: "Cancel",
     },
     blocks: [
       {
@@ -90,7 +86,7 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
         type: "section",
         text: {
           type: "mrkdwn",
-          text: ":clipboard: *Research plan*\nTurns your brief into a stakeholder-ready plan",
+          text: "*Research plan*\nTurns your brief into a stakeholder-ready plan",
         },
         accessory: {
           type: "button",
@@ -106,7 +102,7 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
         type: "section",
         text: {
           type: "mrkdwn",
-          text: ":speech_balloon: *Discussion guide*\nSession script grounded in your objectives",
+          text: "*Discussion guide*\nSession script grounded in your objectives",
         },
         accessory: {
           type: "button",

--- a/backend/src/helpers/slack/ui/transcriptReviewModal.ts
+++ b/backend/src/helpers/slack/ui/transcriptReviewModal.ts
@@ -83,7 +83,7 @@ export const buildTranscriptReviewModal = (params: TranscriptReviewParams): View
       // Header
       {
         type: 'header',
-        text: { type: 'plain_text', text: '🔍 PII Review Required', emoji: true }
+        text: { type: 'plain_text', text: 'PII Review Required', emoji: true }
       },
       {
         type: 'context',
@@ -119,7 +119,7 @@ export const buildTranscriptReviewModal = (params: TranscriptReviewParams): View
         elements: [
           {
             type: 'button',
-            text: { type: 'plain_text', text: '📄 Review Full Transcript on GitHub', emoji: true },
+            text: { type: 'plain_text', text: 'Review Full Transcript on GitHub', emoji: true },
             url: fileUrl,
             action_id: 'review_full_transcript_link',
             style: 'primary'

--- a/backend/src/helpers/slack/ui/uploadNotesModal.ts
+++ b/backend/src/helpers/slack/ui/uploadNotesModal.ts
@@ -31,7 +31,7 @@ export const uploadNotesModal = (participants: Participant[] = []) => {
     },
     "submit": {
       "type": "plain_text",
-      "text": "📤 Upload",
+      "text": "Upload",
       "emoji": true
     },
     "close": {
@@ -42,7 +42,7 @@ export const uploadNotesModal = (participants: Participant[] = []) => {
     "blocks": [
       {
         "type": "header",
-        "text": { "type": "plain_text", "text": "📂 Destination & Participant", "emoji": true }
+        "text": { "type": "plain_text", "text": "Destination & Participant", "emoji": true }
       },
 
       /* Folder */
@@ -85,7 +85,7 @@ export const uploadNotesModal = (participants: Participant[] = []) => {
           {
             "type": "button",
             "action_id": "select_session_notes",
-            "text": { "type": "plain_text", "text": "📝 Take Notes", "emoji": true },
+            "text": { "type": "plain_text", "text": "Take Notes", "emoji": true },
             "style": "primary",
             "value": "session_notes"
           }
@@ -115,7 +115,7 @@ export const uploadNotesModal = (participants: Participant[] = []) => {
       {
         "type": "section",
         "block_id": "processing_info_title",
-        "text": { "type": "mrkdwn", "text": "🤖 *Processing Details*" }
+        "text": { "type": "mrkdwn", "text": "*Processing Details*" }
       },
       {
         "type": "context",
@@ -131,7 +131,7 @@ export const uploadNotesModal = (participants: Participant[] = []) => {
         "block_id": "destination_preview",
         "text": {
           "type": "mrkdwn",
-          "text": "📁 `{project}/{study}/03-fieldwork/[folder]/[participant]-[type]-[date].[ext]`"
+          "text": "`{project}/{study}/03-fieldwork/[folder]/[participant]-[type]-[date].[ext]`"
         }
       },
 

--- a/backend/src/services/github-webhook.service.ts
+++ b/backend/src/services/github-webhook.service.ts
@@ -98,10 +98,10 @@ class GithubWebhookService {
 
           // Compose Slack message blocks
           const blocks = [
-            { type: 'section', text: { type: 'mrkdwn', text: `📝 *Change Request from* <@${requestedBy || 'unknown'}>` } },
+            { type: 'section', text: { type: 'mrkdwn', text: `*Change Request from* <@${requestedBy || 'unknown'}>` } },
             { type: 'section', text: { type: 'mrkdwn', text: previousReason } },
             { type: 'divider' },
-            { type: 'section', text: { type: 'mrkdwn', text: '🔄 *GitHub Activity Detected:*' } },
+            { type: 'section', text: { type: 'mrkdwn', text: '*GitHub Activity Detected:*' } },
             { type: 'section', text: { type: 'mrkdwn', text: `• ${commitMsg}` } },
             { type: 'divider' },
             {


### PR DESCRIPTION
## Summary
- **PR #241**: Modal builders — removed decorative emoji from 26 static payload files
- **PR #240**: Handlers/DMs — removed decorative emoji from 19 dynamic string files
- ~100 decorative emoji removed across ~45 files
- All functional emoji preserved (✅❌⚠️🔴🟡🟢:lock:🗑️)
- §5 checklist and §7 violation log updated with PR numbers
- Also includes: QD app ID update (PR #238 commit) and as-unknown cast fix

## What stays
Severity dots (🔴🟡🟢), status glyphs (✅❌⚠️), access indicators (:lock:), action labels (🗑️)

## Test plan
- [ ] Typecheck + 141 unit tests pass (verified in both PRs)
- [ ] Modal surfaces render without emoji prefix artifacts
- [ ] DMs and ephemeral messages read cleanly without double spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)