### PR TITLE
fix: route 6 trivial-transform tasks to Haiku (P4 ruling)

### DIFF
--- a/backend/src/helpers/langchain.ts
+++ b/backend/src/helpers/langchain.ts
@@ -25,6 +25,9 @@ interface AiGenerationTask {
   task_id: string;
   prompt: string;
   output_format?: string;
+  /** Per-task model override. When set, this task uses the specified model
+   * instead of the default. Used for trivial transforms on Haiku. */
+  model?: string;
   [key: string]: unknown;
 }
 
@@ -121,7 +124,16 @@ export async function executeAiGenerationTasks(
         );
       }
 
-      const response = await llm.invoke(finalPrompt);
+      // Per-task model override (P4 ruling: trivial transforms on Haiku)
+      const taskLlm = task.model && task.model !== modelName
+        ? new ChatAnthropic({
+            anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+            modelName: task.model,
+            temperature,
+            maxTokens,
+          })
+        : llm;
+      const response = await taskLlm.invoke(finalPrompt);
       return { taskId: task.task_id, response: response.content as string };
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);

--- a/config/prompts/desk_research.yaml
+++ b/config/prompts/desk_research.yaml
@@ -245,6 +245,7 @@ ai_generation_tasks:
 
   # Sources
   - task_id: "sources"
+    model: "claude-haiku-4-5-20251001"
     prompt: |
       Create a professional reference list for the desk research.
 

--- a/config/prompts/discussion_guide.yaml
+++ b/config/prompts/discussion_guide.yaml
@@ -122,6 +122,7 @@ emits:
 # ═══════════════════════════════════════════════════════════
 ai_generation_tasks:
   - task_id: "descriptive_title"
+    model: "claude-haiku-4-5-20251001"
     prompt: |
       Generate a concise study title from this research focus: {{research_focus}}
 

--- a/config/prompts/research_brief.yaml
+++ b/config/prompts/research_brief.yaml
@@ -181,6 +181,7 @@ ai_generation_tasks:
   # rendering. Study slugs like "va-mobile-nav-q3" need creative humanization.
   # This is NOT license to use LLM tasks for other computed values without scrutiny.
   - task_id: "descriptive_title"
+    model: "claude-haiku-4-5-20251001"
     prompt: |
       Convert this study slug into a short, descriptive title:
       Study slug: {{selected_study}}
@@ -406,6 +407,7 @@ ai_generation_tasks:
       Schema: [{"risk": "string", "source": "string", "mitigation": "string"}]
 
   - task_id: "approval_items"
+    model: "claude-haiku-4-5-20251001"
     prompt: |
       Generate 4 approval checkboxes for research brief about {{selected_study}}:
       - [ ] Stakeholder approves scope and method

--- a/config/prompts/research_plan.yaml
+++ b/config/prompts/research_plan.yaml
@@ -230,6 +230,7 @@ ai_generation_tasks:
       notes, post-session interviews, etc. Be specific to the methodology.
 
   - task_id: "participant_glance"
+    model: "claude-haiku-4-5-20251001"
     prompt: |
       Write a ONE-LINE glance summary of participant composition for an at-a-glance table.
 

--- a/config/prompts/transcript_upload.yaml
+++ b/config/prompts/transcript_upload.yaml
@@ -665,6 +665,7 @@ ai_generation_tasks:
       - Insights extracted: [Yes/No] (insights_count)
 
   - task_id: "transcript_coding_filename"
+    model: "claude-haiku-4-5-20251001"
     prompt: |
       Extract participant ID and output filename.
 


### PR DESCRIPTION
## Summary
Per-task model override added to `langchain.ts`. 6 trivial-transform tasks (output never researcher-visible prose) switched to `claude-haiku-4-5-20251001`:

| Template | Task | Output |
|----------|------|--------|
| research_brief | descriptive_title | ~20 token editorial title |
| research_brief | approval_items | 4-checkbox mechanical generation |
| research_plan | participant_glance | Single line for table cell |
| discussion_guide | descriptive_title | ~20 token study title |
| desk_research | sources | Bibliography formatting |
| transcript_upload | transcript_coding_filename | Single filename line |

Provenance-chain tasks and structured drafting stay on Sonnet. Bounded-structured-drafting tier re-proposed post-launch with E2E outputs as comparison baseline.

## Test plan
- [ ] 141 tests pass (verified)
- [ ] Generate a brief in dev — verify title renders correctly (Haiku)
- [ ] Generate a plan in dev — verify participant glance line (Haiku)

🤖 Generated with [Claude Code](https://claude.com/claude-code)