### PR TITLE
fix(templates): participant_metadata extraction guard — no inferred demographics

### DIFF
--- a/backend/config/schemas/participant_metadata.yaml
+++ b/backend/config/schemas/participant_metadata.yaml
@@ -10,14 +10,14 @@ properties:
     description: "Participant ID"
   background:
     type: string
-    description: "Military service, disability status, relevant experience"
+    description: "Explicitly stated background relevant to the study (e.g., service era, prior product experience). Never inferred from speech or behavior."
   tech_setup:
     type: string
     description: "Device, OS, connectivity, browser"
   accessibility:
     type: string
     nullable: true
-    description: "Assistive technology or accessibility needs"
+    description: "Assistive technology observed in use, or accessibility needs the participant explicitly stated"
   recruitment_source:
     type: string
     nullable: true

--- a/config/prompts/session_summary.yaml
+++ b/config/prompts/session_summary.yaml
@@ -247,6 +247,14 @@ ai_generation_tasks:
       - Include timestamps if present
       - NEVER fabricate or paraphrase quotes
 
+      PARTICIPANT CONTEXT RULES:
+      Participant context fields record ONLY what the participant explicitly
+      stated or what was directly observed as session mechanics (assistive
+      technology in use, device). NEVER infer demographic, medical, disability,
+      or identity attributes from speech patterns, task performance, or
+      behavioral evidence. When a field's information was not explicitly
+      stated: write "Not stated in session." When in doubt, omit.
+
       CONFIDENCE ASSESSMENT (required for each pain point):
       Assess evidence strength using three levels. Always include a parenthetical
       explanation of WHY you assigned that level:
@@ -274,11 +282,11 @@ ai_generation_tasks:
 
       ## Participant context
 
-      **Background** — [Military service, disability status, relevant experience from sources]
+      **Background** — [Explicitly stated background relevant to the study (e.g., service era, prior experience with the product)]
 
       **App usage** — [Frequency, primary tasks, duration of use]
 
-      **Assistive technology** — [Any AT or accessibility needs, or "None noted"]
+      **Assistive technology** — [Assistive technology observed in use, or accessibility needs the participant explicitly stated, or "None noted"]
 
       **Calling pattern** — [If relevant: how often they call VA support instead of using the app]
 

--- a/docs/claims-audit.md
+++ b/docs/claims-audit.md
@@ -1,0 +1,20 @@
+# Claims vs. Implementation
+
+Every claim the system makes about its own behavior — in UI text, generated documents, ADRs, the design standard, and the patent-relevant architecture story — verified against what the code mechanically does.
+
+**Maintained going forward:** Any new UI text or document template making a behavioral claim adds a row.
+
+---
+
+## Audit table
+
+| # | Claim | Where it appears | What the code does | Status |
+|---|-------|------------------|--------------------|--------|
+| 1 | "All actions are logged for compliance" | Admin Center footer (`adminCenterModal.ts:128`) | Stakeholder changes were not logged until PR #229 (`f9d428c0`). Now all admin actions write audit rows. | TRUE — verified by executed audit-row test |
+| 2 | PII review "N items scrubbed ✓" | PII Review DM (`sessionNotesHandler.ts`) | Scrub is partial by design (name decomposition only, not full PII detection). Checkmark implies completeness. | OPEN — assigned to PII redesign |
+| 3 | "participant_metadata is cascade-required by research_readout so the cascade always receives a value" (A1 demographics ruling rationale) | `backend/docs/qori-modal-design-standard.md` R7 resolved ambiguities | Add Participant demographics never enter the cascade. `participant_metadata` is LLM-extracted from transcripts, not from DB demographics. | FALSE — correction pending in C2 PR |
+| 4 | participant_metadata extraction "traceable to upstream data" | `participant_metadata.yaml` schema, session_summary cascade summary | LLM extraction was inference-capable: `background` field instructed "disability status" extraction, `accessibility` field was open-ended. No grounding rule constrained extraction to explicit statements. | FALSE → FIXED (PR #TBD) — grounding rule added, field descriptions tightened to explicit-only |
+
+---
+
+*Sweep of remaining claims pending — will populate additional rows from modal text, DM text, generated documents, ADRs, and RFI doc.*


### PR DESCRIPTION
## Summary
**Launch-gating fix.** The session_summary extraction prompt could infer demographic, medical, and disability attributes from speech patterns and task performance. For veteran participants, inferred-attributes is the fabrication class this architecture exists to prevent.

### Changes
- **PARTICIPANT CONTEXT RULES** grounding rule added to session_summary.yaml (same authority as Rules 1/5): extraction records ONLY explicit statements and observed session mechanics. Never infer demographic/medical/disability/identity attributes.
- **background field:** removed "disability status" from description → "Explicitly stated background relevant to the study (e.g., service era, prior experience with the product)"
- **accessibility field:** "Any AT or accessibility needs" → "Assistive technology observed in use, or accessibility needs the participant explicitly stated"
- **participant_metadata.yaml schema:** descriptions updated to match prompt
- **claims-audit.md:** seeded with 4 known cases; row 4 reflects this fix

## Test plan
- [ ] Typecheck passes (verified)
- [ ] 141 unit tests pass (verified)
- [ ] Generate a session summary in dev — verify Participant context uses "Not stated" for unobserved fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)