### PR TITLE
fix(modals): P2 — strip internal IDs from DG pre-fill (R5)

### DIFF
--- a/backend/src/helpers/slack/commands/briefHandler.ts
+++ b/backend/src/helpers/slack/commands/briefHandler.ts
@@ -165,7 +165,10 @@ ${data.upstream_stakeholder_questions_for_users ? `STAKEHOLDER QUESTIONS FOR USE
 
 Rules:
 1. If stakeholder questions exist, use them as research questions (they come pre-prioritized).
-2. Otherwise, reframe learning objectives as answerable research questions.
+2. Otherwise, transform learning objectives into research questions. Research questions
+   must be answerable through sessions — transform each objective into what a researcher
+   would actually investigate, not a restatement. If a question would be near-identical
+   to its objective, sharpen it toward observable behavior or decision criteria.
 3. Mark priority: Primary (must-answer), Secondary (valuable), or Exploratory (nice-to-have).
 4. 3-7 questions. Primary questions first.
 5. Do NOT invent statistics, metrics, or numbers. Use ONLY data from the inputs provided.

--- a/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
+++ b/backend/src/helpers/slack/commands/discussion-guide/discussionGuideHandler.ts
@@ -67,28 +67,27 @@ interface ResearchQuestion {
   priority?: string;
 }
 
-/** Format research_objectives (array of {id, objective}) as bullet list for pre-fill. */
+/** Format research_objectives (array of {id, objective}) as bullet list for pre-fill.
+ * IDs (OBJ-001) stay in the cascade; pre-fill renders clean text per R5. */
 function formatObjectivesForPrefill(objectives: unknown): string {
   if (!Array.isArray(objectives)) return '';
   return objectives
     .map((obj: ResearchObjective) => {
-      const id = obj.id || '';
       const objective = obj.objective || '';
-      return id && objective ? `• ${id}: ${objective}` : objective ? `• ${objective}` : '';
+      return objective ? `• ${objective}` : '';
     })
     .filter(Boolean)
     .join('\n');
 }
 
-/** Format research_questions (array of {id, question, priority}) for pre-fill. */
+/** Format research_questions (array of {id, question, priority}) for pre-fill.
+ * IDs (RQ-001) and priority labels stay in the cascade; pre-fill renders clean text per R5. */
 function formatQuestionsForPrefill(questions: unknown): string {
   if (!Array.isArray(questions)) return '';
   return questions
     .map((q: ResearchQuestion) => {
-      const id = q.id || '';
       const question = q.question || '';
-      const priority = q.priority ? ` (${q.priority})` : '';
-      return id && question ? `${id}${priority}: ${question}` : question || '';
+      return question || '';
     })
     .filter(Boolean)
     .join('\n');


### PR DESCRIPTION
## Summary
Pre-filled objectives rendered `OBJ-001: Learn how...`; questions rendered `RQ-001 (Primary): How do...`. IDs stay in the cascade; pre-fill renders clean text per R5.

**Duplication finding:** Objectives and RQ pre-fills read from different cascade variables (`research_objectives` vs `research_questions`). The mapper is correct — the near-identical content happens because the LLM generates `research_questions` by paraphrasing the researcher's `learning_objectives` input. Cascade content similarity, not a code bug.

## Test plan
- [ ] 141 tests pass (verified)
- [ ] Open DG modal with cascade data — verify pre-fills show clean text without IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)