### PR TITLE
fix(modals): C2 — Add Participant R7 wiring + OMB SPD-15 race/ethnicity

### DIFF
--- a/backend/docs/qori-modal-design-standard.md
+++ b/backend/docs/qori-modal-design-standard.md
@@ -96,7 +96,7 @@ Prefill from discovery satisfies but does not alter required status.
 - **`problem_statement`** — REQUIRED under (a): `target_barriers` is hard-required downstream (`research_plan.yaml:69-73`, `discussion_guide.yaml:69-73`) and AI-generated from `problem_statement` + discovery. In the empty-cascade case (no discovery selected), an empty `problem_statement` forces the AI task to generate barriers from nothing — fabricated provenance flowing into plan and discussion guide. `problem_statement` is the human grounding; required.
 - **`session_date`, `session_time`, `current_status`** (Add Participant) — OPTIONAL. Not cascade-required (participant records don't feed YAML templates), not routing/identity, not workflow gates. These are operational metadata for scheduling, not required inputs.
 - **`recruitment_method`** (Add Participant) — REQUIRED under (b): recruitment-source tracking supports federal research methodology auditability. Resolved 2026-08-04.
-- **`race_ethnicity`, `age_range`, `education_level`, `location_type`** (Add Participant) — REQUIRED. `participant_metadata` is cascade-required by `research_readout.yaml:76-80`, so the cascade always receives a value. Every demographics dropdown includes a "Prefer not to say" option — honest data that respects data-minimization in a federal context. Unfreezes §6.7 design freeze (2026-08-04).
+- **`race_ethnicity`, `age_range`, `education_level`, `location_type`** (Add Participant) — REQUIRED. Demographics support research quality (representative sampling documentation), participant tracker breakdowns, and DSAR completeness (federal records management). NOTE: these fields do NOT enter the cascade — `participant_metadata` is LLM-extracted from transcripts, not from DB demographics (corrected 2026-08-05; see backlog item "DB demographics as authoritative cascade source"). Every demographics dropdown includes a "Prefer not to say" option — honest data that respects data-minimization in a federal context. `race_ethnicity` is multi-select per OMB SPD-15 (2024 revision). Unfreezes §6.7 design freeze (2026-08-04).
 
 **Status:** Derivation complete for Brief, Analyze, Synthesis, Readout, Add Participant, Session Notes. Pending: Discover modals.
 
@@ -654,13 +654,13 @@ Derived from `researchBriefModal.ts` — fields with `optional: true`:
 | `session_date` | **NO** | Operational metadata, not cascade-required. Participant can be added before scheduling. |
 | `session_time` | **NO** | Operational metadata, not cascade-required. |
 | `current_status` | **NO** | Operational metadata — has default (line 123: `initial_option: statusOptions[0]`). |
-| `race_ethnicity` | **YES** | `participant_metadata` cascade-required by `research_readout.yaml:76-80`; "Prefer not to say" option present |
-| `age_range` | **YES** | `participant_metadata` cascade-required by `research_readout.yaml:76-80`; "Prefer not to say" option present |
-| `education_level` | **YES** | `participant_metadata` cascade-required by `research_readout.yaml:76-80`; "Prefer not to say" option present |
-| `location_type` | **YES** | `participant_metadata` cascade-required by `research_readout.yaml:76-80`; "Prefer not to say" option present |
+| `race_ethnicity` | **YES** | Research quality + tracker breakdowns + DSAR completeness; "Prefer not to say" option present |
+| `age_range` | **YES** | Research quality + tracker breakdowns + DSAR completeness; "Prefer not to say" option present |
+| `education_level` | **YES** | Research quality + tracker breakdowns + DSAR completeness; "Prefer not to say" option present |
+| `location_type` | **YES** | Research quality + tracker breakdowns + DSAR completeness; "Prefer not to say" option present |
 | `notes_accommodations` | **NO** | Explicitly `optional: true` (line 229) |
 
-**Demographics ruling (2026-08-04):** Four demographics fields remain REQUIRED. `participant_metadata` is cascade-required by `research_readout.yaml:76-80` — the cascade always receives a value. Every demographics dropdown includes a "Prefer not to say" option, providing honest data while respecting data-minimization in a federal context. Resolves previous design freeze.
+**Demographics ruling (2026-08-04, corrected 2026-08-05):** Four demographics fields remain REQUIRED. Demographics support research quality (representative sampling documentation), participant tracker breakdowns, and DSAR completeness. NOTE: these fields do NOT enter the cascade — `participant_metadata` is LLM-extracted from transcripts, not from DB demographics. Every demographics dropdown includes a "Prefer not to say" option, providing honest data while respecting data-minimization in a federal context. `race_ethnicity` is multi-select per OMB SPD-15 (2024 revision): 7 minimum categories, select all that apply, "Prefer not to say" as exclusive alternative. Resolves previous design freeze.
 
 **R7 Derived Required Fields:** `study_select`, `recruitment_method`, `race_ethnicity`, `age_range`, `education_level`, `location_type`.
 

--- a/backend/src/__tests__/__helpers__/view-state-builders.ts
+++ b/backend/src/__tests__/__helpers__/view-state-builders.ts
@@ -259,7 +259,7 @@ export function buildAddParticipantViewState(input: AddParticipantViewStateInput
         notes_input: textInput(input.notes),
       },
       race_ethnicity_block: {
-        race_ethnicity_select: staticSelect(input.raceEthnicity || 'prefer_not_to_say'),
+        race_ethnicity: multiStaticSelect(input.raceEthnicity ? [input.raceEthnicity] : ['prefer_not_to_say']),
       },
       age_range_block: {
         age_range_select: staticSelect(input.ageRange || '35-44'),

--- a/backend/src/helpers/participantYamlProcessor.ts
+++ b/backend/src/helpers/participantYamlProcessor.ts
@@ -128,11 +128,10 @@ const RACE_ETHNICITY_MAPPINGS: Record<string, string> = {
   'black': 'Black or African American',
   'hispanic_latino': 'Hispanic or Latino',
   'hispanic': 'Hispanic or Latino',
+  'middle_eastern_north_african': 'Middle Eastern or North African',
   'native_hawaiian_pacific_islander': 'Native Hawaiian or Other Pacific Islander',
-  'native_hawaiian': 'Native Hawaiian or Other Pacific Islander',
+  'native_hawaiian': 'Native Hawaiian or Pacific Islander',
   'white': 'White',
-  'two_or_more_races': 'Two or More Races',
-  'two_or_more': 'Two or More Races',
   'prefer_not_to_say': 'Prefer not to say',
 };
 
@@ -350,9 +349,14 @@ function generateDemographicBreakdowns(participants: ParticipantRecord[]): Demog
     }
 
     if (typeof demographics === 'object' && demographics) {
-      if (demographics.race_ethnicity && demographics.race_ethnicity !== '') {
-        const raceKey = demographics.race_ethnicity;
-        raceBreakdown[raceKey] = (raceBreakdown[raceKey] || 0) + 1;
+      // SPD-15 (2024): race_ethnicity is an array (select all that apply)
+      const raceValues = Array.isArray(demographics.race_ethnicity)
+        ? demographics.race_ethnicity
+        : demographics.race_ethnicity ? [demographics.race_ethnicity] : [];
+      for (const raceKey of raceValues) {
+        if (raceKey !== '') {
+          raceBreakdown[raceKey] = (raceBreakdown[raceKey] || 0) + 1;
+        }
       }
 
       if (demographics.age_range && demographics.age_range !== '') {

--- a/backend/src/helpers/slack/commands/participantOutreachHandler.ts
+++ b/backend/src/helpers/slack/commands/participantOutreachHandler.ts
@@ -971,13 +971,25 @@ async function handleSessionReminderSubmit({ ack, body, view, client }: SlackVie
 }
 
 async function handleAddParticipantSubmit({ ack, body, view, client }: SlackViewMiddlewareArgs<ViewSubmitAction> & AllMiddlewareArgs): Promise<void> {
-  await ack();
-
   try {
     const state = view.state.values as any;
     const meta = JSON.parse(body.view.private_metadata || '{}');
     const { channelId, userId } = meta;
 
+    // ── Validation (before ack) ──────────────────────────────
+    // SPD-15 (2024): race/ethnicity is multi-select (select all that apply)
+    const raceSelections: string[] = state.race_ethnicity_block?.race_ethnicity?.selected_options?.map((o: any) => o.value) || [];
+    // PNTS cannot be combined with categories — researcher resolves
+    if (raceSelections.includes('prefer_not_to_say') && raceSelections.length > 1) {
+      return ack({
+        response_action: 'errors',
+        errors: { race_ethnicity_block: "Select categories or 'Prefer not to say', not both." },
+      } as any);
+    }
+
+    await ack();
+
+    // ── Extraction ───────────────────────────────────────────
     // Extract study from dropdown selection (action_id: add_participant_study_select)
     const selectedStudyOption = state.study_select_block?.add_participant_study_select?.selected_option || null;
     const study_id = selectedStudyOption?.value || "";
@@ -988,8 +1000,7 @@ async function handleAddParticipantSubmit({ ack, body, view, client }: SlackView
     const scheduled_time = state.session_time_block?.session_time?.selected_time || "";
     const status_select = state.current_status_block?.current_status?.selected_option?.value || "";
     const notes_field = state.notes_accommodations_block?.notes_accommodations?.value || "";
-    // Extract demographic information from the new dropdown fields
-    const race_ethnicity = state.race_ethnicity_block?.race_ethnicity?.selected_option?.value || "";
+    const race_ethnicity = raceSelections;
     const age_range = state.age_range_block?.age_range?.selected_option?.value || "";
     const education_level = state.education_level_block?.education_level?.selected_option?.value || "";
     const location_type = state.location_type_block?.location_type?.selected_option?.value || "";

--- a/backend/src/helpers/slack/ui/addParticipantModal.ts
+++ b/backend/src/helpers/slack/ui/addParticipantModal.ts
@@ -88,7 +88,7 @@ const addParticipantModal = {
 
     // Session Details
     { type: "section", text: { type: "mrkdwn", text: "*Session Details*" } },
-    // Scheduled date
+    // Scheduled date — optional per R7 (operational metadata, not cascade-required)
     {
       type: "input",
       block_id: "session_date_block",
@@ -98,8 +98,9 @@ const addParticipantModal = {
         action_id: "session_date",
         placeholder: { type: "plain_text", text: "Select date" },
       },
+      optional: true,
     },
-    // Scheduled time
+    // Scheduled time — optional per R7
     {
       type: "input",
       block_id: "session_time_block",
@@ -109,8 +110,9 @@ const addParticipantModal = {
         action_id: "session_time",
         placeholder: { type: "plain_text", text: "Select time" },
       },
+      optional: true,
     },
-    // Current status
+    // Current status — optional per R7 (has default)
     {
       type: "input",
       block_id: "current_status_block",
@@ -122,29 +124,30 @@ const addParticipantModal = {
         options: statusOptions,
         initial_option: statusOptions[0],
       },
+      optional: true,
     },
 
     { type: "divider" },
 
     // Demographics
     { type: "section", text: { type: "mrkdwn", text: "*Demographics*" } },
-    // Race/Ethnicity
+    // Race/Ethnicity — OMB SPD-15 (2024 revision): combined question, select all that apply
     {
       type: "input",
       block_id: "race_ethnicity_block",
       label: { type: "plain_text", text: "Race/ethnicity" },
       element: {
-        type: "static_select",
+        type: "multi_static_select",
         action_id: "race_ethnicity",
-        placeholder: { type: "plain_text", text: "Select..." },
+        placeholder: { type: "plain_text", text: "Select all that apply..." },
         options: [
           { text: { type: "plain_text", text: "American Indian or Alaska Native" }, value: "american_indian" },
           { text: { type: "plain_text", text: "Asian" }, value: "asian" },
           { text: { type: "plain_text", text: "Black or African American" }, value: "black" },
           { text: { type: "plain_text", text: "Hispanic or Latino" }, value: "hispanic_latino" },
+          { text: { type: "plain_text", text: "Middle Eastern or North African" }, value: "middle_eastern_north_african" },
           { text: { type: "plain_text", text: "Native Hawaiian or Pacific Islander" }, value: "native_hawaiian" },
           { text: { type: "plain_text", text: "White" }, value: "white" },
-          { text: { type: "plain_text", text: "Two or More Races" }, value: "two_or_more" },
           { text: { type: "plain_text", text: "Prefer not to say" }, value: "prefer_not_to_say" },
         ],
       },

--- a/docs/e2e-punch-list.md
+++ b/docs/e2e-punch-list.md
@@ -19,6 +19,10 @@ Pre-filled objectives and research questions render internal IDs ("OBJ-001", "RQ
 
 Routing selectors (Study/Session) are always the FIRST interactive element in a modal; mode tabs and inputs follow. One modal moves: Session Notes (Select Session above the Manual Notes / Upload Transcript tabs). Add to design standard with a ruling number.
 
+## P4. Model-selection audit (pre-launch worthy)
+
+For every AI task across all templates, report: task → current model → task character (synthesis/extraction on the provenance chain vs. structured drafting vs. trivial transform) → recommended model tier, with rationale. Constraint: anything with anti-fabrication grounding rules or provenance-chain output stays on the strongest tier — cost optimization never trades against the fabrication guards. Include rough per-task token volumes so recommendations carry cost impact. Recommendations only; Lapedra rules per row.
+
 ---
 
 *This list stays open. More items will be added as the walkthrough continues.*


### PR DESCRIPTION
## Summary
**C2 from Block C R7 validation wiring + OMB SPD-15 (2024) amendment.**

### SPD-15 compliance
- `race_ethnicity`: `static_select` → `multi_static_select` (select all that apply per 2024 standard)
- 7 minimum categories in SPD-15 order + "Prefer not to say"
- Added "Middle Eastern or North African"; removed "Two or More Races" (expressed by multi-selection)
- PNTS validation: reject-with-inline-error if submitted alongside categories

### R7 wiring
- `session_date`, `session_time`, `current_status` → `optional: true` (operational metadata per §6.7)

### Downstream array handling
- Handler extraction: `selected_option` → `selected_options` array; `ack()` moved after validation
- Tracker breakdown: iterates array for per-category counts
- Display mapping: `middle_eastern_north_african` added

### §6.5/A1 correction
False claim that demographics feed `participant_metadata` cascade removed from design standard. Corrected rationale: research quality, tracker breakdowns, DSAR completeness.

## Test plan
- [ ] Typecheck passes (verified)
- [ ] 141 unit tests pass (verified)
- [ ] Add participant in dev — verify multi-select renders with 8 options
- [ ] Select "Prefer not to say" + another category → verify inline error
- [ ] Select multiple categories → verify array stored in DB demographics_info
- [ ] Verify participant tracker breakdown counts each selected category

🤖 Generated with [Claude Code](https://claude.com/claude-code)