### PR TITLE
fix(modals): B3 — Add Observer button and cap-line

### DIFF
--- a/backend/src/helpers/slack/ui/addObserverModal.ts
+++ b/backend/src/helpers/slack/ui/addObserverModal.ts
@@ -91,7 +91,7 @@ const buildAddObserverModal = (sessions: SessionOption[], channelName: string) =
       elements: [
         {
           type: 'mrkdwn',
-          text: `Cap: ${MAX_OBSERVERS} total per session · 1 Note-taker · 1 Stakeholder · 2 PM Observers · 3 Silent Observers. Both paths trigger the observer guide DM.`,
+          text: `Up to ${MAX_OBSERVERS} observers per session, in any mix. Role limits within those ${MAX_OBSERVERS}: max 1 Note-taker, 1 Stakeholder, 2 PM Observers. Both paths trigger the observer guide DM.`,
         },
       ],
     },
@@ -101,7 +101,7 @@ const buildAddObserverModal = (sessions: SessionOption[], channelName: string) =
     type: 'modal',
     callback_id: 'add_observer_modal',
     title: { type: 'plain_text', text: 'Add Observer' },
-    submit: { type: 'plain_text', text: 'Done' },
+    submit: { type: 'plain_text', text: 'Add Observer' },
     close: { type: 'plain_text', text: 'Cancel' },
     blocks,
   } as unknown as View;


### PR DESCRIPTION
## Summary
- Button: `"Done"` → `"Add Observer"` (R2 — action-oriented submit)
- Cap-line: reworded to clarify that role limits are sub-caps within the 3-total ceiling, not additive slots. Silent Observer line dropped (sub-cap equals total cap — carries no information)
- Enforced behavior unchanged (`session_observer.service.ts:16-22`)

## Test plan
- [ ] Typecheck passes (verified)
- [ ] 141 unit tests pass (verified)
- [ ] Verify cap-line text renders correctly in dev workspace
- [ ] Try adding 3 observers to a session — confirm enforcement unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)