### PR TITLE
fix(modals): B2 — outreach label and structure fixes

### DIFF
--- a/backend/src/helpers/slack/commands/participantOutreachHandler.ts
+++ b/backend/src/helpers/slack/commands/participantOutreachHandler.ts
@@ -38,7 +38,7 @@ async function participantOutreachHandler({ ack, body, client, command }: SlackC
       studyDropdownBlock = {
         type: 'input',
         block_id: 'study_select_block',
-        label: { type: 'plain_text', text: 'Select an existing study:' },
+        label: { type: 'plain_text', text: 'Study' },
         element: {
           type: 'static_select',
           action_id: 'study_select',
@@ -51,7 +51,8 @@ async function participantOutreachHandler({ ack, body, client, command }: SlackC
     // Only show the dropdown at the top
     let blocks = JSON.parse(JSON.stringify(participantOutreachModal.blocks));
     if (studyDropdownBlock) {
-      blocks.unshift(studyDropdownBlock);
+      // Insert after the intro context block so purpose sentence stays at top
+      blocks.splice(1, 0, studyDropdownBlock);
     }
     await client.views.open({
       trigger_id: body.trigger_id,

--- a/backend/src/helpers/slack/ui/outreach/participantOutreachModal.ts
+++ b/backend/src/helpers/slack/ui/outreach/participantOutreachModal.ts
@@ -11,7 +11,7 @@ export const participantOutreachModal = {
   },
   submit: {
     type: "plain_text",
-    text: "Next",
+    text: "Continue",
   },
   blocks: [
     {
@@ -35,18 +35,11 @@ export const participantOutreachModal = {
       type: "divider",
     },
     {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Message type*",
-      },
-    },
-    {
       type: "input",
       block_id: "message_type_block",
       label: {
         type: "plain_text",
-        text: "Select message type *",
+        text: "Message type",
       },
       element: {
         type: "radio_buttons",


### PR DESCRIPTION
## Summary
- Study field: `"Select an existing study:"` → `"Study"` (R3 — no imperative, no colon)
- Purpose sentence ("Create professional messages…") stays at top intro position — study select now inserted after context block, not before
- Message type: removed doubled section header + input label; single `"Message type"` label (R3)
- Submit: `"Next"` → `"Continue"` (R2)

## Test plan
- [ ] Typecheck passes (verified)
- [ ] 141 unit tests pass (verified)
- [ ] Verify outreach modal layout in dev workspace (purpose → study → divider → message type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)