### PR TITLE
fix: P3 routing-selectors-first (R17) + claims-audit ruling fixes

### DIFF
--- a/backend/docs/qori-modal-design-standard.md
+++ b/backend/docs/qori-modal-design-standard.md
@@ -12,7 +12,7 @@ This document captures the design rulings for Slack Block Kit modals across the 
 
 Remove all decorative emoji from modals. Emoji are permitted only when they carry semantic meaning (e.g., `:warning:` for error states). Decorative emoji (`:file_folder:`, `:bust_in_silhouette:`, `:sparkles:`, artifact icons like `📄`, `🎙️`) should be removed.
 
-**Status:** Enforced. Applied to Research Synthesis, Analyze Session, Tickets, and Research Brief modals.
+**Status:** Verified by manual sweep (PR #241). Applied to Research Synthesis, Analyze Session, Tickets, and Research Brief modals.
 
 ---
 
@@ -32,7 +32,7 @@ Submit button text should describe the action, not just "Submit". Examples:
 | Continue to next step | "Continue" |
 | Launches a sub-modal | "Open" (see R14) |
 
-**Status:** Enforced.
+**Status:** Verified by manual sweep (PR #241).
 
 ---
 
@@ -40,7 +40,7 @@ Submit button text should describe the action, not just "Submit". Examples:
 
 Remove redundant section headers when the input label is self-explanatory. For example, a "Research Study" section header followed by a "Study *" select is redundant — the label suffices. No imperatives ("Select a..."), no colons after labels.
 
-**Status:** Enforced.
+**Status:** Verified by manual sweep (PR #241).
 
 ---
 
@@ -48,7 +48,7 @@ Remove redundant section headers when the input label is self-explanatory. For e
 
 Use terminology that matches the domain. "Synthesis" (not "Analysis") for cross-session synthesis methods. "Analyze" for single-session analysis.
 
-**Status:** Enforced.
+**Status:** Verified by manual sweep (PR #241).
 
 ---
 
@@ -59,7 +59,7 @@ Translate system labels to researcher language. Examples:
 - "target_barriers" → "target barriers"
 - Strip `_metadata` suffixes and convert `snake_case` to spaces.
 
-**Status:** Enforced.
+**Status:** Verified by manual sweep (PR #241).
 
 ---
 
@@ -121,7 +121,7 @@ Use dividers sparingly, only between logical groups. Do not use dividers:
 - After every field
 - To create visual "boxes" around single fields
 
-**Status:** Enforced.
+**Status:** Verified by manual sweep (PR #241).
 
 ---
 
@@ -133,7 +133,7 @@ Use dividers sparingly, only between logical groups. Do not use dividers:
 - **Warnings**: Use `context` blocks with `:warning:` prefix
 - **One primary button per modal**: Submit is primary; secondary actions (Load, Refresh) are non-primary style
 
-**Status:** Enforced.
+**Status:** Verified by manual sweep (PR #241).
 
 ---
 
@@ -166,7 +166,7 @@ or
 
 Keep grounding information compact — one line, `•` separators, no decorative emoji.
 
-**Status:** Enforced.
+**Status:** Verified by manual sweep (PR #241).
 
 ---
 
@@ -177,7 +177,7 @@ Use correct singular/plural forms:
 - `${count} session${count !== 1 ? 's' : ''}`
 - `${count} barrier${count !== 1 ? 's' : ''}`
 
-**Status:** Enforced.
+**Status:** Verified by manual sweep (PR #241).
 
 ---
 
@@ -228,6 +228,16 @@ This design standard governs **all** researcher-facing surfaces — modals, DMs,
 | R15 Danger styling | ✓ | ✓ (destructive buttons) |
 
 **Status:** Ratified 2026-08-04.
+
+---
+
+### R17: Routing Selectors First
+
+Routing selectors (Study, Session) are always the **first interactive element** in a modal. Mode tabs, input fields, and content blocks follow. The researcher establishes context before choosing what to do with it.
+
+This applies to any modal that combines a routing selector with mode tabs or conditional content. Session Notes is the canonical example: Select Session appears above the Manual Notes / Upload Transcript tabs.
+
+**Status:** Ratified 2026-08-05.
 
 ---
 

--- a/backend/src/helpers/slack/ui/addParticipantModal.ts
+++ b/backend/src/helpers/slack/ui/addParticipantModal.ts
@@ -62,7 +62,7 @@ const addParticipantModal = {
         max_length: 100,
         placeholder: { type: "plain_text", text: "e.g., 'screen-reader user', 'Veteran A'" },
       },
-      hint: { type: "plain_text", text: "Private label to help you remember this participant. Do not enter real names — use the system code for identity." },
+      hint: { type: "plain_text", text: "Use the participant code, not a real name — this field is not checked." },
       optional: true,
     },
     // Recruitment method

--- a/backend/src/helpers/slack/ui/sessionNotesModal.ts
+++ b/backend/src/helpers/slack/ui/sessionNotesModal.ts
@@ -89,23 +89,7 @@ export const buildSessionNotesView = (state: SessionNotesState = {}) => {
     submit: { type: 'plain_text', text: isManual ? 'Submit to GitHub' : 'Submit Transcript' },
     close: { type: 'plain_text', text: 'Cancel' },
     blocks: [
-      // Tabs
-      {
-        type: 'actions',
-        block_id: 'tabs',
-        elements: [
-          {
-            type: 'button', action_id: 'tab_manual', value: 'manual',
-            text: { type: 'plain_text', text: 'Manual Notes' },
-          },
-          {
-            type: 'button', action_id: 'tab_upload', value: 'upload',
-            text: { type: 'plain_text', text: 'Upload Transcript' },
-          }
-        ]
-      },
-
-      // Session select (shared)
+      // Session select first (R17: routing selectors before mode tabs)
       {
         type: 'input',
         block_id: 'session_select',
@@ -151,6 +135,22 @@ export const buildSessionNotesView = (state: SessionNotesState = {}) => {
             })()
             : undefined
         }
+      },
+
+      // Tabs (after session select per R17)
+      {
+        type: 'actions',
+        block_id: 'tabs',
+        elements: [
+          {
+            type: 'button', action_id: 'tab_manual', value: 'manual',
+            text: { type: 'plain_text', text: 'Manual Notes' },
+          },
+          {
+            type: 'button', action_id: 'tab_upload', value: 'upload',
+            text: { type: 'plain_text', text: 'Upload Transcript' },
+          }
+        ]
       },
 
       ...(isManual ? manualBlocks(state.preserved) : uploadBlocks(method, state.preserved, state.session?.session_id)),

--- a/config/prompts/affinity_mapping.yaml
+++ b/config/prompts/affinity_mapping.yaml
@@ -364,12 +364,12 @@ notes: |
   v7.0: Interleaved Handlebars/AI architecture (ADR 0005/0016 pattern).
   - Monolithic affinity_complete task replaced by analysis_body task.
   - Handlebars renders: masthead, methodology (toggle), references (toggle),
-    upstream context (toggle), cascade summary (always present).
+    upstream context (toggle), declared inputs (static declaration table).
   - Recommendations kept (deviation from discovery template treatment —
     see comment on analysis_body task for rationale).
   - OUTPUT BOUNDARIES with ## heading instruction added.
   - Dead variable focus_area removed from prompt.
-  - Cascade summary always renders (was conditional).
+  - Declared inputs section always renders (was conditional).
 
   v4.0: Cascade-aware retrofit (superseded by v7.0).
   v3.0-v3.2: Design language, standards polish.

--- a/config/prompts/design_opportunity_generator.yaml
+++ b/config/prompts/design_opportunity_generator.yaml
@@ -415,7 +415,7 @@ notes: |
     description, scope calibration, and IDEO/Stanford/NNG/Kumar references),
     upstream context (toggle, conditional — richest upstream display of any
     template, shows 6 potential sources), validity checklist (toggle),
-    cascade summary (always present).
+    declared inputs (static declaration table).
   - NEW: emits design_hmw_opportunities (replace strategy, Sonnet extraction).
     No downstream consumer currently — emit exists for structural completeness
     and future consumption readiness. HMW statement is a single field (see

--- a/config/prompts/jobs_to_be_done.yaml
+++ b/config/prompts/jobs_to_be_done.yaml
@@ -365,7 +365,7 @@ notes: |
   - Handlebars renders: masthead, methodology (toggle with JTBD framework
     description, dimension model, and Christensen/Moesta/Ulwick/Klement
     references), upstream context (toggle, conditional), validity checklist
-    (toggle), cascade summary (always present).
+    (toggle), declared inputs (static declaration table).
   - NEW: emits validated_jobs (replace strategy, Sonnet extraction).
     When/Want/So triad split into three separate required fields for
     cascade clarity — see schema comment in validated_job.yaml.

--- a/config/prompts/persona_generator.yaml
+++ b/config/prompts/persona_generator.yaml
@@ -389,7 +389,7 @@ notes: |
     (always present, documents both emits and consumes).
   - Recommendations kept (same rationale as affinity_mapping — see comment).
   - OUTPUT BOUNDARIES with ## heading instruction added.
-  - Cascade summary always renders (was conditional).
+  - Declared inputs section always renders (was conditional).
 
   v5.0: Cascade-aware retrofit (superseded by v7.0).
   v4.3: Design language translation.

--- a/config/prompts/research_readout.yaml
+++ b/config/prompts/research_readout.yaml
@@ -649,7 +649,7 @@ notes: |
   - Monolithic research_readout_complete task replaced by analysis_body task.
   - Handlebars renders: masthead, references (toggle), related artifacts (toggle,
     raw detected_files list), upstream context (toggle, conditional on data),
-    validity checklist (toggle), cascade summary (always present).
+    validity checklist (toggle), declared inputs (static declaration table).
   - Related artifacts changed from LLM-categorized table to raw file list via
     Handlebars (mechanical, no LLM judgment on cosmetic categorization).
   - Internal quality checklist removed (redundant with anti-fabrication rules).

--- a/config/prompts/session_summary.yaml
+++ b/config/prompts/session_summary.yaml
@@ -538,7 +538,7 @@ notes: |
   - Monolithic analyze_and_extract task replaced by analysis_body task.
   - Handlebars renders: masthead, references (static), upstream context
     (toggle, conditional), sources appendix (toggle), validity checklist
-    (toggle), cascade summary (always present).
+    (toggle), declared inputs (static declaration table).
   - Barrier validation conditional stays in AI prompt (Option b from delta —
     avoids wasted generation when no upstream barriers exist).
   - Methodology prose stays in AI task (varies per session — format, tasks,

--- a/config/prompts/stakeholder_synthesis.yaml
+++ b/config/prompts/stakeholder_synthesis.yaml
@@ -445,11 +445,11 @@ notes: |
     cross-section coherence) and appendix_observations (raw preservation).
   - Handlebars renders: masthead, methodology (in toggle), validity
     checklist, references, appendix structure, related artifacts,
-    cascade summary (always present).
+    declared inputs (static declaration table).
   - Anti-fabrication guards preserved (6 rules from v5.0).
   - OUTPUT BOUNDARIES rule added to both tasks.
   - derived_variables block removed (handler computes topic_slug).
-  - Cascade summary always renders (was conditional on upstream data).
+  - Declared inputs section always renders (was conditional on upstream data).
   - Methodology section wrapped in details/summary toggle.
 
   v5.0-v5.0.1: Single-task architecture (superseded by v7.0).

--- a/config/prompts/survey_synthesis.yaml
+++ b/config/prompts/survey_synthesis.yaml
@@ -401,7 +401,7 @@ notes: |
   - Monolithic survey_synthesis_complete task split into 2 tasks:
     analysis_body (overview + themes + sentiment) and knowledge_gaps_prose.
   - Handlebars renders: masthead, methodology (toggle), references (toggle),
-    cascade summary (always present).
+    declared inputs (static declaration table).
   - Recommendations removed → Knowledge Gaps (same treatment as desk_research).
   - survey_recommendations emit removed (orphaned — no downstream consumer).
   - sample_demographics emit kept (orphaned but potentially useful).

--- a/config/prompts/usability_issues_extractor.yaml
+++ b/config/prompts/usability_issues_extractor.yaml
@@ -394,7 +394,7 @@ notes: |
   - Monolithic usability_complete task replaced by analysis_body task.
   - Handlebars renders: masthead, methodology (toggle with severity criteria
     and references), upstream context (toggle, conditional), validity checklist
-    (toggle), cascade summary (always present).
+    (toggle), declared inputs (static declaration table).
   - NEW: emits prioritized_issues (replace strategy, Sonnet extraction).
     This closes the broken cascade contract — research_readout declares
     it consumes prioritized_issues from usability_issues but the emit

--- a/docs/architecture-decisions/0007-cascade-contracts-fail-loudly.md
+++ b/docs/architecture-decisions/0007-cascade-contracts-fail-loudly.md
@@ -55,6 +55,6 @@ Empty arrays `[]` and empty objects `{}` count as present — that's valid data 
 
 ## References
 
-- `TemplateContractError` class in `backend/src/utils/yamlProcessor.js`
+- `TemplateContractError` class in `backend/src/helpers/yamlProcessor.ts`
 - Foundation 2 instruction document
 - Related: ADR 0005 (Handlebars architecture — this enforcement complements it), ADR 0006 (transform-on-consume — shapes can still drift even with the contract)


### PR DESCRIPTION
## Summary
**P3 — R17: Routing Selectors First:**
- Session Notes: Select Session moved above Manual Notes / Upload Transcript tabs
- R17 added to design standard with rationale

**Claims-audit rulings (4 fixes):**
- **#9:** Add Participant alias hint → "Use the participant code, not a real name — this field is not checked." (honest advisory)
- **#25:** 9 YAML notes sections: "cascade summary (always present)" → "declared inputs (static declaration table)"
- **#27:** ADR 0007 stale path: `utils/yamlProcessor.js` → `helpers/yamlProcessor.ts`
- **#32:** Design standard: "Enforced" → "Verified by manual sweep (PR #241)" on R1-R5, R9, R10, R12, R13

## Test plan
- [ ] 141 tests pass (verified)
- [ ] Session Notes modal: Select Session appears above tabs
- [ ] Add Participant: alias hint shows "this field is not checked"

🤖 Generated with [Claude Code](https://claude.com/claude-code)