### PR TITLE
fix(templates): metadata ruling — cascade summary → collapsed details (10 templates)

### DIFF
--- a/config/prompts/accessibility_readout.yaml
+++ b/config/prompts/accessibility_readout.yaml
@@ -359,7 +359,8 @@ output_template: |
 
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This accessibility readout emits variables for downstream templates.
 
@@ -376,6 +377,8 @@ output_template: |
   | atomic_nugget_detail | session_summary | Verbatim AT user quotes |
   | personas | persona_generator | AT user context |
   | target_barriers | research_brief | Accessibility-flagged barriers |
+
+  </details>
 
 output_options:
   path: "05-readouts/"

--- a/config/prompts/design_opportunity_generator.yaml
+++ b/config/prompts/design_opportunity_generator.yaml
@@ -377,7 +377,8 @@ output_template: |
 
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This opportunity analysis emits variables for structural completeness. Replace strategy — one analysis per study, not per-participant pool.
 
@@ -397,6 +398,8 @@ output_template: |
   | validated_jobs | jobs_to_be_done | Progress-focused job framing |
   | target_barriers | research_brief | Barrier addressing |
   | research_questions | research_brief | Question addressing |
+
+  </details>
 
 output_options:
   path: "04-synthesis/"

--- a/config/prompts/designer_readout.yaml
+++ b/config/prompts/designer_readout.yaml
@@ -362,7 +362,8 @@ output_template: |
 
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This designer readout emits variables for downstream templates.
 
@@ -380,6 +381,8 @@ output_template: |
   | journey_stages | journey_mapping | Flow context for interventions |
   | validated_themes | affinity_mapping | Thematic pattern references |
   | target_barriers | research_brief | Barrier context |
+
+  </details>
 
 output_options:
   path: "05-readouts/"

--- a/config/prompts/engineering_readout.yaml
+++ b/config/prompts/engineering_readout.yaml
@@ -366,7 +366,8 @@ output_template: |
 
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This engineering readout emits variables for downstream templates.
 
@@ -384,6 +385,8 @@ output_template: |
   | personas | persona_generator | User impact context |
   | target_barriers | research_brief | Barrier context |
   | methodology_selection | research_brief | Study methodology context |
+
+  </details>
 
 output_options:
   path: "05-readouts/"

--- a/config/prompts/jobs_to_be_done.yaml
+++ b/config/prompts/jobs_to_be_done.yaml
@@ -331,7 +331,8 @@ output_template: |
 
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This JTBD analysis emits variables for downstream templates. Replace strategy — one analysis per study, not per-participant pool.
 
@@ -348,6 +349,8 @@ output_template: |
   | validated_themes | affinity_mapping | Job-theme linking |
   | target_barriers | research_brief | Barrier relationship marking |
   | research_questions | research_brief | Question addressing |
+
+  </details>
 
 output_options:
   path: "04-synthesis/"

--- a/config/prompts/journey_mapping.yaml
+++ b/config/prompts/journey_mapping.yaml
@@ -289,23 +289,6 @@ ai_generation_tasks:
 
       ---
 
-      {% if upstream_atomic_nugget_core %}
-      ## Cascade summary
-
-      This journey map synthesizes behavioral sequences from upstream research.
-
-      | Source data | Count |
-      |-------------|-------|
-      | Sessions analyzed | [n] |
-      | Nugget pool size | [n] |
-      | Validated themes available | [n or 0] |
-      | Personas available | [n or 0] |
-      | Target barriers under consideration | [n or 0] |
-
-      ---
-
-      {% endif %}
-
       ## 01 &nbsp;&nbsp; [Stage Title — Descriptive]
 
       [1-2 sentence description of what happens at this stage]

--- a/config/prompts/leadership_readout.yaml
+++ b/config/prompts/leadership_readout.yaml
@@ -259,7 +259,8 @@ output_template: |
 
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This leadership brief emits variables for potential downstream consumption.
 
@@ -276,6 +277,8 @@ output_template: |
   | decision_inputs | research_readout | Decision frame |
   | business_context | research_brief | Business pressures |
   | methodology_selection | research_brief | Study methodology context |
+
+  </details>
 
 output_options:
   path: "05-readouts/"

--- a/config/prompts/persona_generator.yaml
+++ b/config/prompts/persona_generator.yaml
@@ -351,7 +351,8 @@ output_template: |
 
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This persona generation emits variables for downstream templates.
 
@@ -370,6 +371,8 @@ output_template: |
   | participant_metadata | session_summary | Demographics for persona attributes |
   | target_barriers | research_brief | Barrier impact marking |
   | research_questions | research_brief | Question addressing |
+
+  </details>
 
 output_options:
   path: "04-synthesis/"

--- a/config/prompts/research_readout.yaml
+++ b/config/prompts/research_readout.yaml
@@ -596,7 +596,8 @@ output_template: |
 
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This research readout emits variables for downstream audience-specific readouts.
 
@@ -627,6 +628,8 @@ output_template: |
   | journey_stages | journey_mapping | User journey context |
   | stakeholder_constraints | stakeholder_synthesis | Constraint context |
   | alignment_gaps | stakeholder_synthesis | Priority gaps |
+
+  </details>
 
 output_options:
   path: "05-readouts/"

--- a/config/prompts/session_summary.yaml
+++ b/config/prompts/session_summary.yaml
@@ -495,7 +495,8 @@ output_template: |
 
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This session summary emits pool variables consumed by downstream synthesis templates.
 
@@ -514,6 +515,8 @@ output_template: |
   | target_barriers | research_brief | Barrier validation grounding |
   | research_questions | research_brief | Question framing |
   | methodology_selection | research_brief | Observation framing |
+
+  </details>
 
 output_options:
   path: "03-fieldwork/sessions/"

--- a/config/prompts/usability_issues_extractor.yaml
+++ b/config/prompts/usability_issues_extractor.yaml
@@ -361,7 +361,8 @@ output_template: |
 
   ---
 
-  ## Cascade summary
+  <details>
+  <summary><strong>Research provenance</strong></summary>
 
   This usability analysis emits variables for downstream templates. Replace strategy — one analysis per study, not per-participant pool.
 
@@ -378,6 +379,8 @@ output_template: |
   | validated_themes | affinity_mapping | Issue-theme linking |
   | target_barriers | research_brief | Barrier validation |
   | research_questions | research_brief | Question addressing |
+
+  </details>
 
 output_options:
   path: "04-synthesis/"


### PR DESCRIPTION
## Summary
Completes the metadata ruling across all remaining templates. The ruling now applies uniformly — no template ships with a bare `## Cascade summary` heading.

**10 templates updated:** session_summary, research_readout, persona_generator, designer_readout, engineering_readout, accessibility_readout, leadership_readout, design_opportunity_generator, jobs_to_be_done, usability_issues_extractor.

**Each change:** `## Cascade summary` → `<details><summary><strong>Research provenance</strong></summary>` ... `</details>`. All existing table content preserved.

**journey_mapping fix:** Removed duplicated cascade summary from LLM prompt that was generating a count table inside `guide_body` while the output_template already had a separate Research provenance block (bug from #255 restructure).

**Result:** Zero templates have a bare `## Cascade summary`. All 18 cascade-aware templates conform to the metadata ruling.

## Test plan
- [ ] Typecheck passes (verified)
- [ ] 141 unit tests pass (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)