### PR TITLE
fix: PII rescrub loop — full implementation

### DIFF
--- a/backend/src/helpers/slack/commands/sessionNotesHandler.ts
+++ b/backend/src/helpers/slack/commands/sessionNotesHandler.ts
@@ -9,7 +9,7 @@
 import type { AllMiddlewareArgs, SlackCommandMiddlewareArgs, SlackActionMiddlewareArgs, SlackViewMiddlewareArgs, BlockAction, ViewSubmitAction } from '@slack/bolt';
 
 import { buildSessionNotesView, type PreservedInputs } from "../ui/sessionNotesModal";
-import { buildTranscriptReviewModal, type TranscriptReviewModalMetadata } from "../ui/transcriptReviewModal";
+import { buildTranscriptReviewModal, type TranscriptReviewModalMetadata, type ScrubStats } from "../ui/transcriptReviewModal";
 import sessionObserverService from "../../../services/session_observer.service";
 import sessionParticipantService from "../../../services/study_participant.service";
 import { resolveStudyFromName } from "../../../services/research_study.service";
@@ -989,6 +989,123 @@ const handleTranscriptReviewApprove = async ({ ack, body, view, client }: SlackV
   }
 };
 
+// ─── Rescrub loop — re-scrub quarantine with additional terms ─────────────────────
+
+/**
+ * Handle rescrub button click in the transcript review modal.
+ *
+ * Reads quarantine content from GitHub, applies additional find/replace terms,
+ * regenerates quarantine, rebuilds the review modal with updated stats.
+ * Terms are transient — used in memory for find/replace, then discarded (§2.1).
+ * Attestation checkbox resets (reviewer attests to the regenerated version).
+ */
+const handleRescrub = async ({ ack, body, client }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs): Promise<void> => {
+  await ack();
+
+  try {
+    // Extract terms from the input field (actions blocks can read sibling input values)
+    const viewValues = (body as any).view?.state?.values;
+    const rescrubTermsRaw = viewValues?.rescrub_terms_block?.rescrub_terms?.value?.trim() || '';
+
+    if (!rescrubTermsRaw) {
+      // No terms entered — nothing to rescrub
+      return;
+    }
+
+    // Parse comma-separated terms
+    const terms = rescrubTermsRaw.split(',').map((t: string) => t.trim()).filter(Boolean);
+    if (terms.length === 0) return;
+
+    // Parse metadata from private_metadata
+    const metadata: TranscriptReviewModalMetadata = JSON.parse((body as any).view?.private_metadata || '{}');
+    const { quarantinePath, participantCode, studyName, fileUrl } = metadata;
+
+    if (!quarantinePath) {
+      console.error('[PII] Rescrub: missing quarantinePath in metadata');
+      return;
+    }
+
+    // Read current quarantine content from GitHub
+    const { Octokit } = await import('@octokit/rest');
+    const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+    const owner = process.env.GITHUB_OWNER!;
+    const repo = process.env.GITHUB_REPO!;
+
+    let quarantineContent: string;
+    let quarantineSha: string;
+    try {
+      const fileResponse = await octokit.rest.repos.getContent({
+        owner, repo, path: quarantinePath, ref: 'main',
+      });
+      const fileData = fileResponse.data as { content: string; sha: string };
+      quarantineContent = Buffer.from(fileData.content, 'base64').toString('utf-8');
+      quarantineSha = fileData.sha;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('[PII] Rescrub: failed to read quarantine file:', message);
+      return;
+    }
+
+    // Apply find/replace for each term → [REDACTED]
+    let scrubbedContent = quarantineContent;
+    let totalReplacements = 0;
+    for (const term of terms) {
+      const regex = new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
+      const matches = scrubbedContent.match(regex);
+      if (matches) {
+        totalReplacements += matches.length;
+        scrubbedContent = scrubbedContent.replace(regex, '[REDACTED]');
+      }
+    }
+
+    // Regenerate quarantine file with updated content
+    await octokit.rest.repos.createOrUpdateFileContents({
+      owner, repo, path: quarantinePath,
+      message: `Rescrub: ${terms.length} additional term(s) applied`,
+      content: Buffer.from(scrubbedContent).toString('base64'),
+      sha: quarantineSha,
+    });
+
+    console.log(`[PII] Rescrub complete: ${totalReplacements} replacement(s) from ${terms.length} term(s)`);
+    // Terms discarded here — not logged, not stored (§2.1 discipline)
+
+    // Rebuild the review modal with updated stats
+    // Count PII markers in the regenerated content for updated status
+    const phoneCount = (scrubbedContent.match(/\[PHONE\]/g) || []).length;
+    const emailCount = (scrubbedContent.match(/\[EMAIL\]/g) || []).length;
+    const participantNameCount = (scrubbedContent.match(new RegExp(participantCode.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length;
+    const redactedCount = (scrubbedContent.match(/\[REDACTED\]/g) || []).length;
+
+    const updatedStats: ScrubStats = {
+      participantName: participantNameCount,
+      moderatorName: (scrubbedContent.match(/\[Moderator\]/g) || []).length,
+      speakerLabels: 0,
+      phoneNumbers: phoneCount,
+      emailAddresses: emailCount,
+    };
+
+    const updatedModal = buildTranscriptReviewModal({
+      stats: updatedStats,
+      participantCode,
+      studyName,
+      fileUrl,
+      nameProvided: participantNameCount > 0,
+    });
+    updatedModal.private_metadata = (body as any).view?.private_metadata;
+
+    // Update the modal — attestation resets (no initial_options on checkbox)
+    await client.views.update({
+      view_id: (body as any).view?.id,
+      hash: (body as any).view?.hash,
+      view: updatedModal,
+    });
+
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[PII] Rescrub error:', message);
+  }
+};
+
 // ─── Manual notes approval via button click (DB-held quarantine) ─────────────────────
 
 /**
@@ -1153,6 +1270,7 @@ export {
   handleSessionSelectionChange,
   handleSessionNotesSubmission,
   handleTranscriptReviewApprove,
+  handleRescrub,
   handleManualNotesApprove,
   handleManualNotesReject,
 };

--- a/backend/src/helpers/slack/commands/sessionNotesHandler.ts
+++ b/backend/src/helpers/slack/commands/sessionNotesHandler.ts
@@ -903,10 +903,11 @@ const handleTranscriptReviewApprove = async ({ ack, body, view, client }: SlackV
     const quarantineSha = quarantineFile.data.sha;
 
     // 2. Flip PII marker from PENDING-REVIEW to REVIEWED-CLEARED
-    // Use regex for more robust matching (handles whitespace/encoding variations)
+    // First occurrence only — global /g over file body is silent evidence mutation
+    // if a participant ever says the phrase (ADR 0026 §5 over-redaction principle)
     const reviewedContent = rawContent
-      .replace(/<!--\s*PII-STATUS:\s*PENDING-REVIEW\s*-->/gi, '<!-- PII-STATUS: REVIEWED-CLEARED -->')
-      .replace(/\*\*PII Status:\*\*\s*Auto-scrubbed,?\s*pending human review/gi, `**PII Status:** Reviewed and cleared by <@${body.user.id}>`);
+      .replace(/<!--\s*PII-STATUS:\s*PENDING-REVIEW\s*-->/i, '<!-- PII-STATUS: REVIEWED-CLEARED -->')
+      .replace(/\*\*PII Status:\*\*\s*Auto-scrubbed,?\s*pending human review/i, `**PII Status:** Reviewed and cleared by <@${body.user.id}>`);
 
     // 3. Write to final location with updated marker
     const finalResult = await createOrUpdateFileOnGitHub(finalPath, reviewedContent);
@@ -992,6 +993,19 @@ const handleTranscriptReviewApprove = async ({ ack, body, view, client }: SlackV
 // ─── Rescrub loop — re-scrub quarantine with additional terms ─────────────────────
 
 /**
+ * Build a regex from a reviewer-typed term. Single audit point for all
+ * reviewer-supplied text → regex conversions.
+ *
+ * Escapes metacharacters, then anchors with lookarounds (not \b) so terms
+ * match at word edges without failing on non-word-char boundaries like
+ * "Dr. Patel" (where \b between "." and " " is not a word boundary).
+ */
+function buildTermRegex(term: string): RegExp {
+  const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?<!\\w)${escaped}(?!\\w)`, 'gi');
+}
+
+/**
  * Handle rescrub button click in the transcript review modal.
  *
  * Reads quarantine content from GitHub, applies additional find/replace terms,
@@ -1046,15 +1060,22 @@ const handleRescrub = async ({ ack, body, client }: SlackActionMiddlewareArgs<Bl
       return;
     }
 
-    // Apply find/replace for each term → [REDACTED]
+    // Apply find/replace for each term → [REDACTED] (word-boundary anchored)
     let scrubbedContent = quarantineContent;
     let totalReplacements = 0;
+    let zeroMatchCount = 0;
+    // Track per-term match counts positionally (transient — never rendered by text)
+    const perTermCounts: number[] = [];
     for (const term of terms) {
-      const regex = new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
+      const regex = buildTermRegex(term);
       const matches = scrubbedContent.match(regex);
-      if (matches) {
-        totalReplacements += matches.length;
+      const count = matches ? matches.length : 0;
+      perTermCounts.push(count);
+      if (count > 0) {
+        totalReplacements += count;
         scrubbedContent = scrubbedContent.replace(regex, '[REDACTED]');
+      } else {
+        zeroMatchCount++;
       }
     }
 
@@ -1066,11 +1087,11 @@ const handleRescrub = async ({ ack, body, client }: SlackActionMiddlewareArgs<Bl
       sha: quarantineSha,
     });
 
-    console.log(`[PII] Rescrub complete: ${totalReplacements} replacement(s) from ${terms.length} term(s)`);
+    console.log(`[PII] Rescrub complete: ${totalReplacements} replacement(s) from ${terms.length} term(s), ${zeroMatchCount} zero-match`);
     // Terms discarded here — not logged, not stored (§2.1 discipline)
+    // perTermCounts discarded — positional counts only, no term text
 
-    // Rebuild the review modal with updated stats
-    // Count PII markers in the regenerated content for updated status
+    // Count PII markers in the CURRENT file for cumulative status
     const phoneCount = (scrubbedContent.match(/\[PHONE\]/g) || []).length;
     const emailCount = (scrubbedContent.match(/\[EMAIL\]/g) || []).length;
     const participantNameCount = (scrubbedContent.match(new RegExp(participantCode.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length;
@@ -1082,7 +1103,19 @@ const handleRescrub = async ({ ack, body, client }: SlackActionMiddlewareArgs<Bl
       speakerLabels: 0,
       phoneNumbers: phoneCount,
       emailAddresses: emailCount,
+      redactedTerms: redactedCount,
     };
+
+    // Build positional match summary (aggregate numbers only, no term text)
+    const matchParts: string[] = [];
+    for (let i = 0; i < perTermCounts.length; i++) {
+      if (perTermCounts[i] === 0) {
+        matchParts.push(`term ${i + 1} matched 0 times`);
+      } else {
+        matchParts.push(`term ${i + 1} matched ${perTermCounts[i]} time${perTermCounts[i] !== 1 ? 's' : ''}`);
+      }
+    }
+    const rescrubSummary = `${terms.length} term${terms.length !== 1 ? 's' : ''} submitted · ${matchParts.join(' · ')} · ${redactedCount} redaction${redactedCount !== 1 ? 's' : ''} in this file`;
 
     const updatedModal = buildTranscriptReviewModal({
       stats: updatedStats,
@@ -1090,6 +1123,7 @@ const handleRescrub = async ({ ack, body, client }: SlackActionMiddlewareArgs<Bl
       studyName,
       fileUrl,
       nameProvided: participantNameCount > 0,
+      rescrubSummary,
     });
     updatedModal.private_metadata = (body as any).view?.private_metadata;
 

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -73,7 +73,7 @@ import { handleParticipantOutreachSubmit, handleInitialRecruitmentSubmit, handle
 import { handleAddObserverSubmission, handleSelfJoinObserver, handleSelfJoinSubmission } from './commands/addObserverHandler';
 
 // Session notes
-import { handleTabManual, handleTabUpload, handleSessionSelectionChange, handleSessionNotesSubmission, handleTranscriptReviewApprove, handleManualNotesApprove, handleManualNotesReject } from './commands/sessionNotesHandler';
+import { handleTabManual, handleTabUpload, handleSessionSelectionChange, handleSessionNotesSubmission, handleTranscriptReviewApprove, handleRescrub, handleManualNotesApprove, handleManualNotesReject } from './commands/sessionNotesHandler';
 
 // Analysis
 import { analyzeNotesHandler, handleAnalyzeNotesSubmission, handleStudySelectionChange as handleAnalyzeNotesStudyChange, handleSessionSelectionChange as handleAnalyzeNotesSessionChange } from './commands/analyzeNotesHandler';
@@ -591,6 +591,7 @@ slackApp.action('tab_upload', handleTabUpload);
 slackApp.action('session_select_change', handleSessionSelectionChange);
 slackApp.view('session_notes_submit', handleSessionNotesSubmission);
 slackApp.view('transcript_review_approve', handleTranscriptReviewApprove);
+slackApp.action('pii_rescrub', handleRescrub);
 slackApp.action('manual_notes_approve', handleManualNotesApprove);
 slackApp.action('manual_notes_reject', handleManualNotesReject);
 

--- a/backend/src/helpers/slack/ui/transcriptReviewModal.ts
+++ b/backend/src/helpers/slack/ui/transcriptReviewModal.ts
@@ -63,14 +63,14 @@ interface TranscriptReviewParams {
 export const buildTranscriptReviewModal = (params: TranscriptReviewParams): View => {
   const { stats, participantCode, studyName, fileUrl, nameProvided, rescrubSummary } = params;
 
-  // ── Honest status block ──────────────────────────
+  // ── Honest status block — three attributed lines ──────────────
+  // Line 1: Auto-scrub (machine only — no [REDACTED] count)
   const autoScrubLines: string[] = [];
   if (stats.phoneNumbers > 0) autoScrubLines.push(`${stats.phoneNumbers} phone number${stats.phoneNumbers !== 1 ? 's' : ''} → [PHONE]`);
   if (stats.emailAddresses > 0) autoScrubLines.push(`${stats.emailAddresses} email${stats.emailAddresses !== 1 ? 's' : ''} → [EMAIL]`);
   if (stats.participantName > 0) autoScrubLines.push(`participant name → ${participantCode}: ${stats.participantName} replacement${stats.participantName !== 1 ? 's' : ''}`);
   if (stats.moderatorName > 0) autoScrubLines.push(`moderator name → [Moderator]: ${stats.moderatorName}`);
   if (stats.speakerLabels > 0) autoScrubLines.push(`speaker labels: ${stats.speakerLabels}`);
-  if (stats.redactedTerms && stats.redactedTerms > 0) autoScrubLines.push(`${stats.redactedTerms} additional redaction${stats.redactedTerms !== 1 ? 's' : ''} → [REDACTED]`);
 
   const nameStatus = nameProvided
     ? `participant name → ${participantCode}`
@@ -80,9 +80,14 @@ export const buildTranscriptReviewModal = (params: TranscriptReviewParams): View
     ? `Auto-scrub applied: ${autoScrubLines.join(' · ')}`
     : `Auto-scrub applied: ${nameStatus}`;
 
-  // Append positional rescrub summary if present (aggregate numbers only)
+  // Line 3: Your rescrub (reviewer's redactions, not machine's)
+  // Omitted when redactedTerms is zero (no rescrub has occurred)
+  if (stats.redactedTerms && stats.redactedTerms > 0) {
+    statusText += `\nYour rescrub: ${stats.redactedTerms} redaction${stats.redactedTerms !== 1 ? 's' : ''} → [REDACTED]`;
+  }
   if (rescrubSummary) {
-    statusText += `\n${rescrubSummary}`;
+    // Append per-term positional counts for this pass
+    statusText += rescrubSummary.startsWith('\n') ? rescrubSummary : `\n${rescrubSummary}`;
   }
 
   return {

--- a/backend/src/helpers/slack/ui/transcriptReviewModal.ts
+++ b/backend/src/helpers/slack/ui/transcriptReviewModal.ts
@@ -120,9 +120,33 @@ export const buildTranscriptReviewModal = (params: TranscriptReviewParams): View
       },
       { type: 'divider' },
 
-      // Attestation checkbox — required for approval
-      // NOTE: Rescrub loop (additional terms field + re-scrub automation) deferred
-      // to follow-up PR — partial implementation would create false assurance.
+      // Rescrub loop — additional terms to scrub before approving
+      {
+        type: 'input',
+        block_id: 'rescrub_terms_block',
+        optional: true,
+        label: { type: 'plain_text', text: 'Additional names or terms to scrub' },
+        hint: { type: 'plain_text', text: 'Comma-separated. Used for find/replace only — not stored.' },
+        element: {
+          type: 'plain_text_input',
+          action_id: 'rescrub_terms',
+          placeholder: { type: 'plain_text', text: 'e.g., Sarah, Denver VA, Dr. Martinez' },
+        }
+      },
+      {
+        type: 'actions',
+        block_id: 'rescrub_action_block',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Rescrub' },
+            action_id: 'pii_rescrub',
+          }
+        ]
+      },
+      { type: 'divider' },
+
+      // Attestation checkbox — required for approval. Resets on rescrub.
       {
         type: 'input',
         block_id: 'attestation_block',

--- a/backend/src/helpers/slack/ui/transcriptReviewModal.ts
+++ b/backend/src/helpers/slack/ui/transcriptReviewModal.ts
@@ -34,6 +34,8 @@ export interface ScrubStats {
   speakerLabels: number;
   phoneNumbers: number;
   emailAddresses: number;
+  /** Count of [REDACTED] tokens from rescrub terms in the current file */
+  redactedTerms?: number;
 }
 
 interface TranscriptReviewParams {
@@ -47,6 +49,8 @@ interface TranscriptReviewParams {
   fileUrl: string;
   /** Whether a participant name was provided at upload */
   nameProvided: boolean;
+  /** Positional match summary from rescrub (aggregate numbers only, no term text) */
+  rescrubSummary?: string;
 }
 
 /**
@@ -57,23 +61,29 @@ interface TranscriptReviewParams {
  * Per ADR 0026 §2.3: reviewer's job is the headline.
  */
 export const buildTranscriptReviewModal = (params: TranscriptReviewParams): View => {
-  const { stats, participantCode, studyName, fileUrl, nameProvided } = params;
+  const { stats, participantCode, studyName, fileUrl, nameProvided, rescrubSummary } = params;
 
-  // ── Honest status block (item a) ──────────────────────────
+  // ── Honest status block ──────────────────────────
   const autoScrubLines: string[] = [];
   if (stats.phoneNumbers > 0) autoScrubLines.push(`${stats.phoneNumbers} phone number${stats.phoneNumbers !== 1 ? 's' : ''} → [PHONE]`);
   if (stats.emailAddresses > 0) autoScrubLines.push(`${stats.emailAddresses} email${stats.emailAddresses !== 1 ? 's' : ''} → [EMAIL]`);
   if (stats.participantName > 0) autoScrubLines.push(`participant name → ${participantCode}: ${stats.participantName} replacement${stats.participantName !== 1 ? 's' : ''}`);
   if (stats.moderatorName > 0) autoScrubLines.push(`moderator name → [Moderator]: ${stats.moderatorName}`);
   if (stats.speakerLabels > 0) autoScrubLines.push(`speaker labels: ${stats.speakerLabels}`);
+  if (stats.redactedTerms && stats.redactedTerms > 0) autoScrubLines.push(`${stats.redactedTerms} additional redaction${stats.redactedTerms !== 1 ? 's' : ''} → [REDACTED]`);
 
   const nameStatus = nameProvided
     ? `participant name → ${participantCode}`
     : 'no name provided at upload — names NOT scrubbed';
 
-  const statusText = autoScrubLines.length > 0
+  let statusText = autoScrubLines.length > 0
     ? `Auto-scrub applied: ${autoScrubLines.join(' · ')}`
     : `Auto-scrub applied: ${nameStatus}`;
+
+  // Append positional rescrub summary if present (aggregate numbers only)
+  if (rescrubSummary) {
+    statusText += `\n${rescrubSummary}`;
+  }
 
   return {
     type: 'modal',

--- a/docs/architecture-decisions/0026-pii-scrubbing-at-ingestion.md
+++ b/docs/architecture-decisions/0026-pii-scrubbing-at-ingestion.md
@@ -105,6 +105,8 @@ This residual is **bounded**: the repository is private with limited collaborato
 
 **Decision (2026-08-05):** Option 2 ships before the first study with external participants; internal studies proceed on the current bounded residual.
 
+**Blocking dependency (2026-08-05):** The rescrub loop currently writes each iteration as a new quarantine commit, so over-redaction from the rescrub is recoverable via repo history. When Option 2 moves quarantine off git, that recovery path disappears and over-redaction becomes irreversible. **Option 2 must ship WITH a preview-before-commit step in the rescrub loop** — reviewer sees per-term match counts and confirms before the write. This is a blocking dependency, not a backlog item.
+
 ### 6.1 Path bug found and fixed during verification
 
 While verifying this ADR's claims against code (§8), the transcript-write path was found to be **hardcoded to `03-sessions/`** in the upload handler, bypassing the canonical folder constant `STUDY_FOLDERS.FIELDWORK_TRANSCRIPTS` (`03-fieldwork/transcripts/`). The readout scanner reads `03-fieldwork/transcripts/`, so **approved transcripts were written to a location the readout never scanned** — a traceability break: the evidence existed but was invisible to the stage that assembles findings.


### PR DESCRIPTION
## Scope 1: PII rescrub loop — full implementation

Reviewer enters additional names/terms, clicks Rescrub → quarantine regenerates with word-boundary-anchored replacements, modal reopens with updated cumulative status, attestation resets.

### Implementation
- **buildTermRegex() helper** (`sessionNotesHandler.ts:1003-1006`): single audit point for reviewer-typed text → regex. Lookaround anchoring (`(?<!\w)...(?\w)`) prevents over-redaction inside words.
- **Positional match reporting:** "3 terms submitted · term 2 matched 0 times · 14 redactions in this file" — aggregate numbers only, no term text anywhere
- **ScrubStats.redactedTerms:** cumulative [REDACTED] count in current file, shown in honest status block
- **Attestation resets** on each rescrub (reviewer attests to regenerated version)
- **PENDING-REVIEW marker** scoped to first occurrence (was global /gi — silent evidence mutation risk)

### §2.1 discipline
Terms: in memory → find/replace → discarded. Count-only logging. Never in modal, DM, private_metadata, or error messages.

## Scope 2: ADR 0026 §6 — Option 2 blocking dependency

When quarantine moves off git, over-redaction recovery via repo history disappears. Option 2 must ship WITH a preview-before-commit step in the rescrub loop. Recorded as blocking dependency, not backlog.

## Files changed
- `sessionNotesHandler.ts` — rescrub handler + buildTermRegex helper + marker scoping
- `transcriptReviewModal.ts` — rescrub field + redactedTerms in ScrubStats + rescrubSummary display
- `events.ts` — `pii_rescrub` action registration (1 line)
- `0026-pii-scrubbing-at-ingestion.md` — §6 blocking dependency

## Test plan
- [ ] 141 tests pass (verified)
- [ ] Rescrub with "Dr. Patel" → matches at word boundary, not inside words
- [ ] Rescrub with "Al" → no match inside "California", "also"
- [ ] Status shows cumulative counts + positional summary
- [ ] Attestation resets after each rescrub
- [ ] Approve scopes PENDING-REVIEW to first occurrence only

🤖 Generated with [Claude Code](https://claude.com/claude-code)