### PR TITLE
fix: plan launcher input→section block (Slack submit requirement)

### DIFF
--- a/backend/src/helpers/slack/ui/studySetupModal.ts
+++ b/backend/src/helpers/slack/ui/studySetupModal.ts
@@ -63,13 +63,13 @@ export function studySetupModalPlanStudy(studies: StudyOption[] | null, channelI
         type: "divider",
       },
       {
-        type: "input",
+        type: "section",
         block_id: "study_selection",
-        label: {
-          type: "plain_text",
-          text: "Which study?",
+        text: {
+          type: "mrkdwn",
+          text: "*Which study?*",
         },
-        element: {
+        accessory: {
           type: "static_select",
           action_id: "study_select",
           placeholder: {


### PR DESCRIPTION
## Summary
Slack requires `submit` when any `input` block exists. The emoji sweep (PR #242) removed the vestigial submit button but left the study select as an `input` block, causing `invalid_arguments` on `/qori-plan`.

Fix: convert to `section` + `static_select` accessory (Discovery Hub pattern). Handler reads from `body.actions[0]`, not `view.state.values`, so no handler change needed.

## Test plan
- [ ] `/qori-plan` opens modal without error
- [ ] Study select works and fires `study_select` action
- [ ] "Create" buttons open plan/DG modals

🤖 Generated with [Claude Code](https://claude.com/claude-code)