### PR TITLE
fix: add [PII-SEQ] ordering logs to transcript review DM flow

### DIFF
--- a/backend/src/helpers/slack/commands/sessionNotesHandler.ts
+++ b/backend/src/helpers/slack/commands/sessionNotesHandler.ts
@@ -563,7 +563,7 @@ const handleSessionNotesSubmission = async ({ ack, body, view, client }: SlackVi
       };
 
       const scrubResult = scrubTranscript(rawContent, scrubCtx);
-      console.log(`[PII] Scrubbing complete: ${scrubResult.stats.participantName + scrubResult.stats.moderatorName + scrubResult.stats.speakerLabels + scrubResult.stats.phoneNumbers + scrubResult.stats.emailAddresses} items scrubbed`);
+      console.log(`[PII] Scrub pass: ${scrubResult.stats.participantName + scrubResult.stats.moderatorName + scrubResult.stats.speakerLabels + scrubResult.stats.phoneNumbers + scrubResult.stats.emailAddresses} items replaced`);
       // NOTE: Do NOT log the actual content or names
 
       // ── Build scrubbed transcript content with PII marker ──
@@ -650,6 +650,7 @@ ${scrubResult.content}`;
           throw new Error('DM post returned no ts/channel');
         }
         dmResult = { channel: postResult.channel, ts: postResult.ts };
+        console.log(`[PII-SEQ] 1/4 DM posted: channel=${dmResult.channel} ts=${dmResult.ts}`);
       } catch (dmErr) {
         // DM failed — ABORT. Nothing enters git. No orphan.
         const dmMessage = dmErr instanceof Error ? dmErr.message : String(dmErr);
@@ -682,9 +683,11 @@ ${scrubResult.content}`;
         text: `PII Review: ${templateData.study_name} - ${templateData.participant_id}`,
         blocks: finalDmBlocks,
       });
+      console.log(`[PII-SEQ] 2/4 DM button metadata attached`);
 
       // ── STEP 2: Commit quarantine file (permanent) ──
       // DM is already posted. If this fails, update DM to failure state.
+      console.log(`[PII-SEQ] 3/4 quarantine commit attempted`);
       try {
         await createOrUpdateFileOnGitHub(quarantinePath, scrubbedTranscriptContent);
         console.log(`[PII] Transcript saved to quarantine: ${quarantinePath}`);
@@ -699,6 +702,7 @@ ${scrubResult.content}`;
           text: 'Transcript could not be saved to quarantine.',
           blocks: failureBlocks,
         });
+        console.log(`[PII-SEQ] 4/4 DM updated to failure state`);
         return;
       }
 

--- a/docs/claims-audit.md
+++ b/docs/claims-audit.md
@@ -75,7 +75,7 @@ Every claim the system makes about its own behavior — in UI text, generated do
 
 | # | Status | Priority | Recommended action |
 |---|--------|----------|--------------------|
-| 2 | OPEN → REOPENED | **High** | #268 shipped honest-status block but spec item (d) shipped "Reject — needs source fix" as a close-button label with no handler, no note capture, no notification. Inert-control class. DM-swap PR fixes: reject handler with note → uploader DM, quarantine deletion, audit row. Old misleading footer (:155-158) and close-button label removed. |
+| 2 | OPEN → REOPENED | **High** | #268 shipped honest-status block but spec item (d) shipped "Reject — needs source fix" as a close-button label with no handler, no note capture, no notification. Inert-control class. DM-swap PR fixes: reject handler with note → uploader DM, quarantine deletion, audit row. Old misleading footer (:155-158) and close-button label removed. **Log line:** `[PII] Scrubbing complete: N items scrubbed` reworded to neutral `[PII] Scrub pass: N items replaced` — "complete" + "scrubbed" implied thoroughness the partial scrub doesn't guarantee. |
 | 3/33 | FALSE | **High** | §6.5/A1 rationale correction (in C2 PR #259) |
 | 4 | FIXED | — | PR #258 merged |
 | 6/8 | FALSE (dead) | Low | Delete `uploadNotesModal.ts` — dead code with false claims |


### PR DESCRIPTION
## Summary

- Adds four permanent `[PII-SEQ]` log lines to the transcript upload path, one at each step of the DM-first ordering contract:
  1. `[PII-SEQ] 1/4 DM posted: channel=... ts=...`
  2. `[PII-SEQ] 2/4 DM button metadata attached`
  3. `[PII-SEQ] 3/4 quarantine commit attempted`
  4. `[PII-SEQ] 4/4 DM updated to failure state`
- Rewords `[PII] Scrubbing complete: N items scrubbed` → `[PII] Scrub pass: N items replaced` (claims-audit #2 — old framing implied thoroughness the partial scrub doesn't guarantee)

## Why permanent

The DM-first ordering is a safety property (no orphan quarantine files without researcher notification). It must be verifiable in production logs on every upload, not just during ad-hoc testing.

## Test plan

- [ ] Re-run Test D (broken GitHub token) and confirm logs show `1/4 → 2/4 → 3/4 → 4/4` sequence
- [ ] Run Test A (happy path) and confirm `1/4 → 2/4 → 3/4` appear (no 4/4 on success)
- [ ] Verify no PII (names, content, participant identifiers beyond codes) appears in any log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)