### PR TITLE
fix(templates): validity checklists + metadata ruling (5 templates) + delta status

### DIFF
--- a/config/prompts/affinity_mapping.yaml
+++ b/config/prompts/affinity_mapping.yaml
@@ -4,7 +4,7 @@
 id: affinity_mapping
 name: run_affinity_mapping
 label: "Affinity Mapping"
-version: "v7.0"
+version: "v7.1"
 
 description: |
   Group qualitative data into research-grounded themes using inductive
@@ -15,7 +15,7 @@ description: |
 
 author: Qori R&D
 created: 2025-06-27
-last_updated: 2026-05-20
+last_updated: 2026-08-04
 
 # ═══════════════════════════════════════════════════════════
 # CONFIGURATION
@@ -317,9 +317,23 @@ output_template: |
 
   ---
 
+  <details>
+  <summary><strong>Validity checklist</strong></summary>
+
+  | Check | Result |
+  |-------|--------|
+  | Themes grounded in nugget evidence | |
+  | No single-nugget themes | |
+  | Cross-participant patterns identified | |
+  | Unexpected patterns documented | |
+  | Nugget IDs traceable to source sessions | |
+
+  </details>
+
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This affinity analysis emits variables for downstream templates.
 
@@ -336,6 +350,8 @@ output_template: |
   | atomic_nugget_detail | session_summary | Verbatim quotes, behaviors, context |
   | target_barriers | research_brief | Barrier validation grounding |
   | research_questions | research_brief | Research question addressing |
+
+  </details>
 
 output_options:
   path: "04-synthesis/"

--- a/config/prompts/desk_research.yaml
+++ b/config/prompts/desk_research.yaml
@@ -4,7 +4,7 @@
 id: desk_research
 name: run_desk_research
 label: "Desk Research"
-version: v7.0
+version: v7.1
 
 description: |
   Analyze uploaded research documents and generate a synthesis with key
@@ -15,7 +15,7 @@ description: |
 
 author: Qori R&D
 created: 2025-08-27
-last_updated: 2026-05-19
+last_updated: 2026-08-04
 
 # ═══════════════════════════════════════════════════════════
 # CONFIGURATION
@@ -355,9 +355,22 @@ output_template: |
 
   ---
 
+  <details>
+  <summary><strong>Validity checklist</strong></summary>
+
+  | Check | Result |
+  |-------|--------|
+  | All source documents cited | |
+  | Themes supported by multiple sources | |
+  | Knowledge gaps are actionable | |
+  | No claims beyond source material | |
+
+  </details>
+
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This desk research emits discovery variables for downstream templates.
 
@@ -371,6 +384,8 @@ output_template: |
   | source_artifacts | Document metadata for provenance tracking |
 
   **Documents analyzed:** {{document_count}}
+
+  </details>
 
 output_options:
   filename: "{{topic_slug}}-desk-research-{{current_date_iso}}.md"

--- a/config/prompts/research_brief.yaml
+++ b/config/prompts/research_brief.yaml
@@ -4,18 +4,19 @@
 id: research_brief
 name: create_research_brief
 label: "Research Brief"
-version: "v7.0"
+version: "v7.1"
 
 description: |
   Cascade-aware stakeholder approval document for research scope.
   Brief = approval gate. Plan = execution doc.
+  v7.1: Validity checklist (empty cells), cascade summary collapsed per metadata ruling.
   v7.0: Interleaved Handlebars/AI architecture — computed values render
   mechanically, LLM only writes bounded prose sections. Handler assigns
   barrier/question IDs via pre-render JSON tasks (Option C).
 
 author: Qori R&D
 created: 2025-06-26
-last_updated: 2026-05-19
+last_updated: 2026-08-04
 
 # ═══════════════════════════════════════════════════════════
 # CONFIGURATION
@@ -517,9 +518,24 @@ output_template: |
 
   ---
 
+  <details>
+  <summary><strong>Validity checklist</strong></summary>
+
+  | Check | Result |
+  |-------|--------|
+  | Problem statement grounds target barriers | |
+  | Learning objectives map to research questions | |
+  | Methodology fits the research questions | |
+  | Participant approach addresses criteria | |
+  | Discovery sources cited where used | |
+  | Out of scope is explicit | |
+
+  </details>
+
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This brief establishes the research scope for downstream templates.
 
@@ -542,6 +558,8 @@ output_template: |
 
   Full discovery artifacts: see `_discovery/` in study repository.
   {{/if}}
+
+  </details>
 
 output_options:
   path: "01-brief/"

--- a/config/prompts/stakeholder_synthesis.yaml
+++ b/config/prompts/stakeholder_synthesis.yaml
@@ -4,7 +4,7 @@
 id: stakeholder_synthesis
 name: synthesize_stakeholder_interviews
 label: "Stakeholder Synthesis"
-version: "v7.0"
+version: "v7.1"
 
 description: |
   Synthesize internal stakeholder interviews into findings-grade
@@ -15,7 +15,7 @@ description: |
 
 author: Qori R&D
 created: 2026-01-08
-last_updated: 2026-05-20
+last_updated: 2026-08-04
 
 # ═══════════════════════════════════════════════════════════
 # CONFIGURATION
@@ -359,15 +359,15 @@ output_template: |
   <details>
   <summary><strong>Validity checklist</strong></summary>
 
-  | Criterion | Verified |
-  |-----------|:---:|
-  | Quotes verbatim from interview transcripts | ✓ |
-  | Role-only attribution preserved (no real names) | ✓ |
-  | Confidence declared per section | ✓ |
-  | Constraints triangulated across stakeholder perspectives where possible | ✓ |
-  | Alignment gaps explicitly surfaced | ✓ |
-  | Open questions documented for follow-up | ✓ |
-  | Recommendations connect to specific constraints | ✓ |
+  | Check | Result |
+  |-------|--------|
+  | Quotes verbatim from interview transcripts | |
+  | Role-only attribution preserved (no real names) | |
+  | Confidence declared per section | |
+  | Constraints triangulated across stakeholder perspectives | |
+  | Alignment gaps explicitly surfaced | |
+  | Open questions documented for follow-up | |
+  | Recommendations connect to specific constraints | |
 
   </details>
 
@@ -386,9 +386,8 @@ output_template: |
 
   ---
 
-  ---
-
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This stakeholder synthesis emits variables for downstream templates.
 
@@ -402,6 +401,8 @@ output_template: |
   | system_failure_modes | System dynamics with failure points |
 
   **Stakeholders analyzed:** {{document_count}}
+
+  </details>
 
 output_options:
   path: "{{project_slug}}/00-discovery/"

--- a/config/prompts/survey_synthesis.yaml
+++ b/config/prompts/survey_synthesis.yaml
@@ -4,7 +4,7 @@
 id: survey_synthesis
 name: survey_response_synthesizer
 label: "Survey Synthesis"
-version: "v7.0"
+version: "v7.1"
 
 description: |
   Analyze open-ended survey responses using thematic analysis.
@@ -14,7 +14,7 @@ description: |
 
 author: Qori R&D
 created: 2025-08-11
-last_updated: 2026-05-20
+last_updated: 2026-08-04
 
 # ═══════════════════════════════════════════════════════════
 # CONFIGURATION
@@ -341,9 +341,22 @@ output_template: |
 
   ---
 
+  <details>
+  <summary><strong>Validity checklist</strong></summary>
+
+  | Check | Result |
+  |-------|--------|
+  | All survey data files referenced | |
+  | Themes supported by response patterns | |
+  | Sentiment analysis grounded in data | |
+  | Knowledge gaps are actionable | |
+
+  </details>
+
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This survey synthesis emits discovery variables for downstream templates.
 
@@ -357,6 +370,8 @@ output_template: |
   | knowledge_gaps | Questions the survey couldn't answer |
 
   **Files analyzed:** {{document_count}}
+
+  </details>
 
 output_options:
   path: "{{project_slug}}/00-discovery/"

--- a/docs/designer-readout-restructure-delta.md
+++ b/docs/designer-readout-restructure-delta.md
@@ -1,7 +1,7 @@
 # Designer Readout Restructure Delta: v1.1 to v7.0 Conformance
 
 **Date:** 2026-05-20
-**Status:** Proposed (awaiting approval before implementation)
+**Status:** Implemented (2026-05-20). Confirmed by conformance audit 2026-08-04 — all 10 proposed changes applied.
 **Reference:** `affinity_mapping.yaml` v7.0, `persona_generator.yaml` v7.0, ADR 0005/0016
 
 ---


### PR DESCRIPTION
## Summary
**Validity checklists (empty cells)** added to 4 templates: research_brief (6 criteria), affinity_mapping (5), desk_research (4), survey_synthesis (4).

**stakeholder_synthesis v7.1:** Validity checklist pre-populated ✓ marks → empty cells (LLM self-certification is the fabrication pattern; human reviewer fills these). Cascade summary collapsed per metadata ruling.

**Metadata ruling** applied to all 5: cascade summary wrapped in `<details>` titled "Research provenance".

**designer-readout-restructure-delta.md:** Status "Proposed" → "Implemented (2026-05-20)" — confirmed by conformance audit.

## Test plan
- [ ] Typecheck passes (verified)
- [ ] 141 unit tests pass (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)