### PR TITLE
fix: reword reject DM internal reference to plain language

### DIFF
--- a/backend/src/helpers/slack/ui/transcriptReviewModal.ts
+++ b/backend/src/helpers/slack/ui/transcriptReviewModal.ts
@@ -229,7 +229,8 @@ export function buildRejectedDmBlocks(studyName: string, participantCode: string
     {
       type: 'context',
       elements: [
-        { type: 'mrkdwn', text: 'Git history retains the quarantine version per ADR 0026 §6.' }
+        // ADR 0026 §6: quarantine version retained in git history permanently
+        { type: 'mrkdwn', text: 'The deleted file remains in the repository\'s version history.' }
       ]
     }
   ];


### PR DESCRIPTION
## Summary

- Rewords "Git history retains the quarantine version per ADR 0026 §6." → "The deleted file remains in the repository's version history." in the reject terminal-state DM
- ADR reference preserved in code comment for traceability
- **Sweep result:** This was the only internal reference (ADR number, spec section, §-citation) visible on any researcher-facing surface. All other ADR/§ references are in code comments, `authorization_basis` audit fields, or handler logic — none rendered in Block Kit text.

## Test plan

- [ ] Reject a transcript and verify the DM context line reads plain language, not ADR citation

🤖 Generated with [Claude Code](https://claude.com/claude-code)