### PR TITLE
fix(modals): C1 — Brief R7 wiring

### DIFF
--- a/backend/src/helpers/slack/ui/researchBriefModal.ts
+++ b/backend/src/helpers/slack/ui/researchBriefModal.ts
@@ -154,10 +154,11 @@ export const researchBriefModal = {
         multiline: true,
       },
     },
-    // Out of scope
+    // Out of scope — optional per R7 (all consumers optional)
     {
       type: "input",
       block_id: "out_of_scope_block",
+      optional: true,
       label: {
         type: "plain_text",
         text: "What's out of scope?",
@@ -281,10 +282,11 @@ export const researchBriefModal = {
         text: "*Timeline & Budget*",
       },
     },
-    // Start date
+    // Start date — optional per R7 (all consumers optional)
     {
       type: "input",
       block_id: "start_date_block",
+      optional: true,
       label: {
         type: "plain_text",
         text: "When does research start?",
@@ -298,10 +300,11 @@ export const researchBriefModal = {
         },
       },
     },
-    // Decision deadline
+    // Decision deadline — optional per R7 (no cascade consumer)
     {
       type: "input",
       block_id: "decision_deadline_block",
+      optional: true,
       label: {
         type: "plain_text",
         text: "When do stakeholders need findings?",


### PR DESCRIPTION
## Summary
Per §6.1 derivation: `out_of_scope`, `start_date`, `decision_deadline` → `optional: true`. All cascade consumers for these fields are optional; `decision_deadline` has no cascade consumer.

Required fields unchanged: `study_name` (b), `stakeholder` (b), `problem_statement` (a), `learning_objectives` (a), `research_method` (a), `participant_approach` (a).

## Test plan
- [ ] Typecheck + 141 tests pass (verified)
- [ ] Brief modal in dev: verify out_of_scope, dates show "(optional)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)