### PR TITLE
fix(templates): explicit extraction_model: sonnet on 6 high-criticality emits

### DIFF
--- a/config/prompts/desk_research.yaml
+++ b/config/prompts/desk_research.yaml
@@ -423,6 +423,7 @@ emits:
   - key: discovered_barriers
     pool: true
     pool_strategy: append
+    extraction_model: sonnet
     schema:
       type: array
       items:

--- a/config/prompts/research_readout.yaml
+++ b/config/prompts/research_readout.yaml
@@ -177,6 +177,7 @@ emits:
   - key: study_methodology
     pool: false
     pool_strategy: replace
+    extraction_model: sonnet
     schema:
       $ref: schemas/study_methodology.yaml
     extract_from: "Methodology section"

--- a/config/prompts/stakeholder_synthesis.yaml
+++ b/config/prompts/stakeholder_synthesis.yaml
@@ -78,6 +78,7 @@ emits:
   - key: stakeholder_priorities
     pool: false
     pool_strategy: replace
+    extraction_model: sonnet
     schema:
       type: array
       items:
@@ -87,6 +88,7 @@ emits:
   - key: alignment_gaps
     pool: false
     pool_strategy: replace
+    extraction_model: sonnet
     schema:
       type: array
       items:

--- a/config/prompts/survey_synthesis.yaml
+++ b/config/prompts/survey_synthesis.yaml
@@ -54,6 +54,7 @@ emits:
   - key: survey_themes
     pool: true
     pool_strategy: append
+    extraction_model: sonnet
     schema:
       type: array
       items:
@@ -72,6 +73,7 @@ emits:
   - key: discovered_barriers
     pool: true
     pool_strategy: append
+    extraction_model: sonnet
     schema:
       type: array
       items:


### PR DESCRIPTION
## Summary
P4 audit gap: 6 emit extractions on the provenance chain lacked explicit `extraction_model: sonnet`. Currently harmless (default is sonnet), prevents latent routing bugs if the default ever changes.

- `desk_research/discovered_barriers` — consumed by research_brief, stakeholder_synthesis
- `stakeholder_synthesis/stakeholder_priorities` — consumed by brief
- `stakeholder_synthesis/alignment_gaps` — consumed by brief
- `survey_synthesis/survey_themes` — cascade anchor
- `survey_synthesis/discovered_barriers` — consumed by brief
- `research_readout/study_methodology` — used downstream

## Test plan
- [ ] 141 tests pass (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)