### PR TITLE
feat(evidence): canonical evidence and lineage foundation

### DIFF
--- a/backend/src/__tests__/integration/evidence-foundation.test.ts
+++ b/backend/src/__tests__/integration/evidence-foundation.test.ts
@@ -1,0 +1,626 @@
+/**
+ * Evidence Foundation Integration Tests
+ *
+ * Per ADRs 0028-0030: Validates the canonical evidence layer —
+ * source persistence, construct persistence, FK-backed lineage,
+ * CHECK constraints, UUID public_ids, CASCADE deletion semantics,
+ * transactional derivation, and zero-use backward compatibility.
+ *
+ * Requires: PostgreSQL qori_test database with migrations applied.
+ */
+
+import { getTestDb, truncateAll } from './setup/testDb';
+
+const sequelize = getTestDb();
+
+// Mock GitHub functions to prevent actual API calls
+jest.mock('../../helpers/github', () => ({
+  fetchFileFromRepoByPath: jest.fn().mockResolvedValue(null),
+  createOrUpdateFileOnGitHub: jest.fn().mockResolvedValue({ success: true }),
+  getContentRepo: jest.fn().mockReturnValue('test-repo'),
+}));
+
+// Get models
+const Project = sequelize.models.Project;
+const ResearchStudy = sequelize.models.ResearchStudy;
+const EvidenceSourceModel = sequelize.models.EvidenceSource;
+const EvidenceConstructModel = sequelize.models.EvidenceConstruct;
+const EvidenceRelationshipModel = sequelize.models.EvidenceRelationship;
+const StudyVariableModel = sequelize.models.StudyVariable;
+
+// Test fixtures
+let projectId: number;
+let studyId: number;
+
+beforeEach(async () => {
+  await truncateAll();
+
+  const project = await Project.create({
+    name: 'Evidence Test Project',
+    slug: 'evidence-test-project',
+    status: 'active',
+    created_by: 'U_TEST',
+  });
+  projectId = (project as any).id;
+
+  const study = await ResearchStudy.create({
+    project_id: projectId,
+    name: 'Evidence Test Study',
+    slug: 'evidence-test-study',
+    path: 'evidence-test-project/evidence-test-study',
+    status: 'active',
+    created_by: 'U_TEST',
+    channel_name: 'test-evidence',
+    researcher_name: 'Test Researcher',
+    researcher_email: 'test@example.com',
+  });
+  studyId = (study as any).id;
+});
+
+afterAll(async () => {
+  await sequelize.close();
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// 1. SOURCE PERSISTENCE + UUID
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('evidence_sources', () => {
+  it('creates a project-scoped discovery source with auto-generated public_id', async () => {
+    const source = await EvidenceSourceModel.create({
+      project_id: projectId,
+      study_id: null,
+      source_type: 'uploaded_document',
+      label: 'VA Policy Document 2026',
+      artifact_ref: { github_path: '_discovery/desk-research/va-policy.pdf' },
+      metadata: { page_count: 42 },
+      created_by: 'U_TEST',
+    });
+
+    expect((source as any).id).toBeDefined();
+    expect((source as any).public_id).toBeDefined();
+    expect(typeof (source as any).public_id).toBe('string');
+    expect((source as any).public_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect((source as any).project_id).toBe(projectId);
+    expect((source as any).study_id).toBeNull();
+  });
+
+  it('creates a study-scoped source', async () => {
+    const source = await EvidenceSourceModel.create({
+      project_id: projectId,
+      study_id: studyId,
+      source_type: 'session_transcript',
+      label: 'PT-001 Session 1 Transcript',
+      created_by: 'U_TEST',
+    });
+
+    expect((source as any).study_id).toBe(studyId);
+  });
+
+  it('public_id is unique across sources', async () => {
+    const s1 = await EvidenceSourceModel.create({
+      project_id: projectId, source_type: 'uploaded_document',
+      label: 'Source A', created_by: 'U_TEST',
+    });
+    const s2 = await EvidenceSourceModel.create({
+      project_id: projectId, source_type: 'uploaded_document',
+      label: 'Source B', created_by: 'U_TEST',
+    });
+    expect((s1 as any).public_id).not.toBe((s2 as any).public_id);
+  });
+
+  it('public_id persists across updates', async () => {
+    const source = await EvidenceSourceModel.create({
+      project_id: projectId, source_type: 'uploaded_document',
+      label: 'Original', created_by: 'U_TEST',
+    });
+    const originalPublicId = (source as any).public_id;
+
+    await source.update({ label: 'Updated label' });
+
+    const reloaded = await EvidenceSourceModel.findByPk((source as any).id);
+    expect((reloaded as any).public_id).toBe(originalPublicId);
+  });
+
+  it('rejects source with invalid project_id FK', async () => {
+    await expect(
+      EvidenceSourceModel.create({
+        project_id: 99999, source_type: 'uploaded_document',
+        label: 'Orphaned source', created_by: 'U_TEST',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects source with invalid study_id FK', async () => {
+    await expect(
+      EvidenceSourceModel.create({
+        project_id: projectId, study_id: 99999,
+        source_type: 'uploaded_document',
+        label: 'Bad study ref', created_by: 'U_TEST',
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// 2. CONSTRUCT PERSISTENCE + UUID
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('evidence_constructs', () => {
+  it('creates a construct with stable ID, public_id, and JSONB payload', async () => {
+    const construct = await EvidenceConstructModel.create({
+      project_id: projectId,
+      construct_type: 'knowledge_gap',
+      label: 'VA upload process documentation gaps',
+      payload: {
+        id: 'KG-001',
+        summary: 'No documentation exists for the upload retry mechanism',
+      },
+      derivation_type: 'model',
+      derivation_context: {
+        model_name: 'claude-sonnet-4-6',
+        template_id: 'desk_research',
+      },
+      status: 'candidate',
+      created_by: 'U_TEST',
+    });
+
+    expect((construct as any).id).toBeDefined();
+    expect((construct as any).public_id).toBeDefined();
+    expect((construct as any).public_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+
+    // Verify roundtrip of JSONB payload
+    const retrieved = await EvidenceConstructModel.findByPk((construct as any).id);
+    expect((retrieved as any).payload).toEqual({
+      id: 'KG-001',
+      summary: 'No documentation exists for the upload retry mechanism',
+    });
+    expect((retrieved as any).public_id).toBe((construct as any).public_id);
+  });
+
+  it('public_id persists across status transitions', async () => {
+    const construct = await EvidenceConstructModel.create({
+      project_id: projectId, construct_type: 'finding',
+      label: 'Test', status: 'candidate', created_by: 'U_TEST',
+    });
+    const originalPublicId = (construct as any).public_id;
+
+    await construct.update({ status: 'accepted', reviewed_by: 'U_REVIEWER', reviewed_at: new Date() });
+
+    const updated = await EvidenceConstructModel.findByPk((construct as any).id);
+    expect((updated as any).public_id).toBe(originalPublicId);
+    expect((updated as any).status).toBe('accepted');
+  });
+
+  it('defaults status to candidate and derivation_type to model', async () => {
+    const construct = await EvidenceConstructModel.create({
+      project_id: projectId, construct_type: 'barrier',
+      label: 'Test barrier', created_by: 'U_TEST',
+    });
+    expect((construct as any).status).toBe('candidate');
+    expect((construct as any).derivation_type).toBe('model');
+  });
+
+  it('enforces project scope FK', async () => {
+    await expect(
+      EvidenceConstructModel.create({
+        project_id: 99999, construct_type: 'barrier',
+        label: 'Orphaned', created_by: 'U_TEST',
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// 3. FK-BACKED LINEAGE + CHECK CONSTRAINTS
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('evidence_relationships — FK integrity', () => {
+  let sourceId: number;
+  let constructAId: number;
+  let constructBId: number;
+
+  beforeEach(async () => {
+    const source = await EvidenceSourceModel.create({
+      project_id: projectId, source_type: 'uploaded_document',
+      label: 'Policy doc', created_by: 'U_TEST',
+    });
+    sourceId = (source as any).id;
+
+    const constructA = await EvidenceConstructModel.create({
+      project_id: projectId, construct_type: 'knowledge_gap',
+      label: 'Gap A', created_by: 'U_TEST',
+    });
+    constructAId = (constructA as any).id;
+
+    const constructB = await EvidenceConstructModel.create({
+      project_id: projectId, construct_type: 'research_question',
+      label: 'RQ from Gap A', created_by: 'U_TEST',
+    });
+    constructBId = (constructB as any).id;
+  });
+
+  it('valid source → construct works', async () => {
+    const rel = await EvidenceRelationshipModel.create({
+      from_source_id: sourceId,
+      from_construct_id: null,
+      to_source_id: null,
+      to_construct_id: constructAId,
+      relationship_type: 'DERIVED_FROM',
+      provenance: { method: 'desk_research_extraction' },
+    });
+
+    expect((rel as any).id).toBeDefined();
+    expect((rel as any).public_id).toBeDefined();
+    expect((rel as any).from_source_id).toBe(sourceId);
+    expect((rel as any).from_construct_id).toBeNull();
+    expect((rel as any).to_construct_id).toBe(constructAId);
+    expect((rel as any).to_source_id).toBeNull();
+  });
+
+  it('valid construct → construct works', async () => {
+    const rel = await EvidenceRelationshipModel.create({
+      from_source_id: null,
+      from_construct_id: constructAId,
+      to_source_id: null,
+      to_construct_id: constructBId,
+      relationship_type: 'ADDRESSES',
+    });
+
+    expect((rel as any).from_construct_id).toBe(constructAId);
+    expect((rel as any).to_construct_id).toBe(constructBId);
+  });
+
+  it('nonexistent source endpoint fails at DB level', async () => {
+    await expect(
+      EvidenceRelationshipModel.create({
+        from_source_id: 99999,
+        from_construct_id: null,
+        to_source_id: null,
+        to_construct_id: constructAId,
+        relationship_type: 'DERIVED_FROM',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('nonexistent construct endpoint fails at DB level', async () => {
+    await expect(
+      EvidenceRelationshipModel.create({
+        from_source_id: null,
+        from_construct_id: 99999,
+        to_source_id: null,
+        to_construct_id: constructAId,
+        relationship_type: 'SUPPORTS',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('zero FROM endpoints fails (CHECK constraint)', async () => {
+    await expect(
+      EvidenceRelationshipModel.create({
+        from_source_id: null,
+        from_construct_id: null,
+        to_source_id: null,
+        to_construct_id: constructAId,
+        relationship_type: 'DERIVED_FROM',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('two FROM endpoints fails (CHECK constraint)', async () => {
+    await expect(
+      EvidenceRelationshipModel.create({
+        from_source_id: sourceId,
+        from_construct_id: constructAId,
+        to_source_id: null,
+        to_construct_id: constructBId,
+        relationship_type: 'DERIVED_FROM',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('zero TO endpoints fails (CHECK constraint)', async () => {
+    await expect(
+      EvidenceRelationshipModel.create({
+        from_source_id: sourceId,
+        from_construct_id: null,
+        to_source_id: null,
+        to_construct_id: null,
+        relationship_type: 'DERIVED_FROM',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('two TO endpoints fails (CHECK constraint)', async () => {
+    await expect(
+      EvidenceRelationshipModel.create({
+        from_source_id: sourceId,
+        from_construct_id: null,
+        to_source_id: sourceId,
+        to_construct_id: constructAId,
+        relationship_type: 'DERIVED_FROM',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('deletion of source cascades to its relationship edges (no orphan lineage)', async () => {
+    await EvidenceRelationshipModel.create({
+      from_source_id: sourceId,
+      from_construct_id: null,
+      to_source_id: null,
+      to_construct_id: constructAId,
+      relationship_type: 'DERIVED_FROM',
+    });
+
+    // Delete the source
+    await EvidenceSourceModel.destroy({ where: { id: sourceId } });
+
+    // Relationship should be gone
+    const rels = await EvidenceRelationshipModel.count();
+    expect(rels).toBe(0);
+  });
+
+  it('deletion of construct cascades to its relationship edges', async () => {
+    await EvidenceRelationshipModel.create({
+      from_source_id: null,
+      from_construct_id: constructAId,
+      to_source_id: null,
+      to_construct_id: constructBId,
+      relationship_type: 'ADDRESSES',
+    });
+
+    // Delete constructA (the from side)
+    await EvidenceConstructModel.destroy({ where: { id: constructAId } });
+
+    const rels = await EvidenceRelationshipModel.count();
+    expect(rels).toBe(0);
+  });
+
+  it('supports forward query (from source)', async () => {
+    await EvidenceRelationshipModel.create({
+      from_source_id: sourceId, from_construct_id: null,
+      to_source_id: null, to_construct_id: constructAId,
+      relationship_type: 'DERIVED_FROM',
+    });
+
+    const rels = await EvidenceRelationshipModel.findAll({
+      where: { from_source_id: sourceId },
+    });
+    expect(rels).toHaveLength(1);
+    expect((rels[0] as any).to_construct_id).toBe(constructAId);
+  });
+
+  it('supports reverse query (to construct)', async () => {
+    await EvidenceRelationshipModel.create({
+      from_source_id: null, from_construct_id: constructAId,
+      to_source_id: null, to_construct_id: constructBId,
+      relationship_type: 'ADDRESSES',
+    });
+
+    const rels = await EvidenceRelationshipModel.findAll({
+      where: { to_construct_id: constructBId },
+    });
+    expect(rels).toHaveLength(1);
+    expect((rels[0] as any).from_construct_id).toBe(constructAId);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// 4. TRANSACTIONAL DERIVATION
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('transactional derivation', () => {
+  it('creates construct + relationships atomically', async () => {
+    const source = await EvidenceSourceModel.create({
+      project_id: projectId, source_type: 'stakeholder_interview',
+      label: 'Interview with PM', created_by: 'U_TEST',
+    });
+    const sourceId = (source as any).id;
+
+    const result = await sequelize.transaction(async (t) => {
+      const construct = await EvidenceConstructModel.create({
+        project_id: projectId,
+        construct_type: 'stakeholder_constraint',
+        label: 'Must comply with Section 508',
+        payload: { constraint_type: 'regulatory' },
+        derivation_type: 'human',
+        created_by: 'U_TEST',
+      }, { transaction: t });
+
+      const rel = await EvidenceRelationshipModel.create({
+        from_source_id: sourceId,
+        from_construct_id: null,
+        to_source_id: null,
+        to_construct_id: (construct as any).id,
+        relationship_type: 'DERIVED_FROM',
+      }, { transaction: t });
+
+      return { construct, rel };
+    });
+
+    expect(await EvidenceConstructModel.findByPk((result.construct as any).id)).not.toBeNull();
+    expect(await EvidenceRelationshipModel.findByPk((result.rel as any).id)).not.toBeNull();
+  });
+
+  it('rolls back all records on forced failure', async () => {
+    const countBefore = await EvidenceConstructModel.count();
+
+    try {
+      await sequelize.transaction(async (t) => {
+        await EvidenceConstructModel.create({
+          project_id: projectId, construct_type: 'barrier',
+          label: 'Will be rolled back', created_by: 'U_TEST',
+        }, { transaction: t });
+        throw new Error('Simulated derivation failure');
+      });
+    } catch { /* expected */ }
+
+    expect(await EvidenceConstructModel.count()).toBe(countBefore);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// 5. DELETION BEHAVIOR — CASCADE SEMANTICS
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('deletion behavior', () => {
+  it('cascades evidence deletion when project is deleted', async () => {
+    await EvidenceSourceModel.create({
+      project_id: projectId, source_type: 'uploaded_document',
+      label: 'Will cascade delete', created_by: 'U_TEST',
+    });
+    await EvidenceConstructModel.create({
+      project_id: projectId, construct_type: 'knowledge_gap',
+      label: 'Will cascade delete', created_by: 'U_TEST',
+    });
+
+    await Project.destroy({ where: { id: projectId } });
+
+    expect(await EvidenceSourceModel.count({ where: { project_id: projectId } })).toBe(0);
+    expect(await EvidenceConstructModel.count({ where: { project_id: projectId } })).toBe(0);
+  });
+
+  it('study-scoped source/construct is deleted with its study', async () => {
+    await EvidenceSourceModel.create({
+      project_id: projectId, study_id: studyId,
+      source_type: 'session_transcript',
+      label: 'Study-scoped transcript', created_by: 'U_TEST',
+    });
+    await EvidenceConstructModel.create({
+      project_id: projectId, study_id: studyId,
+      construct_type: 'nugget',
+      label: 'Study-scoped nugget', created_by: 'U_TEST',
+    });
+
+    await ResearchStudy.destroy({ where: { id: studyId } });
+
+    // Study-scoped evidence must be gone, NOT reclassified as project-scoped
+    expect(await EvidenceSourceModel.count({ where: { project_id: projectId } })).toBe(0);
+    expect(await EvidenceConstructModel.count({ where: { project_id: projectId } })).toBe(0);
+  });
+
+  it('nothing formerly study-scoped remains as study_id = NULL', async () => {
+    await EvidenceConstructModel.create({
+      project_id: projectId, study_id: studyId,
+      construct_type: 'nugget', label: 'Study nugget', created_by: 'U_TEST',
+    });
+
+    await ResearchStudy.destroy({ where: { id: studyId } });
+
+    const remaining = await EvidenceConstructModel.findAll({
+      where: { project_id: projectId },
+    });
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('project-scoped discovery source survives unrelated study deletion', async () => {
+    // Discovery source: project-scoped (study_id = NULL)
+    await EvidenceSourceModel.create({
+      project_id: projectId, study_id: null,
+      source_type: 'uploaded_document',
+      label: 'Discovery source', created_by: 'U_TEST',
+    });
+
+    // Delete the study — should not affect discovery source
+    await ResearchStudy.destroy({ where: { id: studyId } });
+
+    const remaining = await EvidenceSourceModel.findAll({
+      where: { project_id: projectId },
+    });
+    expect(remaining).toHaveLength(1);
+    expect((remaining[0] as any).label).toBe('Discovery source');
+    expect((remaining[0] as any).study_id).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// 6. ZERO-USE BACKWARD COMPATIBILITY
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('zero-use backward compatibility', () => {
+  it('existing study_variables operations work when evidence tables are empty', async () => {
+    expect(await EvidenceSourceModel.count()).toBe(0);
+    expect(await EvidenceConstructModel.count()).toBe(0);
+    expect(await EvidenceRelationshipModel.count()).toBe(0);
+
+    const variable = await StudyVariableModel.create({
+      project_id: projectId, study_id: studyId,
+      variable_key: 'discovered_barriers', variable_type: 'pool',
+      value: { id: 'DB-001', title: 'Test barrier', summary: 'A barrier' },
+      source_template: 'desk_research', source_version: '7.0',
+      is_pool: true, item_key: 'DB-001', scope: 'study',
+      extracted_at: new Date(),
+    });
+
+    expect((variable as any).id).toBeDefined();
+    const retrieved = await StudyVariableModel.findByPk((variable as any).id);
+    expect((retrieved as any).value).toEqual({
+      id: 'DB-001', title: 'Test barrier', summary: 'A barrier',
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// 7. MULTI-HOP LINEAGE CHAIN
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('multi-hop lineage', () => {
+  it('source → gap → question → nugget chain with FK-backed edges', async () => {
+    const source = await EvidenceSourceModel.create({
+      project_id: projectId, source_type: 'uploaded_document',
+      label: 'Policy analysis', created_by: 'U_TEST',
+    });
+
+    const gap = await EvidenceConstructModel.create({
+      project_id: projectId, construct_type: 'knowledge_gap',
+      label: 'Unknown upload success rate', created_by: 'U_TEST',
+    });
+
+    const question = await EvidenceConstructModel.create({
+      project_id: projectId, study_id: studyId,
+      construct_type: 'research_question',
+      label: 'What is the upload success rate?', created_by: 'U_TEST',
+    });
+
+    const nugget = await EvidenceConstructModel.create({
+      project_id: projectId, study_id: studyId,
+      construct_type: 'nugget',
+      label: 'PT-001 reported 3 failed uploads',
+      payload: { participant: 'PT-001', session: 'S1', severity: 3 },
+      created_by: 'U_TEST',
+    });
+
+    // Create lineage chain with FK columns
+    await EvidenceRelationshipModel.bulkCreate([
+      {
+        from_source_id: (source as any).id, from_construct_id: null,
+        to_source_id: null, to_construct_id: (gap as any).id,
+        relationship_type: 'DERIVED_FROM',
+      },
+      {
+        from_source_id: null, from_construct_id: (gap as any).id,
+        to_source_id: null, to_construct_id: (question as any).id,
+        relationship_type: 'ADDRESSES',
+      },
+      {
+        from_source_id: null, from_construct_id: (nugget as any).id,
+        to_source_id: null, to_construct_id: (question as any).id,
+        relationship_type: 'ADDRESSES',
+      },
+    ]);
+
+    // Verify: what addresses the research question?
+    const addressors = await EvidenceRelationshipModel.findAll({
+      where: { to_construct_id: (question as any).id, relationship_type: 'ADDRESSES' },
+    });
+    expect(addressors).toHaveLength(2);
+
+    const fromConstructIds = addressors.map((r: any) => r.from_construct_id);
+    expect(fromConstructIds).toContain((gap as any).id);
+    expect(fromConstructIds).toContain((nugget as any).id);
+  });
+});

--- a/backend/src/__tests__/integration/setup/testDb.ts
+++ b/backend/src/__tests__/integration/setup/testDb.ts
@@ -28,6 +28,9 @@ import StudyVariable from '../../../database/models/study_variable';
 import CreatedIssue from '../../../database/models/created_issue';
 import SlackUserState from '../../../database/models/slack_user_state';
 import DispositionAuditLog from '../../../database/models/disposition_audit_log';
+import EvidenceSource from '../../../database/models/evidence_source';
+import EvidenceConstruct from '../../../database/models/evidence_construct';
+import EvidenceRelationship from '../../../database/models/evidence_relationship';
 
 let instance: Sequelize | null = null;
 
@@ -53,7 +56,7 @@ export function getTestDb(): Sequelize {
     ChannelConfig, Project, ProjectMember, ResearchStudy, ResearchStudyUserRole,
     StudyStatus, StudyParticipant, SessionObserver, StudyNotes,
     ResearchPlan, SessionSummary, StudyVariable, CreatedIssue, SlackUserState,
-    DispositionAuditLog,
+    DispositionAuditLog, EvidenceSource, EvidenceConstruct, EvidenceRelationship,
   ];
 
   for (const defineModel of modelDefiners) {

--- a/backend/src/__tests__/unit/evidence-projection.test.ts
+++ b/backend/src/__tests__/unit/evidence-projection.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit tests for the evidence projection seam.
+ *
+ * Tests verify:
+ * - Accepted valid constructs project correctly
+ * - Non-accepted constructs are not projected
+ * - Accepted malformed constructs fail loudly (EvidenceProjectionError)
+ * - Projected shape satisfies destination cascade schema
+ * - Projection performs no LLM call (deterministic)
+ * - Same construct produces identical projection repeatedly
+ *
+ * No database required.
+ */
+
+import {
+  projectConstruct,
+  registerProjection,
+  hasProjection,
+} from '../../services/evidence-projection.service';
+import type { EvidenceConstruct } from '../../database/models/evidence_construct';
+import { EvidenceProjectionError } from '../../types/handlers';
+
+// Helper: create a minimal EvidenceConstruct-shaped object for testing
+function fakeConstruct(overrides: Partial<EvidenceConstruct> = {}): EvidenceConstruct {
+  return {
+    id: 1,
+    public_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    project_id: 100,
+    study_id: null,
+    construct_type: 'knowledge_gap',
+    label: 'Test gap',
+    payload: {
+      id: 'KG-001',
+      title: 'Test gap title',
+      summary: 'A knowledge gap',
+      source_document: 'doc1.pdf',
+      evidence: ['doc1.pdf'],
+    },
+    derivation_type: 'deterministic',
+    derivation_context: null,
+    status: 'accepted',
+    reviewed_by: 'U12345',
+    reviewed_at: new Date(),
+    cascade_variable_key: null,
+    created_by: 'U12345',
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  } as unknown as EvidenceConstruct;
+}
+
+describe('evidence-projection.service', () => {
+  describe('projectConstruct — accepted valid construct', () => {
+    it('projects an accepted knowledge_gap into cascade-compatible shape', () => {
+      const construct = fakeConstruct({
+        construct_type: 'knowledge_gap',
+        payload: {
+          id: 'KG-001',
+          title: 'VA upload process gaps',
+          summary: 'Multiple steps require redundant data entry',
+          domain: 'usability',
+          evidence: ['doc1.pdf', 'doc2.pdf'],
+          source_document: 'desk-research-report.md',
+          confidence: 'Strong',
+        },
+        status: 'accepted',
+      });
+
+      const result = projectConstruct(construct);
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(1);
+
+      const projection = result![0];
+      expect(projection.variable_key).toBe('knowledge_gaps');
+      expect(projection.is_pool).toBe(true);
+      expect(projection.item_key).toBe('KG-001');
+      expect(projection.source_template).toBe('evidence_projection');
+      expect(projection.value).toEqual({
+        id: 'KG-001',
+        title: 'VA upload process gaps',
+        summary: 'Multiple steps require redundant data entry',
+        domain: 'usability',
+        evidence: ['doc1.pdf', 'doc2.pdf'],
+        source_document: 'desk-research-report.md',
+        confidence: 'Strong',
+      });
+    });
+
+    it('projects an accepted barrier into discovered_barriers shape', () => {
+      const construct = fakeConstruct({
+        construct_type: 'barrier',
+        payload: {
+          id: 'DB-003',
+          title: 'File size limit blocks uploads',
+          summary: 'Users cannot upload files larger than 10MB',
+          magnitude: 'high',
+          evidence: ['session-3-notes.md'],
+          affected_population: 'Veterans with large medical records',
+          source_document: 'session_notes',
+          confidence: 'Moderate',
+        },
+        status: 'accepted',
+      });
+
+      const result = projectConstruct(construct);
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(1);
+      expect(result![0].variable_key).toBe('discovered_barriers');
+      expect(result![0].is_pool).toBe(true);
+      expect(result![0].value.id).toBe('DB-003');
+      expect(result![0].value.magnitude).toBe('high');
+    });
+  });
+
+  describe('projectConstruct — non-accepted constructs', () => {
+    it('returns null for candidate constructs', () => {
+      const construct = fakeConstruct({ status: 'candidate' });
+      expect(projectConstruct(construct)).toBeNull();
+    });
+
+    it('returns null for rejected constructs', () => {
+      const construct = fakeConstruct({ status: 'rejected' });
+      expect(projectConstruct(construct)).toBeNull();
+    });
+
+    it('returns null for overridden constructs', () => {
+      const construct = fakeConstruct({ status: 'overridden' });
+      expect(projectConstruct(construct)).toBeNull();
+    });
+
+    it('returns null for construct types without a registered projection', () => {
+      const construct = fakeConstruct({
+        construct_type: 'persona',
+        status: 'accepted',
+      });
+      expect(projectConstruct(construct)).toBeNull();
+    });
+  });
+
+  describe('projectConstruct — fail-closed on malformed accepted constructs', () => {
+    it('throws EvidenceProjectionError when payload is null', () => {
+      const construct = fakeConstruct({
+        construct_type: 'knowledge_gap',
+        payload: null,
+        status: 'accepted',
+      });
+
+      expect(() => projectConstruct(construct)).toThrow(EvidenceProjectionError);
+    });
+
+    it('throws EvidenceProjectionError when required field "id" is missing', () => {
+      const construct = fakeConstruct({
+        construct_type: 'knowledge_gap',
+        payload: { title: 'Has title', summary: 'Has summary', source_document: 'doc.pdf' },
+        status: 'accepted',
+      });
+
+      expect(() => projectConstruct(construct)).toThrow(EvidenceProjectionError);
+      try {
+        projectConstruct(construct);
+      } catch (e) {
+        expect((e as EvidenceProjectionError).missingFields).toContain('id');
+      }
+    });
+
+    it('throws EvidenceProjectionError when required field "summary" is missing', () => {
+      const construct = fakeConstruct({
+        construct_type: 'barrier',
+        payload: { id: 'DB-001', title: 'Has title', source_document: 'doc.pdf' },
+        status: 'accepted',
+      });
+
+      expect(() => projectConstruct(construct)).toThrow(EvidenceProjectionError);
+      try {
+        projectConstruct(construct);
+      } catch (e) {
+        expect((e as EvidenceProjectionError).missingFields).toContain('summary');
+      }
+    });
+
+    it('throws EvidenceProjectionError when multiple required fields are missing', () => {
+      const construct = fakeConstruct({
+        construct_type: 'knowledge_gap',
+        payload: { domain: 'usability' }, // missing id, title, summary, source_document
+        status: 'accepted',
+      });
+
+      expect(() => projectConstruct(construct)).toThrow(EvidenceProjectionError);
+      try {
+        projectConstruct(construct);
+      } catch (e) {
+        const err = e as EvidenceProjectionError;
+        expect(err.missingFields).toContain('id');
+        expect(err.missingFields).toContain('title');
+        expect(err.missingFields).toContain('summary');
+        expect(err.missingFields).toContain('source_document');
+      }
+    });
+  });
+
+  describe('projectConstruct — deterministic (idempotent)', () => {
+    it('same construct produces identical projection repeatedly', () => {
+      const construct = fakeConstruct({
+        construct_type: 'knowledge_gap',
+        payload: {
+          id: 'KG-STABLE',
+          title: 'Stable gap',
+          summary: 'Always the same',
+          source_document: 'doc.pdf',
+        },
+        status: 'accepted',
+      });
+
+      const result1 = projectConstruct(construct);
+      const result2 = projectConstruct(construct);
+      const result3 = projectConstruct(construct);
+
+      expect(result1).toEqual(result2);
+      expect(result2).toEqual(result3);
+    });
+  });
+
+  describe('registry', () => {
+    it('hasProjection returns true for registered types', () => {
+      expect(hasProjection('knowledge_gap')).toBe(true);
+      expect(hasProjection('barrier')).toBe(true);
+    });
+
+    it('hasProjection returns false for unregistered types', () => {
+      expect(hasProjection('persona')).toBe(false);
+      expect(hasProjection('ticket_candidate')).toBe(false);
+    });
+
+    it('allows registering custom projections with schema', () => {
+      registerProjection(
+        'finding',
+        (construct) => [{
+          variable_key: 'prioritized_finding',
+          value: {
+            id: String(construct.payload!.id),
+            title: String(construct.payload!.title),
+          },
+          source_template: 'evidence_projection',
+          is_pool: true,
+          item_key: String(construct.payload!.id),
+        }],
+        { requiredPayloadFields: ['id', 'title'] },
+      );
+
+      expect(hasProjection('finding')).toBe(true);
+
+      const result = projectConstruct(fakeConstruct({
+        construct_type: 'finding',
+        payload: { id: 'F-001', title: 'Test finding' },
+        status: 'accepted',
+      }));
+
+      expect(result).not.toBeNull();
+      expect(result![0].variable_key).toBe('prioritized_finding');
+    });
+  });
+});

--- a/backend/src/database/index.ts
+++ b/backend/src/database/index.ts
@@ -17,6 +17,9 @@ import StudyVariable from './models/study_variable';
 import CreatedIssue from './models/created_issue';
 import SlackUserState from './models/slack_user_state';
 import DispositionAuditLog from './models/disposition_audit_log';
+import EvidenceSource from './models/evidence_source';
+import EvidenceConstruct from './models/evidence_construct';
+import EvidenceRelationship from './models/evidence_relationship';
 
 
 // Set environment and configuration
@@ -44,6 +47,9 @@ const modelDefiners = [
   CreatedIssue,
   SlackUserState,
   DispositionAuditLog,
+  EvidenceSource,
+  EvidenceConstruct,
+  EvidenceRelationship,
 ];
 
 // Register all models with Sequelize

--- a/backend/src/database/migrations/20260816000000-create-evidence-tables.js
+++ b/backend/src/database/migrations/20260816000000-create-evidence-tables.js
@@ -1,0 +1,367 @@
+'use strict';
+
+/**
+ * Migration: Create evidence foundation tables
+ *
+ * Per ADRs 0028-0030: Introduces the canonical evidence layer alongside
+ * the existing cascade variable store. Three tables:
+ *
+ *   evidence_sources      — metadata about evidence-bearing inputs
+ *   evidence_constructs   — typed research objects with stable IDs
+ *   evidence_relationships — directed typed edges (lineage graph)
+ *
+ * All tables are additive. The existing cascade pipeline (study_variables)
+ * is unchanged. The application operates normally when these tables are empty.
+ *
+ * Identity: Each table has an integer PK (internal joins) and a UUID
+ * public_id (durable external identity per ADR 0030).
+ *
+ * FK behavior:
+ *   - project_id: CASCADE (project deletion removes its evidence)
+ *   - study_id: CASCADE (study deletion removes study-scoped evidence;
+ *     project-scoped discovery evidence has study_id = NULL and is unaffected)
+ *   - relationship FKs: CASCADE (deleting a source or construct removes
+ *     its relationship edges)
+ *
+ * Lineage integrity:
+ *   - Relationship endpoints use real FK columns (from_source_id,
+ *     from_construct_id, to_source_id, to_construct_id) with CHECK
+ *     constraints enforcing exactly one FROM and one TO endpoint.
+ */
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // ── evidence_sources ──────────────────────────────────────────────
+    await queryInterface.createTable('evidence_sources', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      public_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        unique: true,
+        defaultValue: Sequelize.literal('gen_random_uuid()'),
+        comment: 'Durable external identity — stable across regeneration',
+      },
+
+      // Scope
+      project_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'projects', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      study_id: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: { model: 'research_studies', key: 'id' },
+        onDelete: 'CASCADE',
+        comment: 'NULL for project-scoped discovery sources; CASCADE deletes study-scoped sources with study',
+      },
+
+      // Source identity
+      source_type: {
+        type: Sequelize.STRING(50),
+        allowNull: false,
+        comment: 'uploaded_document | survey_dataset | stakeholder_interview | session_transcript | session_notes | process_document | external_reference',
+      },
+      label: {
+        type: Sequelize.STRING(500),
+        allowNull: false,
+        comment: 'Human-readable label for the source',
+      },
+
+      // Artifact reference (pointer to where the content lives)
+      artifact_ref: {
+        type: Sequelize.JSONB,
+        allowNull: true,
+        comment: 'Reference to source artifact: { github_path, github_sha, study_notes_id, file_url, ... }',
+      },
+
+      // Metadata
+      metadata: {
+        type: Sequelize.JSONB,
+        allowNull: true,
+        comment: 'Source-type-specific metadata: { participant_count, date_collected, methodology, ... }',
+      },
+
+      created_by: {
+        type: Sequelize.STRING(50),
+        allowNull: false,
+        comment: 'Slack user ID of creator',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+
+    // ── evidence_constructs ───────────────────────────────────────────
+    await queryInterface.createTable('evidence_constructs', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      public_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        unique: true,
+        defaultValue: Sequelize.literal('gen_random_uuid()'),
+        comment: 'Durable external identity — stable across regeneration',
+      },
+
+      // Scope
+      project_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'projects', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      study_id: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: { model: 'research_studies', key: 'id' },
+        onDelete: 'CASCADE',
+        comment: 'NULL for project-scoped constructs; CASCADE deletes study-scoped constructs with study',
+      },
+
+      // Type and identity
+      construct_type: {
+        type: Sequelize.STRING(80),
+        allowNull: false,
+        comment: 'knowledge_gap | barrier | research_question | stakeholder_constraint | nugget | survey_pattern | usability_finding | journey_stage | recommendation | finding | theme | persona | ticket_candidate',
+      },
+      label: {
+        type: Sequelize.STRING(500),
+        allowNull: true,
+        comment: 'Human-readable label; NULL for constructs where the payload IS the label',
+      },
+
+      // Structured payload
+      payload: {
+        type: Sequelize.JSONB,
+        allowNull: true,
+        comment: 'Construct-type-specific structured data',
+      },
+
+      // Derivation metadata (ADR 0028)
+      derivation_type: {
+        type: Sequelize.STRING(20),
+        allowNull: false,
+        defaultValue: 'model',
+        comment: 'deterministic | model | human | hybrid',
+      },
+      derivation_context: {
+        type: Sequelize.JSONB,
+        allowNull: true,
+        comment: '{ model_name, model_version, template_id, template_version, method, ... }',
+      },
+
+      // Status (ADR ruling #6: human authority)
+      status: {
+        type: Sequelize.STRING(20),
+        allowNull: false,
+        defaultValue: 'candidate',
+        comment: 'candidate | accepted | rejected | overridden',
+      },
+      reviewed_by: {
+        type: Sequelize.STRING(50),
+        allowNull: true,
+        comment: 'Slack user ID of reviewer, if reviewed',
+      },
+      reviewed_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+
+      // Cascade cross-reference
+      cascade_variable_key: {
+        type: Sequelize.STRING(100),
+        allowNull: true,
+        comment: 'Corresponding study_variables.variable_key, if projected to cascade',
+      },
+
+      created_by: {
+        type: Sequelize.STRING(50),
+        allowNull: false,
+        comment: 'Slack user ID of creator',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+
+    // ── evidence_relationships ────────────────────────────────────────
+    await queryInterface.createTable('evidence_relationships', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      public_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        unique: true,
+        defaultValue: Sequelize.literal('gen_random_uuid()'),
+        comment: 'Durable external identity',
+      },
+
+      // FROM endpoint — exactly one must be non-null (enforced by CHECK)
+      from_source_id: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: { model: 'evidence_sources', key: 'id' },
+        onDelete: 'CASCADE',
+        comment: 'FK to evidence_sources — set when from is a source',
+      },
+      from_construct_id: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: { model: 'evidence_constructs', key: 'id' },
+        onDelete: 'CASCADE',
+        comment: 'FK to evidence_constructs — set when from is a construct',
+      },
+
+      // TO endpoint — exactly one must be non-null (enforced by CHECK)
+      to_source_id: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: { model: 'evidence_sources', key: 'id' },
+        onDelete: 'CASCADE',
+        comment: 'FK to evidence_sources — set when to is a source',
+      },
+      to_construct_id: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: { model: 'evidence_constructs', key: 'id' },
+        onDelete: 'CASCADE',
+        comment: 'FK to evidence_constructs — set when to is a construct',
+      },
+
+      // Relationship semantics
+      relationship_type: {
+        type: Sequelize.STRING(50),
+        allowNull: false,
+        comment: 'DERIVED_FROM | SUPPORTS | ADDRESSES | TESTED_BY | CONTRADICTS | REFINES | IMPLEMENTED_BY | VALIDATES',
+      },
+
+      // Provenance
+      provenance: {
+        type: Sequelize.JSONB,
+        allowNull: true,
+        comment: '{ method, decision_basis, created_by_template, ... }',
+      },
+
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+
+    // ── CHECK constraints for exactly-one endpoint ────────────────────
+    await queryInterface.sequelize.query(`
+      ALTER TABLE evidence_relationships
+      ADD CONSTRAINT chk_exactly_one_from
+      CHECK (
+        (from_source_id IS NOT NULL AND from_construct_id IS NULL)
+        OR
+        (from_source_id IS NULL AND from_construct_id IS NOT NULL)
+      )
+    `);
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE evidence_relationships
+      ADD CONSTRAINT chk_exactly_one_to
+      CHECK (
+        (to_source_id IS NOT NULL AND to_construct_id IS NULL)
+        OR
+        (to_source_id IS NULL AND to_construct_id IS NOT NULL)
+      )
+    `);
+
+    // ── Indexes ───────────────────────────────────────────────────────
+
+    // evidence_sources
+    await queryInterface.addIndex('evidence_sources', ['project_id'], {
+      name: 'idx_evidence_sources_project',
+    });
+    await queryInterface.addIndex('evidence_sources', ['study_id'], {
+      name: 'idx_evidence_sources_study',
+    });
+    await queryInterface.addIndex('evidence_sources', ['source_type'], {
+      name: 'idx_evidence_sources_type',
+    });
+    await queryInterface.addIndex('evidence_sources', ['public_id'], {
+      name: 'idx_evidence_sources_public_id',
+      unique: true,
+    });
+
+    // evidence_constructs
+    await queryInterface.addIndex('evidence_constructs', ['project_id'], {
+      name: 'idx_evidence_constructs_project',
+    });
+    await queryInterface.addIndex('evidence_constructs', ['study_id'], {
+      name: 'idx_evidence_constructs_study',
+    });
+    await queryInterface.addIndex('evidence_constructs', ['construct_type'], {
+      name: 'idx_evidence_constructs_type',
+    });
+    await queryInterface.addIndex('evidence_constructs', ['status'], {
+      name: 'idx_evidence_constructs_status',
+    });
+    await queryInterface.addIndex('evidence_constructs', ['cascade_variable_key'], {
+      name: 'idx_evidence_constructs_cascade_key',
+    });
+    await queryInterface.addIndex('evidence_constructs', ['public_id'], {
+      name: 'idx_evidence_constructs_public_id',
+      unique: true,
+    });
+
+    // evidence_relationships
+    await queryInterface.addIndex('evidence_relationships', ['from_source_id'], {
+      name: 'idx_evidence_relationships_from_source',
+    });
+    await queryInterface.addIndex('evidence_relationships', ['from_construct_id'], {
+      name: 'idx_evidence_relationships_from_construct',
+    });
+    await queryInterface.addIndex('evidence_relationships', ['to_source_id'], {
+      name: 'idx_evidence_relationships_to_source',
+    });
+    await queryInterface.addIndex('evidence_relationships', ['to_construct_id'], {
+      name: 'idx_evidence_relationships_to_construct',
+    });
+    await queryInterface.addIndex('evidence_relationships', ['relationship_type'], {
+      name: 'idx_evidence_relationships_type',
+    });
+    await queryInterface.addIndex('evidence_relationships', ['public_id'], {
+      name: 'idx_evidence_relationships_public_id',
+      unique: true,
+    });
+
+    console.log('Created evidence_sources, evidence_constructs, evidence_relationships tables with FK-backed lineage, CHECK constraints, UUID public_ids, and indexes');
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('evidence_relationships');
+    await queryInterface.dropTable('evidence_constructs');
+    await queryInterface.dropTable('evidence_sources');
+    console.log('Dropped evidence_sources, evidence_constructs, evidence_relationships tables');
+  },
+};

--- a/backend/src/database/models/evidence_construct.ts
+++ b/backend/src/database/models/evidence_construct.ts
@@ -1,0 +1,193 @@
+/**
+ * EvidenceConstruct Model
+ *
+ * Per ADRs 0028-0030: A typed research object with stable database identity,
+ * structured payload, derivation metadata, and acceptance status.
+ *
+ * Constructs represent meaningful research objects that persist independently
+ * of rendered documents: knowledge gaps, barriers, findings, recommendations,
+ * themes, nuggets, etc.
+ *
+ * Identity (ADR 0030):
+ *   id        — internal relational PK
+ *   public_id — durable UUID for external references, exports, provenance
+ *
+ * The typed core + JSONB payload pattern avoids a separate table per construct
+ * type while keeping identity and lineage relational.
+ */
+
+import {
+  DataTypes,
+  Model,
+  type InferAttributes,
+  type InferCreationAttributes,
+  type CreationOptional,
+  type Sequelize,
+} from 'sequelize';
+import { randomUUID } from 'crypto';
+
+export type ConstructType =
+  | 'knowledge_gap'
+  | 'barrier'
+  | 'research_question'
+  | 'stakeholder_constraint'
+  | 'nugget'
+  | 'survey_pattern'
+  | 'usability_finding'
+  | 'journey_stage'
+  | 'recommendation'
+  | 'finding'
+  | 'theme'
+  | 'persona'
+  | 'ticket_candidate';
+
+export type DerivationType = 'deterministic' | 'model' | 'human' | 'hybrid';
+
+export type ConstructStatus = 'candidate' | 'accepted' | 'rejected' | 'overridden';
+
+export interface DerivationContext {
+  model_name?: string;
+  model_version?: string;
+  template_id?: string;
+  template_version?: string;
+  method?: string;
+  [key: string]: unknown;
+}
+
+class EvidenceConstruct extends Model<
+  InferAttributes<EvidenceConstruct>,
+  InferCreationAttributes<EvidenceConstruct>
+> {
+  declare id: CreationOptional<number>;
+  declare public_id: CreationOptional<string>;
+  declare project_id: number;
+  declare study_id: number | null;
+  declare construct_type: ConstructType;
+  declare label: string | null;
+  declare payload: Record<string, unknown> | null;
+  declare derivation_type: CreationOptional<DerivationType>;
+  declare derivation_context: DerivationContext | null;
+  declare status: CreationOptional<ConstructStatus>;
+  declare reviewed_by: string | null;
+  declare reviewed_at: Date | null;
+  declare cascade_variable_key: string | null;
+  declare created_by: string;
+  declare created_at: CreationOptional<Date>;
+  declare updated_at: CreationOptional<Date>;
+
+  static associate(models: Record<string, any>) {
+    this.belongsTo(models.Project, {
+      foreignKey: 'project_id',
+      as: 'project',
+      onDelete: 'CASCADE',
+    });
+
+    this.belongsTo(models.ResearchStudy, {
+      foreignKey: 'study_id',
+      as: 'study',
+      onDelete: 'CASCADE',
+    });
+  }
+}
+
+export default (sequelize: Sequelize) => {
+  EvidenceConstruct.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      public_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        unique: true,
+        defaultValue: () => randomUUID(),
+      },
+      project_id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      study_id: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
+      construct_type: {
+        type: DataTypes.STRING(80),
+        allowNull: false,
+        validate: {
+          isIn: [[
+            'knowledge_gap', 'barrier', 'research_question',
+            'stakeholder_constraint', 'nugget', 'survey_pattern',
+            'usability_finding', 'journey_stage', 'recommendation',
+            'finding', 'theme', 'persona', 'ticket_candidate',
+          ]],
+        },
+      },
+      label: {
+        type: DataTypes.STRING(500),
+        allowNull: true,
+      },
+      payload: {
+        type: DataTypes.JSONB,
+        allowNull: true,
+      },
+      derivation_type: {
+        type: DataTypes.STRING(20),
+        allowNull: false,
+        defaultValue: 'model',
+        validate: {
+          isIn: [['deterministic', 'model', 'human', 'hybrid']],
+        },
+      },
+      derivation_context: {
+        type: DataTypes.JSONB,
+        allowNull: true,
+      },
+      status: {
+        type: DataTypes.STRING(20),
+        allowNull: false,
+        defaultValue: 'candidate',
+        validate: {
+          isIn: [['candidate', 'accepted', 'rejected', 'overridden']],
+        },
+      },
+      reviewed_by: {
+        type: DataTypes.STRING(50),
+        allowNull: true,
+      },
+      reviewed_at: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+      cascade_variable_key: {
+        type: DataTypes.STRING(100),
+        allowNull: true,
+      },
+      created_by: {
+        type: DataTypes.STRING(50),
+        allowNull: false,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    },
+    {
+      tableName: 'evidence_constructs',
+      underscored: true,
+      timestamps: false,
+      sequelize,
+    },
+  );
+
+  return EvidenceConstruct;
+};
+
+export type { EvidenceConstruct };

--- a/backend/src/database/models/evidence_relationship.ts
+++ b/backend/src/database/models/evidence_relationship.ts
@@ -1,0 +1,127 @@
+/**
+ * EvidenceRelationship Model
+ *
+ * Per ADR 0030: Directed typed edges in the evidence lineage graph.
+ *
+ * Lineage endpoint integrity is database-enforced via FK columns and
+ * CHECK constraints:
+ *   - from_source_id / from_construct_id: exactly one non-null (CHECK)
+ *   - to_source_id / to_construct_id: exactly one non-null (CHECK)
+ *   - All four columns are FK-backed with CASCADE delete
+ *
+ * Currently supported edge patterns:
+ *   source → construct    (DERIVED_FROM)
+ *   construct → construct (SUPPORTS, ADDRESSES, TESTED_BY, etc.)
+ *
+ * Future edge types (e.g., recommendation → ticket) can be added via
+ * additive FK columns when those vertical slices are implemented.
+ *
+ * Identity (ADR 0030):
+ *   id        — internal relational PK
+ *   public_id — durable UUID for external references
+ */
+
+import {
+  DataTypes,
+  Model,
+  type InferAttributes,
+  type InferCreationAttributes,
+  type CreationOptional,
+  type Sequelize,
+} from 'sequelize';
+import { randomUUID } from 'crypto';
+
+export type RelationshipType =
+  | 'DERIVED_FROM'
+  | 'SUPPORTS'
+  | 'ADDRESSES'
+  | 'TESTED_BY'
+  | 'CONTRADICTS'
+  | 'REFINES'
+  | 'IMPLEMENTED_BY'
+  | 'VALIDATES';
+
+export interface RelationshipProvenance {
+  method?: string;
+  decision_basis?: string;
+  created_by_template?: string;
+  [key: string]: unknown;
+}
+
+class EvidenceRelationship extends Model<
+  InferAttributes<EvidenceRelationship>,
+  InferCreationAttributes<EvidenceRelationship>
+> {
+  declare id: CreationOptional<number>;
+  declare public_id: CreationOptional<string>;
+  declare from_source_id: number | null;
+  declare from_construct_id: number | null;
+  declare to_source_id: number | null;
+  declare to_construct_id: number | null;
+  declare relationship_type: RelationshipType;
+  declare provenance: RelationshipProvenance | null;
+  declare created_at: CreationOptional<Date>;
+}
+
+export default (sequelize: Sequelize) => {
+  EvidenceRelationship.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      public_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        unique: true,
+        defaultValue: () => randomUUID(),
+      },
+      from_source_id: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
+      from_construct_id: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
+      to_source_id: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
+      to_construct_id: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
+      relationship_type: {
+        type: DataTypes.STRING(50),
+        allowNull: false,
+        validate: {
+          isIn: [[
+            'DERIVED_FROM', 'SUPPORTS', 'ADDRESSES', 'TESTED_BY',
+            'CONTRADICTS', 'REFINES', 'IMPLEMENTED_BY', 'VALIDATES',
+          ]],
+        },
+      },
+      provenance: {
+        type: DataTypes.JSONB,
+        allowNull: true,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    },
+    {
+      tableName: 'evidence_relationships',
+      underscored: true,
+      timestamps: false,
+      sequelize,
+    },
+  );
+
+  return EvidenceRelationship;
+};
+
+export type { EvidenceRelationship };

--- a/backend/src/database/models/evidence_source.ts
+++ b/backend/src/database/models/evidence_source.ts
@@ -1,0 +1,154 @@
+/**
+ * EvidenceSource Model
+ *
+ * Per ADR 0029: Represents an evidence-bearing input — an uploaded document,
+ * survey dataset, stakeholder interview, session transcript, etc.
+ *
+ * Sources are leaf nodes in the evidence graph. They can be the origin of
+ * constructs (via evidence_relationships) but cannot themselves be derived
+ * from other entities.
+ *
+ * Identity (ADR 0030):
+ *   id        — internal relational PK
+ *   public_id — durable UUID for external references, exports, provenance
+ *
+ * Scope:
+ *   - project_id is always required (CASCADE on project delete)
+ *   - study_id is NULL for project-scoped discovery sources
+ *   - study_id CASCADE on study delete (study-scoped evidence is deleted with study)
+ */
+
+import {
+  DataTypes,
+  Model,
+  type InferAttributes,
+  type InferCreationAttributes,
+  type CreationOptional,
+  type Sequelize,
+} from 'sequelize';
+import { randomUUID } from 'crypto';
+
+export type SourceType =
+  | 'uploaded_document'
+  | 'survey_dataset'
+  | 'stakeholder_interview'
+  | 'session_transcript'
+  | 'session_notes'
+  | 'process_document'
+  | 'external_reference';
+
+/**
+ * Reference to where the source artifact content lives.
+ * Not all fields are required — depends on source_type.
+ */
+export interface ArtifactRef {
+  github_path?: string;
+  github_sha?: string;
+  study_notes_id?: number;
+  file_url?: string;
+  [key: string]: unknown;
+}
+
+class EvidenceSource extends Model<
+  InferAttributes<EvidenceSource>,
+  InferCreationAttributes<EvidenceSource>
+> {
+  declare id: CreationOptional<number>;
+  declare public_id: CreationOptional<string>;
+  declare project_id: number;
+  declare study_id: number | null;
+  declare source_type: SourceType;
+  declare label: string;
+  declare artifact_ref: ArtifactRef | null;
+  declare metadata: Record<string, unknown> | null;
+  declare created_by: string;
+  declare created_at: CreationOptional<Date>;
+  declare updated_at: CreationOptional<Date>;
+
+  static associate(models: Record<string, any>) {
+    this.belongsTo(models.Project, {
+      foreignKey: 'project_id',
+      as: 'project',
+      onDelete: 'CASCADE',
+    });
+
+    this.belongsTo(models.ResearchStudy, {
+      foreignKey: 'study_id',
+      as: 'study',
+      onDelete: 'CASCADE',
+    });
+  }
+}
+
+export default (sequelize: Sequelize) => {
+  EvidenceSource.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      public_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        unique: true,
+        defaultValue: () => randomUUID(),
+      },
+      project_id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      study_id: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
+      source_type: {
+        type: DataTypes.STRING(50),
+        allowNull: false,
+        validate: {
+          isIn: [[
+            'uploaded_document', 'survey_dataset', 'stakeholder_interview',
+            'session_transcript', 'session_notes', 'process_document',
+            'external_reference',
+          ]],
+        },
+      },
+      label: {
+        type: DataTypes.STRING(500),
+        allowNull: false,
+      },
+      artifact_ref: {
+        type: DataTypes.JSONB,
+        allowNull: true,
+      },
+      metadata: {
+        type: DataTypes.JSONB,
+        allowNull: true,
+      },
+      created_by: {
+        type: DataTypes.STRING(50),
+        allowNull: false,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    },
+    {
+      tableName: 'evidence_sources',
+      underscored: true,
+      timestamps: false,
+      sequelize,
+    },
+  );
+
+  return EvidenceSource;
+};
+
+export type { EvidenceSource };

--- a/backend/src/services/evidence-projection.service.ts
+++ b/backend/src/services/evidence-projection.service.ts
@@ -1,0 +1,249 @@
+/**
+ * Evidence Projection Service
+ *
+ * Per ADR 0029: The projection seam — transforms accepted canonical
+ * constructs into cascade-compatible shapes without requiring LLM
+ * re-extraction.
+ *
+ * FAIL-CLOSED (ADR 0029 correction): An accepted construct that cannot
+ * satisfy its projection contract throws EvidenceProjectionError rather
+ * than producing malformed cascade variables with invented defaults.
+ *
+ * Flow:
+ *   accepted EvidenceConstruct
+ *   → validate canonical construct requirements
+ *   → projection transform
+ *   → validate destination cascade shape
+ *   → CascadeProjection
+ *
+ * This is a service boundary, not a framework. Each vertical slice
+ * defines its own projection logic as a plain function.
+ *
+ * Long-term relationship:
+ *   accepted evidence/construct
+ *   ├→ authoritative evidence store (evidence_constructs table)
+ *   ├→ study_variables projection (this service)
+ *   └→ template rendering context
+ */
+
+import type { ConstructType } from '../database/models/evidence_construct';
+import type { EvidenceConstruct } from '../database/models/evidence_construct';
+import { EvidenceProjectionError } from '../types/handlers';
+
+// ═══════════════════════════════════════════════════════════════════════
+// PROJECTION TYPES
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * A cascade-compatible variable ready to be written to study_variables.
+ * Mirrors the shape that studyVariables.ts expects.
+ */
+export interface CascadeProjection {
+  variable_key: string;
+  value: Record<string, unknown>;
+  source_template: string;
+  source_version?: string;
+  is_pool: boolean;
+  item_key?: string;
+  participant_id?: string;
+}
+
+/**
+ * A projection function transforms an accepted EvidenceConstruct
+ * into one or more CascadeProjection values.
+ *
+ * MUST throw EvidenceProjectionError if the construct's payload
+ * is missing required fields for the destination cascade shape.
+ * MUST NOT invent defaults for missing required data.
+ */
+export type ProjectionFn = (construct: EvidenceConstruct) => CascadeProjection[];
+
+/**
+ * Schema definition for projection validation.
+ * Lists which payload fields are required for this projection.
+ */
+export interface ProjectionSchema {
+  requiredPayloadFields: string[];
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// PROJECTION REGISTRY
+// ═══════════════════════════════════════════════════════════════════════
+
+const projectionRegistry = new Map<ConstructType, ProjectionFn>();
+const projectionSchemas = new Map<ConstructType, ProjectionSchema>();
+
+export function registerProjection(
+  constructType: ConstructType,
+  fn: ProjectionFn,
+  schema: ProjectionSchema,
+): void {
+  projectionRegistry.set(constructType, fn);
+  projectionSchemas.set(constructType, schema);
+}
+
+export function hasProjection(constructType: ConstructType): boolean {
+  return projectionRegistry.has(constructType);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// CORE PROJECTION (fail-closed)
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * Project an accepted construct into cascade-compatible shape(s).
+ *
+ * Returns null if:
+ *   - construct is not in accepted status
+ *   - no projection is registered for the construct type
+ *
+ * Throws EvidenceProjectionError if:
+ *   - accepted construct is missing required payload fields
+ *   - projection produces an invalid cascade shape
+ *
+ * Deterministic: same construct always produces identical projection.
+ */
+export function projectConstruct(construct: EvidenceConstruct): CascadeProjection[] | null {
+  if (construct.status !== 'accepted') return null;
+
+  const fn = projectionRegistry.get(construct.construct_type);
+  if (!fn) return null;
+
+  // Step 1: Validate canonical construct requirements
+  const schema = projectionSchemas.get(construct.construct_type);
+  if (schema) {
+    validateConstructPayload(construct, schema);
+  }
+
+  // Step 2: Execute projection transform
+  const projections = fn(construct);
+
+  // Step 3: Validate destination cascade shape
+  for (const projection of projections) {
+    validateCascadeProjection(projection, construct.construct_type);
+  }
+
+  return projections;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// VALIDATION (fail-closed)
+// ═══════════════════════════════════════════════════════════════════════
+
+function validateConstructPayload(
+  construct: EvidenceConstruct,
+  schema: ProjectionSchema,
+): void {
+  const payload = construct.payload;
+  if (!payload && schema.requiredPayloadFields.length > 0) {
+    throw new EvidenceProjectionError(
+      `Accepted ${construct.construct_type} (id=${construct.id}) has null payload but projection requires fields: ${schema.requiredPayloadFields.join(', ')}`,
+      construct.construct_type,
+      schema.requiredPayloadFields,
+    );
+  }
+
+  const missingFields: string[] = [];
+  for (const field of schema.requiredPayloadFields) {
+    if (payload![field] === undefined || payload![field] === null) {
+      missingFields.push(field);
+    }
+  }
+
+  if (missingFields.length > 0) {
+    throw new EvidenceProjectionError(
+      `Accepted ${construct.construct_type} (id=${construct.id}) is missing required payload fields for projection: ${missingFields.join(', ')}`,
+      construct.construct_type,
+      missingFields,
+    );
+  }
+}
+
+function validateCascadeProjection(
+  projection: CascadeProjection,
+  constructType: string,
+): void {
+  if (!projection.variable_key) {
+    throw new EvidenceProjectionError(
+      `Projection for ${constructType} produced empty variable_key`,
+      constructType,
+    );
+  }
+  if (projection.is_pool && !projection.item_key) {
+    throw new EvidenceProjectionError(
+      `Pool projection for ${constructType} → ${projection.variable_key} is missing item_key`,
+      constructType,
+    );
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// BUILT-IN PROJECTIONS
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * Knowledge gap → knowledge_gaps cascade shape.
+ *
+ * Demonstrates the pattern: a canonical evidence construct is validated,
+ * transformed into the shape downstream YAML templates expect via their
+ * `consumes:` declarations, and validated again. No LLM call. No defaults.
+ */
+registerProjection(
+  'knowledge_gap',
+  (construct) => {
+    const payload = construct.payload!;
+    return [
+      {
+        variable_key: 'knowledge_gaps',
+        value: {
+          id: String(payload.id),
+          title: String(payload.title),
+          summary: String(payload.summary),
+          domain: payload.domain ?? null,
+          evidence: payload.evidence ?? [],
+          source_document: String(payload.source_document),
+          confidence: payload.confidence ?? null,
+        },
+        source_template: 'evidence_projection',
+        source_version: '1.0',
+        is_pool: true,
+        item_key: String(payload.id),
+      },
+    ];
+  },
+  {
+    requiredPayloadFields: ['id', 'title', 'summary', 'source_document'],
+  },
+);
+
+/**
+ * Barrier → discovered_barriers cascade shape.
+ */
+registerProjection(
+  'barrier',
+  (construct) => {
+    const payload = construct.payload!;
+    return [
+      {
+        variable_key: 'discovered_barriers',
+        value: {
+          id: String(payload.id),
+          title: String(payload.title),
+          summary: String(payload.summary),
+          magnitude: payload.magnitude ?? null,
+          evidence: payload.evidence ?? [],
+          affected_population: payload.affected_population ?? null,
+          source_document: String(payload.source_document),
+          confidence: payload.confidence ?? null,
+        },
+        source_template: 'evidence_projection',
+        source_version: '1.0',
+        is_pool: true,
+        item_key: String(payload.id),
+      },
+    ];
+  },
+  {
+    requiredPayloadFields: ['id', 'title', 'summary', 'source_document'],
+  },
+);

--- a/backend/src/services/evidence.service.ts
+++ b/backend/src/services/evidence.service.ts
@@ -1,0 +1,415 @@
+/**
+ * Evidence Service
+ *
+ * Per ADRs 0028-0030: CRUD operations on the canonical evidence layer
+ * (sources, constructs, relationships) with transactional derivation support.
+ *
+ * This service does NOT replace study_variables or the cascade pipeline.
+ * It provides the authoritative evidence store that coexists with the
+ * cascade projection layer.
+ *
+ * Relationship endpoints use FK-backed columns (from_source_id,
+ * from_construct_id, to_source_id, to_construct_id) with CHECK
+ * constraints at the database level. Callers use the typed
+ * CreateSourceToConstructInput / CreateConstructToConstructInput
+ * interfaces — they never manipulate raw polymorphic IDs.
+ */
+
+import { Op, type Transaction, type CreationAttributes } from 'sequelize';
+import sequelize from '../database';
+import type { EvidenceSource, SourceType, ArtifactRef } from '../database/models/evidence_source';
+import type {
+  EvidenceConstruct,
+  ConstructType,
+  DerivationType,
+  ConstructStatus,
+  DerivationContext,
+} from '../database/models/evidence_construct';
+import type {
+  EvidenceRelationship,
+  RelationshipType,
+  RelationshipProvenance,
+} from '../database/models/evidence_relationship';
+
+const EvidenceSourceModel = sequelize.models.EvidenceSource as typeof EvidenceSource;
+const EvidenceConstructModel = sequelize.models.EvidenceConstruct as typeof EvidenceConstruct;
+const EvidenceRelationshipModel = sequelize.models.EvidenceRelationship as typeof EvidenceRelationship;
+
+// ═══════════════════════════════════════════════════════════════════════
+// INPUT TYPES
+// ═══════════════════════════════════════════════════════════════════════
+
+export interface CreateSourceInput {
+  project_id: number;
+  study_id?: number | null;
+  source_type: SourceType;
+  label: string;
+  artifact_ref?: ArtifactRef | null;
+  metadata?: Record<string, unknown> | null;
+  created_by: string;
+}
+
+export interface CreateConstructInput {
+  project_id: number;
+  study_id?: number | null;
+  construct_type: ConstructType;
+  label?: string | null;
+  payload?: Record<string, unknown> | null;
+  derivation_type?: DerivationType;
+  derivation_context?: DerivationContext | null;
+  status?: ConstructStatus;
+  cascade_variable_key?: string | null;
+  created_by: string;
+}
+
+/** Source → Construct relationship. */
+export interface CreateSourceToConstructInput {
+  from_source_id: number;
+  to_construct_id: number;
+  relationship_type: RelationshipType;
+  provenance?: RelationshipProvenance | null;
+}
+
+/** Construct → Construct relationship. */
+export interface CreateConstructToConstructInput {
+  from_construct_id: number;
+  to_construct_id: number;
+  relationship_type: RelationshipType;
+  provenance?: RelationshipProvenance | null;
+}
+
+export type CreateRelationshipInput =
+  | CreateSourceToConstructInput
+  | CreateConstructToConstructInput;
+
+/** A construct + its required lineage relationships, persisted atomically. */
+export interface DerivationInput {
+  construct: CreateConstructInput;
+  relationships: DerivationRelationshipInput[];
+}
+
+/**
+ * Relationship input for derivations. A to_construct_id of 0 is a sentinel
+ * meaning "the construct being created in this derivation."
+ */
+export type DerivationRelationshipInput =
+  | { from_source_id: number; to_construct_id: number; relationship_type: RelationshipType; provenance?: RelationshipProvenance | null }
+  | { from_construct_id: number; to_construct_id: number; relationship_type: RelationshipType; provenance?: RelationshipProvenance | null };
+
+// ═══════════════════════════════════════════════════════════════════════
+// SOURCES
+// ═══════════════════════════════════════════════════════════════════════
+
+export async function createSource(
+  input: CreateSourceInput,
+  transaction?: Transaction,
+): Promise<EvidenceSource> {
+  return EvidenceSourceModel.create(
+    {
+      project_id: input.project_id,
+      study_id: input.study_id ?? null,
+      source_type: input.source_type,
+      label: input.label,
+      artifact_ref: input.artifact_ref ?? null,
+      metadata: input.metadata ?? null,
+      created_by: input.created_by,
+    } as CreationAttributes<EvidenceSource>,
+    { transaction },
+  );
+}
+
+export async function getSourceById(
+  id: number,
+  transaction?: Transaction,
+): Promise<EvidenceSource | null> {
+  return EvidenceSourceModel.findByPk(id, { transaction });
+}
+
+export async function getSourcesByProject(projectId: number): Promise<EvidenceSource[]> {
+  return EvidenceSourceModel.findAll({
+    where: { project_id: projectId },
+    order: [['created_at', 'DESC']],
+  });
+}
+
+export async function getSourcesByStudy(studyId: number): Promise<EvidenceSource[]> {
+  return EvidenceSourceModel.findAll({
+    where: { study_id: studyId },
+    order: [['created_at', 'DESC']],
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// CONSTRUCTS
+// ═══════════════════════════════════════════════════════════════════════
+
+export async function createConstruct(
+  input: CreateConstructInput,
+  transaction?: Transaction,
+): Promise<EvidenceConstruct> {
+  return EvidenceConstructModel.create(
+    {
+      project_id: input.project_id,
+      study_id: input.study_id ?? null,
+      construct_type: input.construct_type,
+      label: input.label ?? null,
+      payload: input.payload ?? null,
+      derivation_type: input.derivation_type ?? 'model',
+      derivation_context: input.derivation_context ?? null,
+      status: input.status ?? 'candidate',
+      cascade_variable_key: input.cascade_variable_key ?? null,
+      created_by: input.created_by,
+    } as CreationAttributes<EvidenceConstruct>,
+    { transaction },
+  );
+}
+
+export async function getConstructById(
+  id: number,
+  transaction?: Transaction,
+): Promise<EvidenceConstruct | null> {
+  return EvidenceConstructModel.findByPk(id, { transaction });
+}
+
+export async function getConstructsByProject(
+  projectId: number,
+  filters?: {
+    construct_type?: ConstructType;
+    status?: ConstructStatus;
+    study_id?: number | null;
+  },
+): Promise<EvidenceConstruct[]> {
+  const where: Record<string, unknown> = { project_id: projectId };
+  if (filters?.construct_type) where.construct_type = filters.construct_type;
+  if (filters?.status) where.status = filters.status;
+  if (filters?.study_id !== undefined) where.study_id = filters.study_id;
+
+  return EvidenceConstructModel.findAll({
+    where,
+    order: [['created_at', 'DESC']],
+  });
+}
+
+export async function getConstructsByStudy(
+  studyId: number,
+  filters?: {
+    construct_type?: ConstructType;
+    status?: ConstructStatus;
+  },
+): Promise<EvidenceConstruct[]> {
+  const where: Record<string, unknown> = { study_id: studyId };
+  if (filters?.construct_type) where.construct_type = filters.construct_type;
+  if (filters?.status) where.status = filters.status;
+
+  return EvidenceConstructModel.findAll({
+    where,
+    order: [['created_at', 'DESC']],
+  });
+}
+
+export async function updateConstructStatus(
+  id: number,
+  status: ConstructStatus,
+  reviewedBy: string,
+  transaction?: Transaction,
+): Promise<EvidenceConstruct | null> {
+  const construct = await EvidenceConstructModel.findByPk(id, { transaction });
+  if (!construct) return null;
+
+  await construct.update(
+    {
+      status,
+      reviewed_by: reviewedBy,
+      reviewed_at: new Date(),
+    },
+    { transaction },
+  );
+
+  return construct;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// RELATIONSHIPS (FK-backed endpoints)
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * Create a source → construct relationship.
+ * FK integrity enforced at DB level — invalid source or construct IDs will
+ * throw a Sequelize ForeignKeyConstraintError.
+ */
+export async function createSourceToConstruct(
+  input: CreateSourceToConstructInput,
+  transaction?: Transaction,
+): Promise<EvidenceRelationship> {
+  return EvidenceRelationshipModel.create(
+    {
+      from_source_id: input.from_source_id,
+      from_construct_id: null,
+      to_source_id: null,
+      to_construct_id: input.to_construct_id,
+      relationship_type: input.relationship_type,
+      provenance: input.provenance ?? null,
+    } as CreationAttributes<EvidenceRelationship>,
+    { transaction },
+  );
+}
+
+/**
+ * Create a construct → construct relationship.
+ * FK integrity enforced at DB level.
+ */
+export async function createConstructToConstruct(
+  input: CreateConstructToConstructInput,
+  transaction?: Transaction,
+): Promise<EvidenceRelationship> {
+  return EvidenceRelationshipModel.create(
+    {
+      from_source_id: null,
+      from_construct_id: input.from_construct_id,
+      to_source_id: null,
+      to_construct_id: input.to_construct_id,
+      relationship_type: input.relationship_type,
+      provenance: input.provenance ?? null,
+    } as CreationAttributes<EvidenceRelationship>,
+    { transaction },
+  );
+}
+
+/** Get all relationships where the given source is the origin. */
+export async function getRelationshipsFromSource(
+  sourceId: number,
+  relationshipType?: RelationshipType,
+): Promise<EvidenceRelationship[]> {
+  const where: Record<string, unknown> = { from_source_id: sourceId };
+  if (relationshipType) where.relationship_type = relationshipType;
+  return EvidenceRelationshipModel.findAll({ where, order: [['created_at', 'ASC']] });
+}
+
+/** Get all relationships where the given construct is the origin. */
+export async function getRelationshipsFromConstruct(
+  constructId: number,
+  relationshipType?: RelationshipType,
+): Promise<EvidenceRelationship[]> {
+  const where: Record<string, unknown> = { from_construct_id: constructId };
+  if (relationshipType) where.relationship_type = relationshipType;
+  return EvidenceRelationshipModel.findAll({ where, order: [['created_at', 'ASC']] });
+}
+
+/** Get all relationships targeting the given construct. */
+export async function getRelationshipsToConstruct(
+  constructId: number,
+  relationshipType?: RelationshipType,
+): Promise<EvidenceRelationship[]> {
+  const where: Record<string, unknown> = { to_construct_id: constructId };
+  if (relationshipType) where.relationship_type = relationshipType;
+  return EvidenceRelationshipModel.findAll({ where, order: [['created_at', 'ASC']] });
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// TRANSACTIONAL DERIVATION
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * Create a construct with its required lineage relationships atomically.
+ * If any relationship creation fails, the entire derivation is rolled back.
+ *
+ * Per ADR 0029: "Failed lineage writes must not leave partially accepted
+ * derivations."
+ *
+ * Relationship inputs use a to_construct_id sentinel of 0 to mean
+ * "the construct being created in this derivation."
+ */
+export async function createDerivation(input: DerivationInput): Promise<{
+  construct: EvidenceConstruct;
+  relationships: EvidenceRelationship[];
+}> {
+  return sequelize.transaction(async (transaction) => {
+    const construct = await createConstruct(input.construct, transaction);
+
+    const relationships: EvidenceRelationship[] = [];
+    for (const relInput of input.relationships) {
+      const resolvedToId = relInput.to_construct_id === 0 ? construct.id : relInput.to_construct_id;
+
+      if ('from_source_id' in relInput) {
+        const rel = await createSourceToConstruct(
+          { ...relInput, to_construct_id: resolvedToId },
+          transaction,
+        );
+        relationships.push(rel);
+      } else {
+        const resolvedFromId = relInput.from_construct_id === 0 ? construct.id : relInput.from_construct_id;
+        const rel = await createConstructToConstruct(
+          { ...relInput, from_construct_id: resolvedFromId, to_construct_id: resolvedToId },
+          transaction,
+        );
+        relationships.push(rel);
+      }
+    }
+
+    return { construct, relationships };
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// EVIDENCE RECORD COUNTS (for audit/deletion)
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * Count evidence records for a project (for pre-deletion audit context).
+ * Follows the CRITICAL ORDERING pattern from audit.service.ts:
+ * gather counts BEFORE delete.
+ */
+export async function gatherEvidenceRecordCounts(
+  projectId: number,
+  studyId?: number,
+): Promise<{ sources: number; constructs: number; relationships: number }> {
+  const sourceWhere: Record<string, unknown> = { project_id: projectId };
+  const constructWhere: Record<string, unknown> = { project_id: projectId };
+  if (studyId !== undefined) {
+    sourceWhere.study_id = studyId;
+    constructWhere.study_id = studyId;
+  }
+
+  const sources = await EvidenceSourceModel.count({ where: sourceWhere });
+  const constructs = await EvidenceConstructModel.count({ where: constructWhere });
+
+  // Relationships don't have project_id — count via constructs and sources
+  let relationships = 0;
+  if (constructs > 0 || sources > 0) {
+    const orConditions: Record<string, unknown>[] = [];
+
+    if (constructs > 0) {
+      const constructIds = (
+        await EvidenceConstructModel.findAll({
+          where: constructWhere,
+          attributes: ['id'],
+        })
+      ).map((c) => (c as EvidenceConstruct).id);
+
+      orConditions.push(
+        { from_construct_id: { [Op.in]: constructIds } },
+        { to_construct_id: { [Op.in]: constructIds } },
+      );
+    }
+
+    if (sources > 0) {
+      const sourceIds = (
+        await EvidenceSourceModel.findAll({
+          where: sourceWhere,
+          attributes: ['id'],
+        })
+      ).map((s) => (s as EvidenceSource).id);
+
+      orConditions.push(
+        { from_source_id: { [Op.in]: sourceIds } },
+        { to_source_id: { [Op.in]: sourceIds } },
+      );
+    }
+
+    relationships = await EvidenceRelationshipModel.count({
+      where: { [Op.or]: orConditions },
+    });
+  }
+
+  return { sources, constructs, relationships };
+}

--- a/backend/src/types/handlers.ts
+++ b/backend/src/types/handlers.ts
@@ -63,6 +63,29 @@ export class TemplateContractError extends Error {
 }
 
 // ---------------------------------------------------------------------------
+// Evidence projection error
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when an accepted evidence construct fails projection validation.
+ * Per ADR 0029: projection must fail closed — an accepted construct that
+ * cannot satisfy its projection contract throws rather than producing
+ * malformed cascade variables.
+ *
+ * Analogous to TemplateContractError for the evidence → cascade boundary.
+ */
+export class EvidenceProjectionError extends Error {
+  constructor(
+    message: string,
+    public readonly constructType?: string,
+    public readonly missingFields?: string[],
+  ) {
+    super(message);
+    this.name = 'EvidenceProjectionError';
+  }
+}
+
+// ---------------------------------------------------------------------------
 // PII redaction error
 // ---------------------------------------------------------------------------
 

--- a/docs/architecture-decisions/0028-deterministic-research-transformations.md
+++ b/docs/architecture-decisions/0028-deterministic-research-transformations.md
@@ -1,0 +1,55 @@
+# ADR 0028: Deterministic research transformations occur outside generative models
+
+**Status:** Accepted
+**Date:** 2026-08-15
+**Decision drivers:** Evidence architecture foundation — ensuring authoritative quantitative and structural operations are not mediated by LLMs, which introduce non-determinism and potential error.
+
+## Context
+
+Qori's pipeline currently routes all analytical output through LLM generation: the model receives context, produces prose and structured JSON, and the variable extractor parses the result. This works well for interpretive tasks — synthesizing themes, drafting recommendations, identifying patterns in qualitative data.
+
+However, some operations are deterministic by nature: counting participants who experienced a barrier, computing severity distributions, calculating percentages, assigning stable IDs, maintaining provenance relationships, and aggregating cross-tabs. When these operations pass through an LLM, the results are probabilistic approximations of what should be exact computations. A model might count 7 participants when the data contains 8, or compute a percentage that doesn't match its own numerator and denominator.
+
+The existing rendering architecture (ADR 0005) already separates Handlebars template rendering from LLM generation slots. This ADR extends that separation to the evidence and analysis layer.
+
+## Decision
+
+Deterministic transformations occur outside the generative model.
+
+Specifically, LLMs must not be the authoritative source for:
+
+- Arithmetic (sums, differences, ratios)
+- Denominators, percentages, medians
+- Counts and frequencies (participant counts, occurrence counts)
+- Severity aggregation where the aggregation formula is defined
+- Cross-tabulations
+- ID assignment (construct IDs, relationship IDs, sequence numbers)
+- Stable provenance relationships (source→construct, construct→construct)
+- Timestamps and temporal ordering
+- Status transitions (candidate→accepted→rejected)
+
+LLMs may interpret, contextualize, and narrate computed facts. They may also produce genuinely interpretive constructs (themes, findings, recommendations) where human judgment is the methodology.
+
+When a template or handler needs both computed facts and interpretive prose, the handler computes the deterministic values first and injects them as template variables. The LLM receives computed facts as context, not as tasks to reproduce.
+
+## Alternatives considered
+
+**Status quo — let the LLM do everything.** Simpler implementation, but produces authoritative-looking numbers that are occasionally wrong. Detected in usability testing when a readout claimed 5/7 participants encountered a barrier but the underlying data showed 6/8. The cost of a wrong number in a federal research context is high.
+
+**Post-LLM validation — generate then verify.** Run LLM output through deterministic checks and retry on mismatch. Adds latency, doesn't eliminate the root problem (the LLM is still the source), and creates a confusing contract where the system sometimes silently corrects its own output.
+
+## Consequences
+
+- Handlers that produce quantitative outputs must compute them in code before calling the LLM.
+- The evidence service (ADR 0029) stores computed constructs with `derivation_type: 'deterministic'` so downstream consumers know the value is exact.
+- Variable extraction (via `variableExtractor.ts`) remains valid for genuinely interpretive constructs — themes, findings, recommendations — where the LLM is performing analysis, not arithmetic.
+- Future survey analysis will use this pattern heavily: codebook frequency tables, cross-tabs, and statistical summaries are computed in code; the LLM interprets the computed results.
+- Template authors must distinguish between "ask the model to compute" and "inject a computed value for the model to narrate."
+- Projection validation (evidence → cascade) is deterministic infrastructure: payload field checks, cascade schema validation, and shape transformation are all code operations, never LLM operations.
+
+## References
+
+- ADR 0005 — Handlebars template architecture (structural separation of rendering from generation)
+- ADR 0008 — Render empty rather than fabricate
+- ADR 0012 — Structured JSON for LLM outputs
+- `backend/src/helpers/variableExtractor.ts` — extraction remains valid for interpretive constructs

--- a/docs/architecture-decisions/0029-canonical-evidence-state-and-cascade-projection.md
+++ b/docs/architecture-decisions/0029-canonical-evidence-state-and-cascade-projection.md
@@ -1,0 +1,75 @@
+# ADR 0029: Canonical evidence state is distinct from cascade projection
+
+**Status:** Accepted
+**Date:** 2026-08-15
+**Decision drivers:** Evidence architecture foundation — establishing that authoritative research evidence persists independently of the consumer-shaped variables in `study_variables`.
+
+## Context
+
+Qori currently stores all structured research state in the `study_variables` table as consumer-shaped JSONB values. This works well for the cascade pipeline: each template declares what it `consumes` and `emits`, the variable extractor parses LLM output into the declared schema, and downstream templates read the stored shape directly.
+
+However, this conflates two distinct concerns:
+
+1. **Authoritative evidence state** — the durable truth about what was observed, analyzed, and decided. A knowledge gap exists. A barrier was validated by 6 of 8 participants. A finding is accepted. A recommendation led to a GitHub ticket.
+
+2. **Cascade projection** — the shape a downstream consumer expects. A research readout template needs findings formatted with supporting_themes arrays and severity_distribution objects. An affinity map template needs nuggets grouped by participant.
+
+When these are the same thing, several problems emerge:
+- Evidence identity is tied to template schema. If a template changes its expected shape, historical evidence must be migrated or becomes unqueryable.
+- Cross-study queries (future `/qori-ask`) must parse consumer-shaped JSONB to answer "which studies found accessibility barriers?" — a structural query against an unstructured store.
+- Deterministic facts (ADR 0028) route through LLM extraction to land in the variable store, introducing unnecessary non-determinism.
+
+## Decision
+
+Authoritative research evidence and construct state is distinct from `study_variables` cascade projection.
+
+The long-term relationship is:
+
+```
+accepted evidence/construct
+├→ authoritative evidence store (evidence_constructs table)
+├→ study_variables projection where required
+└→ template rendering context
+```
+
+`study_variables` remains in place, unchanged, and continues to serve the existing cascade pipeline. No migration of existing variables into the evidence layer. No dual-write of every current emit.
+
+The evidence layer introduces:
+- **evidence_sources** — metadata about evidence-bearing inputs (uploaded documents, transcripts, survey datasets)
+- **evidence_constructs** — typed research objects with stable database IDs, structured JSONB payloads, derivation metadata, and acceptance status
+- **evidence_relationships** — directed typed edges between sources and constructs
+
+The projection seam is a service boundary: when a vertical slice converts a template to evidence-aware operation, accepted constructs are projected into the cascade-compatible shape through validated deterministic transformation — no LLM re-extraction, no render/extract round-trip. The projection flow is:
+
+```
+accepted EvidenceConstruct
+→ validate canonical construct requirements (required payload fields)
+→ deterministic projection transform
+→ validate destination cascade schema (variable_key, pool/singleton, item_key)
+→ CascadeProjection
+```
+
+If an accepted construct cannot satisfy its projection contract, the service throws `EvidenceProjectionError` (fail-closed). It does not invent defaults, silently omit fields, or produce malformed cascade variables.
+
+## Alternatives considered
+
+**Replace study_variables entirely.** Disruptive — 27 YAML templates, 40+ variable types, and the entire cascade pipeline depend on the current schema. The migration risk far exceeds the benefit, especially since study_variables works correctly for its purpose.
+
+**Store evidence as additional study_variables rows.** Keeps one table, but overloads study_variables with a responsibility it wasn't designed for. Evidence needs relational identity (FKs between constructs), acceptance status, derivation metadata, and typed relationships — none of which fit the variable store's append/pool/singleton model.
+
+**Build evidence as a separate microservice.** Premature — the evidence layer shares the same Postgres database, the same project/study FKs, and the same transaction boundaries. Extracting it to a service boundary adds network overhead and distributed transaction complexity for no current benefit.
+
+## Consequences
+
+- The cascade pipeline continues to work exactly as before. Empty evidence tables have zero impact on existing workflows.
+- New vertical slices (starting with survey) will write to evidence tables and project into study_variables, rather than routing through LLM extraction for deterministic constructs.
+- Future `/qori-ask` queries structured evidence directly, not by searching generated Markdown or parsing consumer-shaped JSONB.
+- DSAR/deletion implications: project_id uses CASCADE — deleting a project removes all its evidence. study_id also uses CASCADE — deleting a study removes study-scoped evidence. Project-scoped discovery evidence (study_id = NULL) is unaffected by study deletion. Study deletion does NOT silently reclassify study-scoped evidence as project-scoped by nulling study_id. The disposition audit log (ADR 0025) captures pre-deletion counts including evidence records.
+- The projection seam is a service, not a framework. Each vertical slice defines its own projection logic as a plain function. Projection validation is deterministic infrastructure (ADR 0028) — no LLM involvement.
+
+## References
+
+- ADR 0028 — Deterministic research transformations
+- `backend/src/helpers/studyVariables.ts` — existing cascade variable store (unchanged)
+- `backend/src/helpers/variableExtractor.ts` — extraction (unchanged, still valid for interpretive constructs)
+- `backend/src/types/cascade.ts` — cascade type definitions (unchanged)

--- a/docs/architecture-decisions/0030-evidence-lineage-identity.md
+++ b/docs/architecture-decisions/0030-evidence-lineage-identity.md
@@ -1,0 +1,73 @@
+# ADR 0030: Stable database IDs and typed relational lineage are authoritative evidence identity
+
+**Status:** Accepted
+**Date:** 2026-08-15
+**Decision drivers:** Evidence architecture foundation — ensuring research provenance survives document regeneration, template changes, and artifact renames.
+
+## Context
+
+Qori generates Markdown documents stored in GitHub repositories. These documents contain section headers, numbered findings, citation markers (`[D1]`, `[S1]`), and cross-references. The current cascade system uses string-based IDs within JSONB payloads (e.g., `KG-001` for knowledge gaps, `TB-003` for target barriers) that are assigned by the LLM during extraction and referenced by downstream variables via linkage fields.
+
+These string IDs serve the cascade pipeline well — they're human-readable, appear in rendered documents, and enable traceability within a single study's cascade flow. However, they have limitations as canonical identity:
+
+- They're assigned by the LLM (non-deterministic — ADR 0028)
+- They exist only inside JSONB payloads, not as relational database entities
+- They can't participate in foreign key relationships
+- Cross-study queries require parsing JSONB to find references
+- Document regeneration could reassign IDs (KG-001 might refer to different gaps across regenerations)
+
+The evidence architecture needs identity that is stable, relational, and independent of rendered document anchors.
+
+## Decision
+
+Stable database IDs and typed relational lineage are the authoritative evidence identity. Rendered document anchors (section numbers, citation markers, human-readable codes) are presentation references, not identity.
+
+Evidence identity has three tiers:
+
+1. **Integer PK (`id`)** — internal relational identity. Used for joins, FK references within the evidence layer, and transactional operations. Never exposed outside the persistence layer.
+
+2. **UUID (`public_id`)** — durable machine identity. Auto-generated, stable across document regeneration, template version changes, and artifact renames. Suitable for provenance chains, exports, API references, GitHub document anchors, admin surfaces, and future `/qori-ask`. Every evidence_source, evidence_construct, and evidence_relationship has a `public_id UUID NOT NULL UNIQUE`.
+
+3. **Human-readable label** — presentation reference. Optional display identifiers such as `RQ-004`, `F-012`, `NUGGET-PT003-007`. May vary by artifact context. Stored in the construct's JSONB payload or label field. Not identity.
+
+Specifically:
+
+- Every evidence source, construct, and relationship gets an auto-incrementing integer PK for internal use and a UUID `public_id` for durable external identity.
+- Relationships between entities are stored as rows in `evidence_relationships` with FK-backed columns (`from_source_id`, `from_construct_id`, `to_source_id`, `to_construct_id`) and CHECK constraints enforcing exactly one FROM and one TO endpoint. Lineage endpoint integrity is database-enforced, not service-layer validated.
+- Construct payloads may contain human-readable labels (e.g., `"label": "Upload barrier"`) for display purposes, but these are presentation references, not identity.
+- Existing cascade string IDs (`KG-001`, `TB-003`, `PT-007`) remain valid within the cascade pipeline. They are not replaced. When a construct is promoted from cascade to evidence, the cascade ID may be stored in the construct's JSONB payload as a cross-reference.
+
+The provenance chain:
+
+```
+source (DB ID) → construct (DB ID) → construct (DB ID) → ... → ticket (DB ID)
+```
+
+is structurally possible through `evidence_relationships` rows, each with typed relationship semantics (`DERIVED_FROM`, `SUPPORTS`, `ADDRESSES`, `IMPLEMENTED_BY`, etc.).
+
+## Alternatives considered
+
+**UUIDs as the only PK (no integer PK).** UUIDs are globally unique but slower for joins and less readable in debugging. The two-tier approach (integer PK for internal joins, UUID public_id for external identity) gives both performance and durability without trade-off.
+
+**Service-layer referential integrity (polymorphic from_type/from_id).** The initial implementation used polymorphic type+id columns with integrity checks in application code. This was corrected: lineage is a trust boundary and must be database-enforced. FK-backed columns with CHECK constraints prevent orphan edges at the Postgres level.
+
+**Embed relationships in JSONB arrays.** The current cascade pattern — `supporting_nuggets: ["NUG-001", "NUG-003"]` — works for template rendering. But JSONB arrays can't enforce referential integrity, can't be indexed for reverse lookups, and can't participate in transactional guarantees. The evidence layer needs "find all constructs that support finding F" as a relational query, not a full-table JSONB scan.
+
+**Graph database (Neo4j, etc.).** The evidence layer is a directed graph, and a graph database would be a natural fit. But Qori runs on PostgreSQL, the team knows PostgreSQL, and the graph is small enough (hundreds to low thousands of nodes per project) that a relational representation with typed edges is sufficient. A graph database would add operational complexity with no current query-performance justification.
+
+## Consequences
+
+- Evidence entities have durable identity (`public_id` UUID) that survives document regeneration, template version changes, and artifact renames.
+- Lineage endpoint integrity is database-enforced via FK columns and CHECK constraints. Invalid references fail at INSERT, not at query time.
+- Reverse lookups ("what supports this finding?") are indexed relational queries, not JSONB scans.
+- The evidence_relationships table supports the full provenance chain from source → ... → ticket without requiring all intermediate nodes to exist yet. Future edge types (e.g., recommendation → ticket) can be added via additive FK columns.
+- Cascade string IDs (`KG-001`, etc.) continue to work unchanged within the cascade pipeline. Three ID tiers coexist: integer PKs for internal joins, UUIDs for durable external identity, cascade IDs for template rendering.
+- Future `/qori-ask` can traverse the relationship graph relationally: "find all recommendations supported by findings from study X that reference barrier B."
+- Deletion of a source or construct cascades to its relationship edges — no orphan lineage can exist.
+
+## References
+
+- ADR 0028 — Deterministic research transformations (ID assignment is deterministic)
+- ADR 0029 — Canonical evidence state vs cascade projection
+- ADR 0020 — System-assigned participant codes (existing pattern for stable IDs)
+- `backend/src/types/cascade.ts` — existing cascade string IDs (unchanged)

--- a/docs/architecture-decisions/0031-progressive-modal-contracts.md
+++ b/docs/architecture-decisions/0031-progressive-modal-contracts.md
@@ -1,0 +1,59 @@
+# ADR 0031: Progressive modal contracts — consumes / asks / commits / control / uploads / derives
+
+**Status:** Accepted
+**Date:** 2026-08-15
+**Decision drivers:** Evidence architecture foundation — establishing a conceptual vocabulary for modal interactions that prevents researchers from re-entering information Qori already knows, without requiring an immediate whole-product rewrite.
+
+## Context
+
+Qori's modals collect researcher input for AI-powered document generation. Currently, modal design is ad hoc: each modal defines its own fields based on what the template needs. Some fields pre-populate from the database (e.g., lead researcher auto-fills from Slack profile), but there is no systematic vocabulary for distinguishing between "information Qori already has" and "genuinely new input the researcher must provide."
+
+As the evidence layer (ADR 0029) grows, Qori will accumulate accepted research state: project context, discovery findings, research questions, validated barriers, participant observations. Modals should progressively consume this state rather than asking researchers to re-enter or re-describe it.
+
+`/qori-start` is the root context — it establishes the project, problem statement, and GitHub structure that all subsequent workflows reference. Every modal downstream of `/qori-start` can, in principle, consume project-level context.
+
+## Decision
+
+From this point forward, whenever a modal is materially changed, its contract is conceptually defined using these categories:
+
+- **CONSUMES** — accepted context Qori already knows with sufficient confidence. These values are loaded from the database or evidence store and displayed as read-only or pre-populated fields. The researcher should not need to re-enter them.
+
+- **ASKS** — genuinely missing information or required human choice that Qori cannot derive. These are the modal's interactive fields — the researcher must provide or confirm these values.
+
+- **COMMITS** — authoritative state created or changed by the interaction. What does submitting this modal write to the database? This makes the modal's side effects explicit.
+
+- **CONTROL** — workflow-only state that influences processing but isn't research content. Examples: "generate in background" toggle, study selector, output format preference.
+
+- **UPLOADS** — raw evidence or source material attached to the interaction. Examples: uploaded transcripts, survey datasets, policy documents.
+
+- **DERIVES** — values computed by the system from other inputs, not entered by the researcher and not requiring LLM generation. Examples: next participant code, project slug, display date.
+
+The governing UX rule: **Do not ask a researcher to re-enter information Qori already knows with sufficient confidence.**
+
+This is a progressive discipline, not a framework. No generic modal DSL is built. No existing modal is rewritten solely to conform. The vocabulary is applied when a modal is next materially changed, and the contract is documented in the modal builder's JSDoc or a companion comment.
+
+`/qori-start` is recognized as the root project context. Its COMMITS (project name, problem statement, channel binding, project membership) are CONSUMES candidates for every downstream modal.
+
+## Alternatives considered
+
+**Build a modal contract DSL now.** A declarative format (`{ consumes: [...], asks: [...], commits: [...] }`) that generates modals automatically. Premature — Qori has ~30 modals, ~35% are dynamic factory functions (per the modals architecture decision in CLAUDE.md), and the evidence layer doesn't yet have enough accepted state to make automatic consumption valuable. Build the vocabulary first; consider automation after 3-5 modals have been manually converted.
+
+**Skip the vocabulary — just pre-populate where obvious.** Some modals already pre-populate (lead researcher, start date). But without a vocabulary, there's no systematic way to audit "which modals ask for things Qori already knows" or to plan evidence-layer integration. The vocabulary costs nothing to adopt and makes the progressive conversion auditable.
+
+**Rewrite all modals now.** The evidence layer has zero rows. Rewriting 30 modals to consume evidence state that doesn't exist yet is waste. Progressive adoption means each modal conversion happens alongside the vertical slice that populates the evidence it would consume.
+
+## Consequences
+
+- New or materially changed modals document their CONSUMES/ASKS/COMMITS/CONTROL/UPLOADS/DERIVES contract.
+- Existing modals are not rewritten solely to conform — the contract is applied when the modal is next changed for functional reasons.
+- `/qori-start` is recognized as the root context. Its committed state (project, problem statement, channel) is consumable by all downstream modals.
+- The evidence layer (ADR 0029) progressively provides more CONSUMES candidates as vertical slices populate it.
+- Modal review becomes auditable: "this modal ASKS for methodology, but the research brief already COMMITTED a methodology choice" is a visible contract violation that can be resolved by converting the field from ASKS to CONSUMES.
+- No infrastructure is built in this phase — this is a vocabulary and a discipline, not a framework.
+
+## References
+
+- ADR 0029 — Canonical evidence state (provides CONSUMES candidates)
+- `/qori-start` handler — `backend/src/helpers/slack/commands/projectStartHandler.ts`
+- Modal builders — `backend/src/helpers/slack/ui/`
+- CLAUDE.md — Modals Architecture section (decision to keep modals as JS, ~35% dynamic)

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -100,6 +100,10 @@ Start with `0001` and read forward. The history is itself useful — it shows ho
 - [0025 — Admin center and federal records management](./0025-admin-center-records-management.md) — Owner-as-records-authority; disposition schedules; legal holds; retention-gated deletion; audit logging
 - [0026 — PII scrubbing at ingestion](./0026-pii-scrubbing-at-ingestion.md) — Transient-capture scrub; quarantine; review-gates-commit; no real names stored
 - [0027 — Single study per project accepted for launch (Phase 2D)](./0027-single-study-per-project-phase-2d.md) — Doubled {slug}/{slug} path is accepted artifact; multi-study deferred post-launch
+- [0028 — Deterministic research transformations occur outside generative models](./0028-deterministic-research-transformations.md) — LLMs interpret computed facts; they don't compute them
+- [0029 — Canonical evidence state is distinct from cascade projection](./0029-canonical-evidence-state-and-cascade-projection.md) — Authoritative evidence persists independently of study_variables consumer shapes
+- [0030 — Stable database IDs and typed relational lineage are authoritative evidence identity](./0030-evidence-lineage-identity.md) — DB IDs are identity; document anchors are presentation
+- [0031 — Progressive modal contracts](./0031-progressive-modal-contracts.md) — CONSUMES/ASKS/COMMITS/CONTROL/UPLOADS/DERIVES vocabulary applied progressively
 
 ### Lessons (informal ADRs from failure modes)
 


### PR DESCRIPTION
## Why

Qori needs durable evidence identity and lineage beneath the existing CCA cascade to truthfully support the provenance chain:

> source evidence → research question → fieldwork → observation → analysis → finding → recommendation → GitHub ticket

This foundation also enables future `/qori-ask`, where researchers query accumulated findings with evidence-backed answers.

## What

- **evidence_sources** — metadata about evidence-bearing inputs (documents, transcripts, datasets)
- **evidence_constructs** — typed research objects with stable ID, UUID public identity, JSONB payload, derivation metadata, acceptance status
- **evidence_relationships** — FK-backed directed lineage edges with CHECK constraints enforcing exactly-one-from and exactly-one-to endpoint
- **Evidence service** — CRUD with transactional derivation (construct + lineage atomically)
- **Projection seam** — fail-closed validated transform from accepted evidence → cascade-compatible shapes, no LLM re-extraction
- **EvidenceProjectionError** — typed error for accepted constructs that fail projection validation
- **ADRs 0028-0031** — deterministic transformations, canonical evidence vs cascade projection, evidence lineage identity, progressive modal contracts

### Key design decisions

- FK-backed lineage endpoints with database CHECK constraints (not polymorphic service-layer validation)
- UUID `public_id` on all three tables for durable external identity
- `study_id CASCADE` — study-scoped evidence deleted with study (not silently reclassified)
- Fail-closed projection — accepted constructs missing required fields throw, not default

## What this does NOT change

- No current workflow writes evidence rows
- No survey rebuild
- No study_variables migration
- No prompt/template changes
- No modal changes
- No `/qori-ask`
- No staleness behavior
- No GitHub ticket changes

## Migration behavior

- Additive only — 3 new empty tables
- Reversible `down()` drops all three
- No existing data rewrite
- Existing app operates normally with zero evidence rows
- Backward-compatible: existing cascade tests pass unchanged

## Verification

- **Typecheck:** `tsc --noEmit` — clean
- **Unit tests:** 159 passed, 0 failed (14 suites)
- **Integration tests:** 233 passed, 0 failed (20 suites)
- **Pattern enforcement:** `any` budget passes (zero new `any` in production code)
- **Migration:** applies cleanly, creates tables with FK/CHECK/UUID constraints

## Test plan

- [x] Typecheck passes
- [x] Unit tests pass (including 15 new projection tests)
- [x] Integration tests pass (including 29 new evidence foundation tests)
- [x] Pattern enforcement (any budget) passes
- [x] Migration applies and reverses cleanly
- [x] Existing cascade variable store unaffected
- [ ] CI pipeline green
- [ ] Railway dev deploys successfully
- [ ] Evidence tables visible in dev Postgres
- [ ] Existing `/qori-start` or discovery workflow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)