### PR TITLE
fix(modals): B5 — Update Participant + Session Notes

### DIFF
--- a/backend/src/helpers/slack/ui/outreach/updateParticipantStatusModal.ts
+++ b/backend/src/helpers/slack/ui/outreach/updateParticipantStatusModal.ts
@@ -16,7 +16,7 @@ export const updateParticipantStatusModal = {
   },
   submit: {
     type: "plain_text",
-    text: "Update Status",
+    text: "Update Participant",
   },
   close: {
     type: "plain_text",
@@ -57,11 +57,10 @@ export const updateParticipantStatusModal = {
           type: "button",
           text: {
             type: "plain_text",
-            text: "Load Participants for Selected Study",
+            text: "Load Participants",
             emoji: true,
           },
           action_id: "load_participants_button",
-          style: "primary",
           confirm: {
             title: {
               type: "plain_text",
@@ -106,7 +105,7 @@ export const updateParticipantStatusModal = {
       },
       label: {
         type: "plain_text",
-        text: "*Participant*",
+        text: "Participant",
       },
       hint: {
         type: "plain_text",
@@ -114,13 +113,6 @@ export const updateParticipantStatusModal = {
       },
     },
     { type: "divider" },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Update*",
-      },
-    },
     {
       type: "input",
       block_id: "status_update_block",
@@ -135,7 +127,7 @@ export const updateParticipantStatusModal = {
       },
       label: {
         type: "plain_text",
-        text: "New Status",
+        text: "Status",
       },
     },
     {
@@ -153,7 +145,7 @@ export const updateParticipantStatusModal = {
       },
       label: {
         type: "plain_text",
-        text: "*Update Notes*",
+        text: "Notes",
       },
     },
     {

--- a/backend/src/helpers/slack/ui/sessionNotesModal.ts
+++ b/backend/src/helpers/slack/ui/sessionNotesModal.ts
@@ -86,7 +86,7 @@ export const buildSessionNotesView = (state: SessionNotesState = {}) => {
     callback_id: 'session_notes_submit',
     private_metadata: JSON.stringify(essentialData),
     title: { type: 'plain_text', text: 'Session Notes' },
-    submit: { type: 'plain_text', text: isManual ? 'Submit to GitHub' : 'Process & Submit' },
+    submit: { type: 'plain_text', text: isManual ? 'Submit to GitHub' : 'Submit Transcript' },
     close: { type: 'plain_text', text: 'Cancel' },
     blocks: [
       // Tabs
@@ -97,12 +97,10 @@ export const buildSessionNotesView = (state: SessionNotesState = {}) => {
           {
             type: 'button', action_id: 'tab_manual', value: 'manual',
             text: { type: 'plain_text', text: 'Manual Notes' },
-            style: isManual ? 'primary' : undefined
           },
           {
             type: 'button', action_id: 'tab_upload', value: 'upload',
             text: { type: 'plain_text', text: 'Upload Transcript' },
-            style: !isManual ? 'primary' : undefined
           }
         ]
       },
@@ -155,7 +153,7 @@ export const buildSessionNotesView = (state: SessionNotesState = {}) => {
         }
       },
 
-      ...(isManual ? manualBlocks(state.preserved) : uploadBlocks(method, state.preserved)),
+      ...(isManual ? manualBlocks(state.preserved) : uploadBlocks(method, state.preserved, state.session?.session_id)),
 
     ]
   } as unknown as View;
@@ -202,7 +200,7 @@ const manualBlocks = (preserved?: PreservedInputs) => {
   ];
 }
 
-const uploadBlocks = (method: string, preserved?: PreservedInputs) => {
+const uploadBlocks = (method: string, preserved?: PreservedInputs, participantCode?: string) => {
   const filesSelected = method === 'files';
   return [
     // PII Scrubbing Section
@@ -215,7 +213,7 @@ const uploadBlocks = (method: string, preserved?: PreservedInputs) => {
       elements: [
         {
           type: 'mrkdwn',
-          text: '⚠️ *Privacy protection:* Enter the participant\'s real name below. It will be replaced with their code (e.g., PT-001) in the transcript before saving. *This name is NOT stored* — it\'s used only for find/replace, then discarded.'
+          text: `⚠️ *Privacy protection:* Enter the participant's real name below. It will be replaced with their code (${participantCode || 'e.g., PT-001'}) in the transcript before saving. *This name is not stored* — it's used only for find/replace, then discarded.`
         }
       ]
     },
@@ -223,8 +221,8 @@ const uploadBlocks = (method: string, preserved?: PreservedInputs) => {
       type: 'input',
       block_id: 'pii_real_name',
       optional: true,
-      label: { type: 'plain_text', text: 'Participant\'s real name (for scrubbing)' },
-      hint: { type: 'plain_text', text: 'e.g., "David Chen" — will be replaced with PT-001. Leave blank if transcript is already anonymized.' },
+      label: { type: 'plain_text', text: 'Participant\'s real name' },
+      hint: { type: 'plain_text', text: `Will be replaced with ${participantCode || 'participant code'}. Leave blank if already anonymized.` },
       element: {
         type: 'plain_text_input',
         action_id: 'real_name_input',
@@ -233,13 +231,12 @@ const uploadBlocks = (method: string, preserved?: PreservedInputs) => {
       }
     },
     { type: 'divider' },
-    { type: 'section', text: { type: 'mrkdwn', text: '*Select Input Method*' } },
     // Files
     {
       type: 'input',
       block_id: 'transcript_files',
       optional: true,
-      label: { type: 'plain_text', text: 'Upload File' },
+      label: { type: 'plain_text', text: 'Upload file' },
       hint: { type: 'plain_text', text: 'You can attach multiple files. Common types: txt, md, pdf, docx, mp3, wav.' },
       element: {
         type: 'file_input',
@@ -315,7 +312,7 @@ const uploadBlocks = (method: string, preserved?: PreservedInputs) => {
       type: 'input',
       block_id: 'transcript_paste',
       optional: true,
-      label: { type: 'plain_text', text: 'Or paste Transcript' },
+      label: { type: 'plain_text', text: 'Or paste transcript' },
       element: {
         type: 'plain_text_input', action_id: 'text', multiline: true,
         placeholder: { type: 'plain_text', text: 'Paste transcript text here...' },


### PR DESCRIPTION
## Summary
**Update Participant:**
- Button aligned to title: both say "Update Participant"
- "Load Participants for Selected Study" → "Load Participants", primary style removed (R10)
- Removed literal asterisks in plain_text labels and redundant section header (R3)

**Session Notes:**
- "Process & Submit" → "Submit Transcript" (R2)
- Tab buttons: removed green `primary` style (R10 — tabs aren't primary actions)
- PII: removed "(for scrubbing)" from label (R11), replaced hardcoded "PT-001" with dynamic participant code
- Collapsed "Select Input Method" header (R3), normalized label casing

## Test plan
- [ ] Typecheck passes (verified)
- [ ] 141 unit tests pass (verified)
- [ ] Verify Update Participant modal in dev
- [ ] Verify Session Notes tab switching still works without primary style
- [ ] Verify PII scrubbing text shows actual participant code when session is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)