### PR TITLE
feat(survey): structured CSV ingestion with deterministic facts

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,7 @@
         "compression": "^1.7.4",
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",
+        "csv-parse": "^7.0.2",
         "date-fns": "^4.1.0",
         "debug": "~2.6.9",
         "dotenv": "^8.6.0",
@@ -8685,6 +8686,12 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-7.0.2.tgz",
+      "integrity": "sha512-uKZghv9UmPkMVLYy//KZ9HFAIJsl7wkhoEdIL0+rhuSY9pZQlhaeGEDPIe+/w7eh81MOql8Q/9+inAGWG6ZHYA==",
+      "license": "MIT"
     },
     "node_modules/d": {
       "version": "1.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -47,6 +47,7 @@
     "compression": "^1.7.4",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
+    "csv-parse": "^7.0.2",
     "date-fns": "^4.1.0",
     "debug": "~2.6.9",
     "dotenv": "^8.6.0",

--- a/backend/src/__tests__/__fixtures__/survey/duplicate-ids.csv
+++ b/backend/src/__tests__/__fixtures__/survey/duplicate-ids.csv
@@ -1,0 +1,4 @@
+response_id,satisfaction,notes
+R-501,Good,"First entry"
+R-502,Bad,"Second entry"
+R-501,Good,"Duplicate ID"

--- a/backend/src/__tests__/__fixtures__/survey/malformed.csv
+++ b/backend/src/__tests__/__fixtures__/survey/malformed.csv
@@ -1,0 +1,5 @@
+response_id,satisfaction,notes
+R-301,Good,"This is fine"
+R-302,Bad
+R-303,Good,"Extra field here","unexpected column"
+R-304,,

--- a/backend/src/__tests__/__fixtures__/survey/missing-values.csv
+++ b/backend/src/__tests__/__fixtures__/survey/missing-values.csv
@@ -1,0 +1,6 @@
+response_id,overall_satisfaction,difficulty_rating,completion_status,biggest_challenge
+R-201,Satisfied,Easy,Complete,"Finding the right form"
+R-202,,Moderate,,
+R-203,Dissatisfied,,Incomplete,"Upload kept failing"
+R-204,,,Complete,""
+R-205,Very Satisfied,Very Easy,Complete,"Nothing major"

--- a/backend/src/__tests__/__fixtures__/survey/no-respondent-id.csv
+++ b/backend/src/__tests__/__fixtures__/survey/no-respondent-id.csv
@@ -1,0 +1,6 @@
+overall_satisfaction,difficulty_rating,completion_status,biggest_challenge
+Satisfied,Easy,Complete,"Finding the right form"
+Very Satisfied,Very Easy,Complete,"Nothing major"
+Dissatisfied,Difficult,Incomplete,"Upload kept failing"
+Satisfied,Moderate,Complete,"Understanding the terminology"
+Very Dissatisfied,Very Difficult,Incomplete,"Everything was confusing"

--- a/backend/src/__tests__/__fixtures__/survey/ordinal-categories.csv
+++ b/backend/src/__tests__/__fixtures__/survey/ordinal-categories.csv
@@ -1,0 +1,8 @@
+response_id,experience_level,satisfaction_1to5,difficulty_1to5,department
+R-601,Senior,4,2,Engineering
+R-602,Junior,5,1,Design
+R-603,Mid-level,3,3,Engineering
+R-604,Senior,4,2,Research
+R-605,Junior,2,4,Design
+R-606,Mid-level,4,1,Engineering
+R-607,Senior,5,2,Research

--- a/backend/src/__tests__/__fixtures__/survey/quoted-multiline.csv
+++ b/backend/src/__tests__/__fixtures__/survey/quoted-multiline.csv
@@ -1,0 +1,9 @@
+response_id,satisfaction,open_feedback
+R-401,Satisfied,"This was a great experience.
+I would definitely use it again.
+The interface was clean and intuitive."
+R-402,Dissatisfied,"Multiple issues:
+1. Upload failed twice
+2. Lost my progress
+3. Had to start over"
+R-403,Neutral,"It was okay, nothing special"

--- a/backend/src/__tests__/__fixtures__/survey/standard.csv
+++ b/backend/src/__tests__/__fixtures__/survey/standard.csv
@@ -1,0 +1,11 @@
+response_id,timestamp,overall_satisfaction,difficulty_rating,completion_status,biggest_challenge,additional_feedback
+R-101,2026-06-01 10:30:00,Satisfied,Easy,Complete,"Finding the right form","Overall good experience"
+R-102,2026-06-01 11:15:00,Very Satisfied,Very Easy,Complete,"Nothing major","Loved the new interface"
+R-103,2026-06-02 09:00:00,Dissatisfied,Difficult,Incomplete,"Upload kept failing, lost my progress twice","Needs serious work on file uploads"
+R-104,2026-06-02 14:30:00,Satisfied,Moderate,Complete,"Understanding the terminology","The help section was useful"
+R-105,2026-06-03 08:45:00,Very Dissatisfied,Very Difficult,Incomplete,"Everything was confusing from the start","I gave up after 20 minutes"
+R-106,2026-06-03 16:00:00,Neutral,Moderate,Complete,"The process was long but manageable",""
+R-107,2026-06-04 10:00:00,Satisfied,Easy,Complete,"Minor layout issues","Would recommend to colleagues"
+R-108,2026-06-04 13:20:00,Dissatisfied,Difficult,Partial,"Could not find where to submit final documents","Navigation needs improvement"
+R-109,2026-06-05 09:30:00,Satisfied,Easy,Complete,"No challenges","Quick and painless"
+R-110,2026-06-05 15:45:00,Very Satisfied,Very Easy,Complete,"","Best government form I have used"

--- a/backend/src/__tests__/integration/setup/testDb.ts
+++ b/backend/src/__tests__/integration/setup/testDb.ts
@@ -31,6 +31,7 @@ import DispositionAuditLog from '../../../database/models/disposition_audit_log'
 import EvidenceSource from '../../../database/models/evidence_source';
 import EvidenceConstruct from '../../../database/models/evidence_construct';
 import EvidenceRelationship from '../../../database/models/evidence_relationship';
+import SurveyFieldSchema from '../../../database/models/survey_field_schema';
 
 let instance: Sequelize | null = null;
 
@@ -57,6 +58,7 @@ export function getTestDb(): Sequelize {
     StudyStatus, StudyParticipant, SessionObserver, StudyNotes,
     ResearchPlan, SessionSummary, StudyVariable, CreatedIssue, SlackUserState,
     DispositionAuditLog, EvidenceSource, EvidenceConstruct, EvidenceRelationship,
+    SurveyFieldSchema,
   ];
 
   for (const defineModel of modelDefiners) {

--- a/backend/src/__tests__/integration/survey-evidence.test.ts
+++ b/backend/src/__tests__/integration/survey-evidence.test.ts
@@ -168,6 +168,92 @@ describe('survey_field_schemas', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════
+// ACCEPTED-SCHEMA REUSE GUARD
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('accepted-schema reuse guard', () => {
+  it('partially reviewed schema is NOT treated as reusable accepted schema', async () => {
+    const source = await EvidenceSourceModel.create({
+      project_id: projectId, source_type: 'survey_dataset',
+      label: 'Partial review test', artifact_ref: { content_hash: 'abc123' },
+      created_by: 'U_TEST',
+    } as CreationAttributes<EvidenceSource>);
+    const sourceId = (source as any).id;
+
+    // Simulate paginated review: first 2 fields confirmed, third still pending
+    await SurveyFieldSchemaModel.create({
+      evidence_source_id: sourceId, field_name: 'field_a',
+      inferred_role: 'nominal', confirmed_role: 'nominal',
+      review_status: 'confirmed', reviewed_by: 'U_TEST', reviewed_at: new Date(),
+    } as CreationAttributes<SurveyFieldSchema>);
+    await SurveyFieldSchemaModel.create({
+      evidence_source_id: sourceId, field_name: 'field_b',
+      inferred_role: 'ordinal', confirmed_role: 'ordinal',
+      review_status: 'confirmed', reviewed_by: 'U_TEST', reviewed_at: new Date(),
+    } as CreationAttributes<SurveyFieldSchema>);
+    await SurveyFieldSchemaModel.create({
+      evidence_source_id: sourceId, field_name: 'field_c',
+      inferred_role: 'open_text',
+      review_status: 'pending', // NOT confirmed
+    } as CreationAttributes<SurveyFieldSchema>);
+
+    // Query the same way the handler does:
+    const confirmedSchemas = await SurveyFieldSchemaModel.findAll({
+      where: { evidence_source_id: sourceId, review_status: 'confirmed' },
+    });
+    const pendingCount = await SurveyFieldSchemaModel.count({
+      where: { evidence_source_id: sourceId, review_status: 'pending' },
+    });
+
+    // Guard: must have confirmed rows AND zero pending AND count matches CSV headers
+    const csvHeaderCount = 3; // simulated: field_a, field_b, field_c
+    const isCompleteAccepted = confirmedSchemas.length > 0
+      && pendingCount === 0
+      && confirmedSchemas.length === csvHeaderCount;
+
+    // Partial review must NOT be treated as accepted
+    expect(isCompleteAccepted).toBe(false);
+    expect(pendingCount).toBe(1);
+    expect(confirmedSchemas.length).toBe(2);
+  });
+
+  it('fully reviewed schema IS treated as reusable accepted schema', async () => {
+    const source = await EvidenceSourceModel.create({
+      project_id: projectId, source_type: 'survey_dataset',
+      label: 'Full review test', artifact_ref: { content_hash: 'def456' },
+      created_by: 'U_TEST',
+    } as CreationAttributes<EvidenceSource>);
+    const sourceId = (source as any).id;
+
+    // All fields confirmed
+    await SurveyFieldSchemaModel.create({
+      evidence_source_id: sourceId, field_name: 'field_a',
+      inferred_role: 'nominal', confirmed_role: 'nominal',
+      review_status: 'confirmed', reviewed_by: 'U_TEST', reviewed_at: new Date(),
+    } as CreationAttributes<SurveyFieldSchema>);
+    await SurveyFieldSchemaModel.create({
+      evidence_source_id: sourceId, field_name: 'field_b',
+      inferred_role: 'ordinal', confirmed_role: 'ordinal',
+      review_status: 'confirmed', reviewed_by: 'U_TEST', reviewed_at: new Date(),
+    } as CreationAttributes<SurveyFieldSchema>);
+
+    const confirmedSchemas = await SurveyFieldSchemaModel.findAll({
+      where: { evidence_source_id: sourceId, review_status: 'confirmed' },
+    });
+    const pendingCount = await SurveyFieldSchemaModel.count({
+      where: { evidence_source_id: sourceId, review_status: 'pending' },
+    });
+
+    const csvHeaderCount = 2; // simulated: field_a, field_b
+    const isCompleteAccepted = confirmedSchemas.length > 0
+      && pendingCount === 0
+      && confirmedSchemas.length === csvHeaderCount;
+
+    expect(isCompleteAccepted).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
 // DETERMINISTIC CONSTRUCTS + LINEAGE
 // ═══════════════════════════════════════════════════════════════════════
 

--- a/backend/src/__tests__/integration/survey-evidence.test.ts
+++ b/backend/src/__tests__/integration/survey-evidence.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Survey Evidence Integration Tests
+ *
+ * Validates: evidence_source creation for survey datasets,
+ * survey_field_schema persistence and review state transitions,
+ * deterministic construct creation with lineage, source reuse
+ * via content hash, and zero-use backward compatibility.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { getTestDb, truncateAll } from './setup/testDb';
+import type { CreationAttributes } from 'sequelize';
+import type { EvidenceSource } from '../../database/models/evidence_source';
+import type { SurveyFieldSchema } from '../../database/models/survey_field_schema';
+import { parseCsvBuffer } from '../../helpers/survey/csvParser';
+import { computeContentHash } from '../../helpers/survey/sourceHash';
+import { inferFieldSchema } from '../../helpers/survey/schemaInference';
+import { computeSurveyFacts } from '../../helpers/survey/statsEngine';
+import type { ConfirmedField } from '../../types/survey';
+
+const sequelize = getTestDb();
+
+jest.mock('../../helpers/github', () => ({
+  fetchFileFromRepoByPath: jest.fn().mockResolvedValue(null),
+  createOrUpdateFileOnGitHub: jest.fn().mockResolvedValue({ success: true }),
+  getContentRepo: jest.fn().mockReturnValue('test-repo'),
+}));
+
+const Project = sequelize.models.Project;
+const EvidenceSourceModel = sequelize.models.EvidenceSource;
+const EvidenceConstructModel = sequelize.models.EvidenceConstruct;
+const EvidenceRelationshipModel = sequelize.models.EvidenceRelationship;
+const SurveyFieldSchemaModel = sequelize.models.SurveyFieldSchema;
+
+const FIXTURES = join(__dirname, '../__fixtures__/survey');
+let projectId: number;
+
+beforeEach(async () => {
+  await truncateAll();
+  const project = await Project.create({
+    name: 'Survey Test Project', slug: 'survey-test', status: 'active', created_by: 'U_TEST',
+  });
+  projectId = (project as any).id;
+});
+
+afterAll(async () => { await sequelize.close(); });
+
+// ═══════════════════════════════════════════════════════════════════════
+// SOURCE CREATION
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('survey evidence_source', () => {
+  it('creates a survey_dataset source with content hash', async () => {
+    const csv = readFileSync(join(FIXTURES, 'standard.csv'));
+    const hash = computeContentHash(csv);
+
+    const source = await EvidenceSourceModel.create({
+      project_id: projectId,
+      source_type: 'survey_dataset',
+      label: 'Test Survey — standard.csv',
+      artifact_ref: { filename: 'standard.csv', content_hash: hash },
+      metadata: { row_count: 10, column_count: 7 },
+      created_by: 'U_TEST',
+    } as CreationAttributes<EvidenceSource>);
+
+    expect((source as any).id).toBeDefined();
+    expect((source as any).public_id).toBeDefined();
+    expect((source as any).source_type).toBe('survey_dataset');
+    expect((source as any).artifact_ref.content_hash).toBe(hash);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// FIELD SCHEMA PERSISTENCE
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('survey_field_schemas', () => {
+  let sourceId: number;
+
+  beforeEach(async () => {
+    const source = await EvidenceSourceModel.create({
+      project_id: projectId, source_type: 'survey_dataset',
+      label: 'Test', artifact_ref: { content_hash: 'abc' },
+      created_by: 'U_TEST',
+    } as CreationAttributes<EvidenceSource>);
+    sourceId = (source as any).id;
+  });
+
+  it('persists inferred field schemas', async () => {
+    await SurveyFieldSchemaModel.create({
+      evidence_source_id: sourceId,
+      field_name: 'overall_satisfaction',
+      inferred_role: 'ordinal',
+      inference_source: 'heuristic',
+      review_status: 'pending',
+    } as CreationAttributes<SurveyFieldSchema>);
+
+    const schemas = await SurveyFieldSchemaModel.findAll({
+      where: { evidence_source_id: sourceId },
+    });
+    expect(schemas).toHaveLength(1);
+    expect((schemas[0] as any).inferred_role).toBe('ordinal');
+    expect((schemas[0] as any).review_status).toBe('pending');
+  });
+
+  it('transitions from pending to confirmed with reviewer info', async () => {
+    const schema = await SurveyFieldSchemaModel.create({
+      evidence_source_id: sourceId,
+      field_name: 'difficulty_rating',
+      inferred_role: 'ordinal',
+      review_status: 'pending',
+    } as CreationAttributes<SurveyFieldSchema>);
+
+    await schema.update({
+      confirmed_role: 'ordinal',
+      order_metadata: ['Very Easy', 'Easy', 'Moderate', 'Difficult', 'Very Difficult'],
+      review_status: 'confirmed',
+      reviewed_by: 'U_REVIEWER',
+      reviewed_at: new Date(),
+    });
+
+    const updated = await SurveyFieldSchemaModel.findByPk((schema as any).id);
+    expect((updated as any).confirmed_role).toBe('ordinal');
+    expect((updated as any).order_metadata).toEqual(['Very Easy', 'Easy', 'Moderate', 'Difficult', 'Very Difficult']);
+    expect((updated as any).review_status).toBe('confirmed');
+  });
+
+  it('enforces unique (evidence_source_id, field_name)', async () => {
+    await SurveyFieldSchemaModel.create({
+      evidence_source_id: sourceId, field_name: 'satisfaction',
+      inferred_role: 'ordinal', review_status: 'pending',
+    } as CreationAttributes<SurveyFieldSchema>);
+
+    await expect(
+      SurveyFieldSchemaModel.create({
+        evidence_source_id: sourceId, field_name: 'satisfaction',
+        inferred_role: 'nominal', review_status: 'pending',
+      } as CreationAttributes<SurveyFieldSchema>),
+    ).rejects.toThrow();
+  });
+
+  it('cascades on evidence_source deletion', async () => {
+    await SurveyFieldSchemaModel.create({
+      evidence_source_id: sourceId, field_name: 'test_field',
+      inferred_role: 'nominal', review_status: 'pending',
+    } as CreationAttributes<SurveyFieldSchema>);
+
+    await EvidenceSourceModel.destroy({ where: { id: sourceId } });
+
+    const remaining = await SurveyFieldSchemaModel.count({
+      where: { evidence_source_id: sourceId },
+    });
+    expect(remaining).toBe(0);
+  });
+
+  it('stores and clears pending_csv_content (quarantine pattern)', async () => {
+    const csvContent = 'id,val\n1,a\n2,b';
+    const schema = await SurveyFieldSchemaModel.create({
+      evidence_source_id: sourceId, field_name: 'id',
+      inferred_role: 'id', review_status: 'pending',
+      pending_csv_content: csvContent,
+    } as CreationAttributes<SurveyFieldSchema>);
+
+    expect((schema as any).pending_csv_content).toBe(csvContent);
+
+    // Clear on confirmation
+    await schema.update({ pending_csv_content: null, review_status: 'confirmed' });
+    const updated = await SurveyFieldSchemaModel.findByPk((schema as any).id);
+    expect((updated as any).pending_csv_content).toBeNull();
+    expect((updated as any).review_status).toBe('confirmed');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// DETERMINISTIC CONSTRUCTS + LINEAGE
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('deterministic survey constructs', () => {
+  it('creates survey_dataset_summary construct with lineage to source', async () => {
+    const csv = readFileSync(join(FIXTURES, 'standard.csv'));
+    const hash = computeContentHash(csv);
+    const survey = parseCsvBuffer(csv, 'standard.csv');
+
+    const source = await EvidenceSourceModel.create({
+      project_id: projectId, source_type: 'survey_dataset',
+      label: 'Standard survey', artifact_ref: { content_hash: hash },
+      created_by: 'U_TEST',
+    } as CreationAttributes<EvidenceSource>);
+
+    const confirmedFields: ConfirmedField[] = [
+      { fieldName: 'response_id', confirmedRole: 'id', orderMetadata: null, isDemographic: false },
+      { fieldName: 'overall_satisfaction', confirmedRole: 'ordinal',
+        orderMetadata: ['Very Dissatisfied', 'Dissatisfied', 'Neutral', 'Satisfied', 'Very Satisfied'],
+        isDemographic: false },
+      { fieldName: 'completion_status', confirmedRole: 'nominal', orderMetadata: null, isDemographic: false },
+    ];
+
+    const facts = computeSurveyFacts(survey, confirmedFields, hash);
+
+    // Create construct
+    const construct = await EvidenceConstructModel.create({
+      project_id: projectId,
+      construct_type: 'survey_dataset_summary',
+      label: `Standard survey — ${facts.totalRespondents} respondents`,
+      payload: { total_respondents: facts.totalRespondents, source_content_hash: hash },
+      derivation_type: 'deterministic',
+      status: 'accepted',
+      created_by: 'U_TEST',
+    });
+
+    // Create lineage
+    await EvidenceRelationshipModel.create({
+      from_source_id: (source as any).id,
+      from_construct_id: null,
+      to_source_id: null,
+      to_construct_id: (construct as any).id,
+      relationship_type: 'DERIVED_FROM',
+    });
+
+    // Verify lineage
+    const rels = await EvidenceRelationshipModel.findAll({
+      where: { from_source_id: (source as any).id },
+    });
+    expect(rels).toHaveLength(1);
+    expect((rels[0] as any).to_construct_id).toBe((construct as any).id);
+    expect((construct as any).derivation_type).toBe('deterministic');
+    expect((construct as any).status).toBe('accepted');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// DETERMINISM INVARIANT
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('determinism invariant', () => {
+  it('same CSV + same schema produces identical computed facts 3 times', () => {
+    const csv = readFileSync(join(FIXTURES, 'standard.csv'));
+    const hash = computeContentHash(csv);
+    const survey = parseCsvBuffer(csv, 'standard.csv');
+
+    const fields: ConfirmedField[] = [
+      { fieldName: 'response_id', confirmedRole: 'id', orderMetadata: null, isDemographic: false },
+      { fieldName: 'overall_satisfaction', confirmedRole: 'ordinal',
+        orderMetadata: ['Very Dissatisfied', 'Dissatisfied', 'Neutral', 'Satisfied', 'Very Satisfied'],
+        isDemographic: false },
+      { fieldName: 'difficulty_rating', confirmedRole: 'ordinal',
+        orderMetadata: ['Very Difficult', 'Difficult', 'Moderate', 'Easy', 'Very Easy'],
+        isDemographic: false },
+      { fieldName: 'completion_status', confirmedRole: 'nominal', orderMetadata: null, isDemographic: false },
+      { fieldName: 'biggest_challenge', confirmedRole: 'open_text', orderMetadata: null, isDemographic: false },
+    ];
+
+    const run1 = computeSurveyFacts(survey, fields, hash);
+    const run2 = computeSurveyFacts(survey, fields, hash);
+    const run3 = computeSurveyFacts(survey, fields, hash);
+
+    expect(run1).toEqual(run2);
+    expect(run2).toEqual(run3);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// ZERO-USE COMPATIBILITY
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('zero-use backward compatibility', () => {
+  it('existing cascade operations work when survey tables are empty', async () => {
+    expect(await SurveyFieldSchemaModel.count()).toBe(0);
+
+    // study_variables still works
+    const StudyVariableModel = sequelize.models.StudyVariable;
+    const study = await sequelize.models.ResearchStudy.create({
+      project_id: projectId, name: 'Compat Study', slug: 'compat',
+      path: 'survey-test/compat', status: 'active', created_by: 'U_TEST',
+      channel_name: 'test', researcher_name: 'Test', researcher_email: 'test@test.com',
+    });
+
+    const variable = await StudyVariableModel.create({
+      project_id: projectId, study_id: (study as any).id,
+      variable_key: 'discovered_barriers', variable_type: 'pool',
+      value: { id: 'DB-001', title: 'Test' },
+      source_template: 'desk_research', is_pool: true, item_key: 'DB-001',
+      scope: 'study', extracted_at: new Date(),
+    });
+
+    expect((variable as any).id).toBeDefined();
+  });
+});

--- a/backend/src/__tests__/integration/survey-evidence.test.ts
+++ b/backend/src/__tests__/integration/survey-evidence.test.ts
@@ -154,21 +154,16 @@ describe('survey_field_schemas', () => {
     expect(remaining).toBe(0);
   });
 
-  it('stores and clears pending_csv_content (quarantine pattern)', async () => {
-    const csvContent = 'id,val\n1,a\n2,b';
+  it('schema rows contain no raw CSV content column', async () => {
     const schema = await SurveyFieldSchemaModel.create({
-      evidence_source_id: sourceId, field_name: 'id',
-      inferred_role: 'id', review_status: 'pending',
-      pending_csv_content: csvContent,
+      evidence_source_id: sourceId, field_name: 'test',
+      inferred_role: 'nominal', review_status: 'pending',
     } as CreationAttributes<SurveyFieldSchema>);
 
-    expect((schema as any).pending_csv_content).toBe(csvContent);
-
-    // Clear on confirmation
-    await schema.update({ pending_csv_content: null, review_status: 'confirmed' });
-    const updated = await SurveyFieldSchemaModel.findByPk((schema as any).id);
-    expect((updated as any).pending_csv_content).toBeNull();
-    expect((updated as any).review_status).toBe('confirmed');
+    // Verify the model does not have a pending_csv_content column
+    // (raw CSV staging moved to Redis)
+    const raw = schema as unknown as Record<string, unknown>;
+    expect(raw.pending_csv_content).toBeUndefined();
   });
 });
 

--- a/backend/src/__tests__/unit/survey/csvParser.test.ts
+++ b/backend/src/__tests__/unit/survey/csvParser.test.ts
@@ -1,0 +1,124 @@
+/**
+ * CSV Parser unit tests.
+ *
+ * Covers: normal CSV, quoted commas, quoted newlines, escaped quotes,
+ * BOM, blank cells, duplicate headers, malformed rows, empty file,
+ * header-only file.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { parseCsvBuffer, CsvParseError } from '../../../helpers/survey/csvParser';
+
+const FIXTURES = join(__dirname, '../../__fixtures__/survey');
+
+function fixture(name: string): Buffer {
+  return readFileSync(join(FIXTURES, name));
+}
+
+describe('csvParser', () => {
+  it('parses a standard CSV with headers and data rows', () => {
+    const result = parseCsvBuffer(fixture('standard.csv'), 'standard.csv');
+
+    expect(result.headers).toEqual([
+      'response_id', 'timestamp', 'overall_satisfaction',
+      'difficulty_rating', 'completion_status', 'biggest_challenge',
+      'additional_feedback',
+    ]);
+    expect(result.rowCount).toBe(10);
+    expect(result.rows[0].values.response_id).toBe('R-101');
+    expect(result.rows[0].values.overall_satisfaction).toBe('Satisfied');
+    expect(result.rows[0].rowIndex).toBe(0);
+    expect(result.parseWarnings).toHaveLength(0);
+  });
+
+  it('handles quoted commas inside values', () => {
+    const csv = 'name,comment\nAlice,"Hello, world"\nBob,"One, two, three"';
+    const result = parseCsvBuffer(csv, 'quoted-commas.csv');
+
+    expect(result.rowCount).toBe(2);
+    expect(result.rows[0].values.comment).toBe('Hello, world');
+    expect(result.rows[1].values.comment).toBe('One, two, three');
+  });
+
+  it('handles quoted newlines inside values', () => {
+    const result = parseCsvBuffer(fixture('quoted-multiline.csv'), 'quoted-multiline.csv');
+
+    expect(result.rowCount).toBe(3);
+    expect(result.rows[0].values.open_feedback).toContain('great experience');
+    expect(result.rows[0].values.open_feedback).toContain('definitely use it again');
+    expect(result.rows[1].values.open_feedback).toContain('Multiple issues');
+  });
+
+  it('handles escaped quotes', () => {
+    const csv = 'id,text\n1,"She said ""hello"""\n2,"He said ""goodbye"""';
+    const result = parseCsvBuffer(csv, 'escaped-quotes.csv');
+
+    expect(result.rowCount).toBe(2);
+    expect(result.rows[0].values.text).toBe('She said "hello"');
+    expect(result.rows[1].values.text).toBe('He said "goodbye"');
+  });
+
+  it('handles UTF-8 BOM', () => {
+    const bom = Buffer.from([0xEF, 0xBB, 0xBF]);
+    const csv = Buffer.concat([bom, Buffer.from('id,name\n1,Alice\n2,Bob')]);
+    const result = parseCsvBuffer(csv, 'bom.csv');
+
+    expect(result.headers[0]).toBe('id');
+    expect(result.rowCount).toBe(2);
+  });
+
+  it('handles blank cells as empty strings', () => {
+    const result = parseCsvBuffer(fixture('missing-values.csv'), 'missing-values.csv');
+
+    expect(result.rowCount).toBe(5);
+    // Row R-202 has empty satisfaction and completion_status
+    expect(result.rows[1].values.overall_satisfaction).toBe('');
+    expect(result.rows[1].values.completion_status).toBe('');
+  });
+
+  it('deduplicates duplicate headers with warning', () => {
+    const csv = 'name,name,value\nAlice,Smith,100\nBob,Jones,200';
+    const result = parseCsvBuffer(csv, 'dup-headers.csv');
+
+    expect(result.headers).toEqual(['name', 'name_2', 'value']);
+    expect(result.parseWarnings.length).toBeGreaterThan(0);
+    expect(result.parseWarnings[0]).toContain('Duplicate header');
+  });
+
+  it('warns on malformed rows with column count mismatch', () => {
+    const result = parseCsvBuffer(fixture('malformed.csv'), 'malformed.csv');
+
+    expect(result.rowCount).toBeGreaterThan(0);
+    expect(result.parseWarnings.some(w => w.includes('columns'))).toBe(true);
+  });
+
+  it('throws CsvParseError on empty file', () => {
+    expect(() => parseCsvBuffer('', 'empty.csv')).toThrow(CsvParseError);
+    expect(() => parseCsvBuffer('   ', 'whitespace.csv')).toThrow(CsvParseError);
+  });
+
+  it('throws CsvParseError on header-only file', () => {
+    expect(() => parseCsvBuffer('id,name,value', 'headers-only.csv')).toThrow(CsvParseError);
+  });
+
+  it('assigns sequential rowIndex starting from 0', () => {
+    const result = parseCsvBuffer(fixture('standard.csv'), 'standard.csv');
+
+    for (let i = 0; i < result.rows.length; i++) {
+      expect(result.rows[i].rowIndex).toBe(i);
+    }
+  });
+
+  it('skips completely empty rows', () => {
+    const csv = 'id,val\n1,a\n,,\n2,b';
+    const result = parseCsvBuffer(csv, 'with-empty-row.csv');
+    expect(result.rowCount).toBe(2);
+  });
+
+  it('accepts string input in addition to Buffer', () => {
+    const csv = 'id,name\n1,Test';
+    const result = parseCsvBuffer(csv, 'string-input.csv');
+    expect(result.rowCount).toBe(1);
+  });
+});

--- a/backend/src/__tests__/unit/survey/respondentIdentity.test.ts
+++ b/backend/src/__tests__/unit/survey/respondentIdentity.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Respondent Identity unit tests.
+ *
+ * Covers: declared ID used, duplicate IDs fail, stable generated keys,
+ * different rows get different IDs, labels are not canonical.
+ */
+
+import {
+  assignRespondentIdentities,
+  DuplicateRespondentIdError,
+} from '../../../helpers/survey/respondentIdentity';
+import { parseCsvBuffer } from '../../../helpers/survey/csvParser';
+import { computeContentHash } from '../../../helpers/survey/sourceHash';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import type { ConfirmedField } from '../../../types/survey';
+
+const FIXTURES = join(__dirname, '../../__fixtures__/survey');
+
+describe('respondentIdentity', () => {
+  it('uses declared ID field when confirmed', () => {
+    const csv = readFileSync(join(FIXTURES, 'standard.csv'));
+    const survey = parseCsvBuffer(csv, 'standard.csv');
+    const hash = computeContentHash(csv);
+
+    const confirmedFields: ConfirmedField[] = [
+      { fieldName: 'response_id', confirmedRole: 'id', orderMetadata: null, isDemographic: false },
+      { fieldName: 'overall_satisfaction', confirmedRole: 'ordinal', orderMetadata: null, isDemographic: false },
+    ];
+
+    const identities = assignRespondentIdentities(survey, confirmedFields, hash);
+
+    expect(identities[0].canonicalKey).toBe('R-101');
+    expect(identities[0].source).toBe('declared');
+    expect(identities[1].canonicalKey).toBe('R-102');
+  });
+
+  it('throws DuplicateRespondentIdError on duplicate declared IDs', () => {
+    const csv = readFileSync(join(FIXTURES, 'duplicate-ids.csv'));
+    const survey = parseCsvBuffer(csv, 'duplicate-ids.csv');
+    const hash = computeContentHash(csv);
+
+    const confirmedFields: ConfirmedField[] = [
+      { fieldName: 'response_id', confirmedRole: 'id', orderMetadata: null, isDemographic: false },
+    ];
+
+    expect(() => assignRespondentIdentities(survey, confirmedFields, hash))
+      .toThrow(DuplicateRespondentIdError);
+  });
+
+  it('generates stable keys for same dataset', () => {
+    const csv = readFileSync(join(FIXTURES, 'no-respondent-id.csv'));
+    const survey = parseCsvBuffer(csv, 'no-respondent-id.csv');
+    const hash = computeContentHash(csv);
+
+    const confirmedFields: ConfirmedField[] = [
+      { fieldName: 'overall_satisfaction', confirmedRole: 'ordinal', orderMetadata: null, isDemographic: false },
+    ];
+
+    const run1 = assignRespondentIdentities(survey, confirmedFields, hash);
+    const run2 = assignRespondentIdentities(survey, confirmedFields, hash);
+
+    for (let i = 0; i < run1.length; i++) {
+      expect(run1[i].canonicalKey).toBe(run2[i].canonicalKey);
+    }
+  });
+
+  it('different rows get different generated IDs', () => {
+    const csv = readFileSync(join(FIXTURES, 'no-respondent-id.csv'));
+    const survey = parseCsvBuffer(csv, 'no-respondent-id.csv');
+    const hash = computeContentHash(csv);
+
+    const confirmedFields: ConfirmedField[] = [
+      { fieldName: 'overall_satisfaction', confirmedRole: 'ordinal', orderMetadata: null, isDemographic: false },
+    ];
+
+    const identities = assignRespondentIdentities(survey, confirmedFields, hash);
+    const keys = identities.map(i => i.canonicalKey);
+    const uniqueKeys = new Set(keys);
+    expect(uniqueKeys.size).toBe(keys.length);
+  });
+
+  it('display labels are R001-format, not canonical identity', () => {
+    const csv = readFileSync(join(FIXTURES, 'no-respondent-id.csv'));
+    const survey = parseCsvBuffer(csv, 'no-respondent-id.csv');
+    const hash = computeContentHash(csv);
+
+    const confirmedFields: ConfirmedField[] = [];
+
+    const identities = assignRespondentIdentities(survey, confirmedFields, hash);
+
+    expect(identities[0].displayLabel).toBe('R001');
+    expect(identities[1].displayLabel).toBe('R002');
+    // Labels are NOT the canonical key
+    expect(identities[0].canonicalKey).not.toBe('R001');
+    expect(identities[0].source).toBe('generated');
+  });
+
+  it('generated keys depend on content hash, not external source ID', () => {
+    const csv1 = 'col1\nA\nB';
+    const csv2 = 'col1\nA\nB\nC';
+    const survey1 = parseCsvBuffer(csv1, 'test1.csv');
+    const survey2 = parseCsvBuffer(csv2, 'test2.csv');
+    const hash1 = computeContentHash(csv1);
+    const hash2 = computeContentHash(csv2);
+
+    const ids1 = assignRespondentIdentities(survey1, [], hash1);
+    const ids2 = assignRespondentIdentities(survey2, [], hash2);
+
+    // Same row index but different content hash → different keys
+    expect(ids1[0].canonicalKey).not.toBe(ids2[0].canonicalKey);
+  });
+});

--- a/backend/src/__tests__/unit/survey/schemaInference.test.ts
+++ b/backend/src/__tests__/unit/survey/schemaInference.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Schema Inference unit tests.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { inferFieldSchema } from '../../../helpers/survey/schemaInference';
+import { parseCsvBuffer } from '../../../helpers/survey/csvParser';
+
+const FIXTURES = join(__dirname, '../../__fixtures__/survey');
+
+describe('schemaInference', () => {
+  it('infers response_id as id field', () => {
+    const csv = readFileSync(join(FIXTURES, 'standard.csv'));
+    const survey = parseCsvBuffer(csv, 'standard.csv');
+    const fields = inferFieldSchema(survey);
+
+    const idField = fields.find(f => f.fieldName === 'response_id');
+    expect(idField).toBeDefined();
+    expect(idField!.inferredRole).toBe('id');
+  });
+
+  it('infers timestamp field', () => {
+    const csv = readFileSync(join(FIXTURES, 'standard.csv'));
+    const survey = parseCsvBuffer(csv, 'standard.csv');
+    const fields = inferFieldSchema(survey);
+
+    const tsField = fields.find(f => f.fieldName === 'timestamp');
+    expect(tsField).toBeDefined();
+    expect(tsField!.inferredRole).toBe('timestamp');
+  });
+
+  it('infers Likert-label fields as ordinal', () => {
+    const csv = readFileSync(join(FIXTURES, 'standard.csv'));
+    const survey = parseCsvBuffer(csv, 'standard.csv');
+    const fields = inferFieldSchema(survey);
+
+    const satField = fields.find(f => f.fieldName === 'overall_satisfaction');
+    expect(satField).toBeDefined();
+    expect(satField!.inferredRole).toBe('ordinal');
+
+    const diffField = fields.find(f => f.fieldName === 'difficulty_rating');
+    expect(diffField).toBeDefined();
+    expect(diffField!.inferredRole).toBe('ordinal');
+  });
+
+  it('infers small integer range as ordinal', () => {
+    const csv = readFileSync(join(FIXTURES, 'ordinal-categories.csv'));
+    const survey = parseCsvBuffer(csv, 'ordinal-categories.csv');
+    const fields = inferFieldSchema(survey);
+
+    const sat = fields.find(f => f.fieldName === 'satisfaction_1to5');
+    expect(sat).toBeDefined();
+    expect(sat!.inferredRole).toBe('ordinal');
+  });
+
+  it('infers open-text fields', () => {
+    const csv = readFileSync(join(FIXTURES, 'standard.csv'));
+    const survey = parseCsvBuffer(csv, 'standard.csv');
+    const fields = inferFieldSchema(survey);
+
+    const challenge = fields.find(f => f.fieldName === 'biggest_challenge');
+    expect(challenge).toBeDefined();
+    expect(challenge!.inferredRole).toBe('open_text');
+  });
+
+  it('infers low-cardinality text as nominal', () => {
+    const csv = readFileSync(join(FIXTURES, 'standard.csv'));
+    const survey = parseCsvBuffer(csv, 'standard.csv');
+    const fields = inferFieldSchema(survey);
+
+    const status = fields.find(f => f.fieldName === 'completion_status');
+    expect(status).toBeDefined();
+    expect(status!.inferredRole).toBe('nominal');
+  });
+
+  it('provides sample values for each field', () => {
+    const csv = readFileSync(join(FIXTURES, 'standard.csv'));
+    const survey = parseCsvBuffer(csv, 'standard.csv');
+    const fields = inferFieldSchema(survey);
+
+    for (const field of fields) {
+      expect(field.sampleValues).toBeDefined();
+      expect(Array.isArray(field.sampleValues)).toBe(true);
+      expect(field.sampleValues.length).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it('reports present and missing counts', () => {
+    const csv = readFileSync(join(FIXTURES, 'missing-values.csv'));
+    const survey = parseCsvBuffer(csv, 'missing-values.csv');
+    const fields = inferFieldSchema(survey);
+
+    const satField = fields.find(f => f.fieldName === 'overall_satisfaction');
+    expect(satField).toBeDefined();
+    expect(satField!.presentCount).toBe(3); // R-201, R-203, R-205 have values
+    expect(satField!.missingCount).toBe(2); // R-202, R-204 are empty
+  });
+
+  it('returns one field per header in header order', () => {
+    const csv = readFileSync(join(FIXTURES, 'standard.csv'));
+    const survey = parseCsvBuffer(csv, 'standard.csv');
+    const fields = inferFieldSchema(survey);
+
+    expect(fields.length).toBe(survey.headers.length);
+    for (let i = 0; i < fields.length; i++) {
+      expect(fields[i].fieldName).toBe(survey.headers[i]);
+    }
+  });
+
+  it('infers department as nominal (low cardinality categorical)', () => {
+    const csv = readFileSync(join(FIXTURES, 'ordinal-categories.csv'));
+    const survey = parseCsvBuffer(csv, 'ordinal-categories.csv');
+    const fields = inferFieldSchema(survey);
+
+    const dept = fields.find(f => f.fieldName === 'department');
+    expect(dept).toBeDefined();
+    expect(dept!.inferredRole).toBe('nominal');
+  });
+});

--- a/backend/src/__tests__/unit/survey/schemaReview.test.ts
+++ b/backend/src/__tests__/unit/survey/schemaReview.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Schema Review validation tests.
+ *
+ * Covers:
+ * - Ordinal order validation: incomplete order fails, duplicate fails
+ * - Field count check: >100 fields rejected
+ * - Pagination: getTotalPages
+ */
+
+import {
+  parseSchemaReviewValues,
+  OrdinalOrderValidationError,
+  checkFieldCountSupported,
+  getTotalPages,
+} from '../../../helpers/slack/ui/surveySchemaReviewModal';
+import type { SurveyField } from '../../../types/survey';
+
+function fakeField(name: string, role: string = 'nominal'): SurveyField {
+  return {
+    fieldName: name,
+    inferredRole: role as any,
+    sampleValues: [],
+    distinctCount: 3,
+    presentCount: 10,
+    missingCount: 0,
+  };
+}
+
+describe('schema review validation', () => {
+  describe('ordinal order', () => {
+    it('incomplete ordinal order fails closed', () => {
+      const fields = [fakeField('satisfaction', 'ordinal')];
+      const allValues = new Map([['satisfaction', ['Good', 'Fair', 'Poor']]]);
+
+      // Order only has 2 of 3 categories
+      const values = {
+        field_role_satisfaction: { role_select: { selected_option: { value: 'ordinal' } } },
+        field_order_satisfaction: { order_input: { value: 'Good | Fair' } }, // Missing "Poor"
+        field_demo_satisfaction: { demo_check: {} },
+      };
+
+      expect(() =>
+        parseSchemaReviewValues(values as any, fields, allValues)
+      ).toThrow(OrdinalOrderValidationError);
+    });
+
+    it('duplicate category in order fails', () => {
+      const fields = [fakeField('satisfaction', 'ordinal')];
+      const allValues = new Map([['satisfaction', ['Good', 'Fair', 'Poor']]]);
+
+      const values = {
+        field_role_satisfaction: { role_select: { selected_option: { value: 'ordinal' } } },
+        field_order_satisfaction: { order_input: { value: 'Good | Good | Fair | Poor' } },
+        field_demo_satisfaction: { demo_check: {} },
+      };
+
+      expect(() =>
+        parseSchemaReviewValues(values as any, fields, allValues)
+      ).toThrow(OrdinalOrderValidationError);
+    });
+
+    it('confirmed complete order succeeds', () => {
+      const fields = [fakeField('satisfaction', 'ordinal')];
+      const allValues = new Map([['satisfaction', ['Good', 'Fair', 'Poor']]]);
+
+      const values = {
+        field_role_satisfaction: { role_select: { selected_option: { value: 'ordinal' } } },
+        field_order_satisfaction: { order_input: { value: 'Poor | Fair | Good' } },
+        field_demo_satisfaction: { demo_check: {} },
+      };
+
+      const result = parseSchemaReviewValues(values as any, fields, allValues);
+      expect(result[0].orderMetadata).toEqual(['Poor', 'Fair', 'Good']);
+    });
+
+    it('ordinal without order input produces null orderMetadata (no median)', () => {
+      const fields = [fakeField('rating', 'ordinal')];
+      const allValues = new Map([['rating', ['1', '2', '3']]]);
+
+      const values = {
+        field_role_rating: { role_select: { selected_option: { value: 'ordinal' } } },
+        // No order input block at all
+        field_demo_rating: { demo_check: {} },
+      };
+
+      const result = parseSchemaReviewValues(values as any, fields, allValues);
+      expect(result[0].confirmedRole).toBe('ordinal');
+      expect(result[0].orderMetadata).toBeNull();
+    });
+  });
+
+  describe('field count limit', () => {
+    it('rejects >100 fields', () => {
+      const error = checkFieldCountSupported(101);
+      expect(error).not.toBeNull();
+      expect(error).toContain('101');
+      expect(error).toContain('100');
+    });
+
+    it('accepts <=100 fields', () => {
+      expect(checkFieldCountSupported(100)).toBeNull();
+      expect(checkFieldCountSupported(50)).toBeNull();
+      expect(checkFieldCountSupported(1)).toBeNull();
+    });
+  });
+
+  describe('pagination', () => {
+    it('computes correct page count', () => {
+      expect(getTotalPages(1)).toBe(1);
+      expect(getTotalPages(20)).toBe(1);
+      expect(getTotalPages(21)).toBe(2);
+      expect(getTotalPages(40)).toBe(2);
+      expect(getTotalPages(41)).toBe(3);
+      expect(getTotalPages(100)).toBe(5);
+    });
+  });
+});

--- a/backend/src/__tests__/unit/survey/statsEngine.test.ts
+++ b/backend/src/__tests__/unit/survey/statsEngine.test.ts
@@ -166,6 +166,30 @@ describe('statsEngine', () => {
     });
   });
 
+  describe('ordinal computation gate', () => {
+    it('appearance order does not become measurement order', () => {
+      // Even if values appear in a specific order in the CSV, no median
+      // without explicit confirmed order
+      const { survey, hash } = standardSurvey();
+      const fieldsAppearanceOnly = standardFields.map(f =>
+        f.fieldName === 'overall_satisfaction'
+          ? { ...f, orderMetadata: null } // inferred as ordinal but no confirmed order
+          : f
+      );
+      const facts = computeSurveyFacts(survey, fieldsAppearanceOnly, hash);
+      const stat = facts.fieldStats.find(f => f.fieldName === 'overall_satisfaction');
+      expect(stat!.median).toBeNull(); // NO median without confirmed order
+      expect(stat!.distribution).toBeDefined(); // distribution IS shown
+    });
+
+    it('confirmed order produces deterministic median', () => {
+      const { survey, hash } = standardSurvey();
+      const facts = computeSurveyFacts(survey, standardFields, hash);
+      const stat = facts.fieldStats.find(f => f.fieldName === 'overall_satisfaction');
+      expect(stat!.median).toBe('Satisfied');
+    });
+  });
+
   describe('determinism', () => {
     it('same CSV + same schema produces identical facts 3 times', () => {
       const { survey, hash } = standardSurvey();

--- a/backend/src/__tests__/unit/survey/statsEngine.test.ts
+++ b/backend/src/__tests__/unit/survey/statsEngine.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Statistics Engine unit tests.
+ *
+ * Covers: distributions, ordinal median (with and without order),
+ * continuous median, cross-tabs, nonresponse, determinism.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { parseCsvBuffer } from '../../../helpers/survey/csvParser';
+import { computeContentHash } from '../../../helpers/survey/sourceHash';
+import { computeSurveyFacts, extractOpenTextContent } from '../../../helpers/survey/statsEngine';
+import type { ConfirmedField } from '../../../types/survey';
+
+const FIXTURES = join(__dirname, '../../__fixtures__/survey');
+
+function standardSurvey() {
+  const csv = readFileSync(join(FIXTURES, 'standard.csv'));
+  return { survey: parseCsvBuffer(csv, 'standard.csv'), hash: computeContentHash(csv) };
+}
+
+const standardFields: ConfirmedField[] = [
+  { fieldName: 'response_id', confirmedRole: 'id', orderMetadata: null, isDemographic: false },
+  { fieldName: 'timestamp', confirmedRole: 'timestamp', orderMetadata: null, isDemographic: false },
+  {
+    fieldName: 'overall_satisfaction', confirmedRole: 'ordinal',
+    orderMetadata: ['Very Dissatisfied', 'Dissatisfied', 'Neutral', 'Satisfied', 'Very Satisfied'],
+    isDemographic: false,
+  },
+  {
+    fieldName: 'difficulty_rating', confirmedRole: 'ordinal',
+    orderMetadata: ['Very Difficult', 'Difficult', 'Moderate', 'Easy', 'Very Easy'],
+    isDemographic: false,
+  },
+  { fieldName: 'completion_status', confirmedRole: 'nominal', orderMetadata: null, isDemographic: false },
+  { fieldName: 'biggest_challenge', confirmedRole: 'open_text', orderMetadata: null, isDemographic: false },
+  { fieldName: 'additional_feedback', confirmedRole: 'open_text', orderMetadata: null, isDemographic: false },
+];
+
+describe('statsEngine', () => {
+  describe('computeSurveyFacts', () => {
+    it('computes correct total respondent count', () => {
+      const { survey, hash } = standardSurvey();
+      const facts = computeSurveyFacts(survey, standardFields, hash);
+      expect(facts.totalRespondents).toBe(10);
+    });
+
+    it('computes ordinal distribution', () => {
+      const { survey, hash } = standardSurvey();
+      const facts = computeSurveyFacts(survey, standardFields, hash);
+
+      const satStat = facts.fieldStats.find(f => f.fieldName === 'overall_satisfaction');
+      expect(satStat).toBeDefined();
+      expect(satStat!.distribution).toBeDefined();
+      expect(satStat!.distribution!['Satisfied']).toBe(4);
+      expect(satStat!.distribution!['Very Satisfied']).toBe(2);
+      expect(satStat!.distribution!['Dissatisfied']).toBe(2);
+    });
+
+    it('computes ordinal median with confirmed order', () => {
+      const { survey, hash } = standardSurvey();
+      const facts = computeSurveyFacts(survey, standardFields, hash);
+
+      const satStat = facts.fieldStats.find(f => f.fieldName === 'overall_satisfaction');
+      expect(satStat!.median).toBeDefined();
+      expect(satStat!.median).toBe('Satisfied');
+    });
+
+    it('does NOT compute ordinal median without order metadata', () => {
+      const { survey, hash } = standardSurvey();
+      const fieldsNoOrder = standardFields.map(f =>
+        f.fieldName === 'overall_satisfaction'
+          ? { ...f, orderMetadata: null }
+          : f
+      );
+      const facts = computeSurveyFacts(survey, fieldsNoOrder, hash);
+
+      const satStat = facts.fieldStats.find(f => f.fieldName === 'overall_satisfaction');
+      expect(satStat!.median).toBeNull();
+      // Distribution still computed
+      expect(satStat!.distribution).toBeDefined();
+    });
+
+    it('computes nominal distribution', () => {
+      const { survey, hash } = standardSurvey();
+      const facts = computeSurveyFacts(survey, standardFields, hash);
+
+      const statusStat = facts.fieldStats.find(f => f.fieldName === 'completion_status');
+      expect(statusStat).toBeDefined();
+      expect(statusStat!.distribution!['Complete']).toBe(7);
+      expect(statusStat!.distribution!['Incomplete']).toBe(2);
+      expect(statusStat!.distribution!['Partial']).toBe(1);
+    });
+
+    it('computes continuous median', () => {
+      const csv = 'id,score\n1,85\n2,92\n3,78\n4,95\n5,88';
+      const survey = parseCsvBuffer(csv, 'scores.csv');
+      const hash = computeContentHash(csv);
+      const fields: ConfirmedField[] = [
+        { fieldName: 'id', confirmedRole: 'id', orderMetadata: null, isDemographic: false },
+        { fieldName: 'score', confirmedRole: 'continuous', orderMetadata: null, isDemographic: false },
+      ];
+
+      const facts = computeSurveyFacts(survey, fields, hash);
+      const scoreStat = facts.fieldStats.find(f => f.fieldName === 'score');
+      expect(scoreStat!.median).toBe(88); // sorted: 78,85,88,92,95 → median = 88
+      expect(scoreStat!.nValidNumeric).toBe(5);
+      expect(scoreStat!.nInvalidNumeric).toBe(0);
+    });
+
+    it('counts missing values correctly', () => {
+      const csv = readFileSync(join(FIXTURES, 'missing-values.csv'));
+      const survey = parseCsvBuffer(csv, 'missing-values.csv');
+      const hash = computeContentHash(csv);
+
+      const fields: ConfirmedField[] = [
+        { fieldName: 'response_id', confirmedRole: 'id', orderMetadata: null, isDemographic: false },
+        { fieldName: 'overall_satisfaction', confirmedRole: 'ordinal', orderMetadata: null, isDemographic: false },
+        { fieldName: 'difficulty_rating', confirmedRole: 'ordinal', orderMetadata: null, isDemographic: false },
+        { fieldName: 'completion_status', confirmedRole: 'nominal', orderMetadata: null, isDemographic: false },
+        { fieldName: 'biggest_challenge', confirmedRole: 'open_text', orderMetadata: null, isDemographic: false },
+      ];
+
+      const facts = computeSurveyFacts(survey, fields, hash);
+      const satStat = facts.fieldStats.find(f => f.fieldName === 'overall_satisfaction');
+      expect(satStat!.nPresent).toBe(3);
+      expect(satStat!.nMissing).toBe(2);
+    });
+
+    it('includes nonresponse limitation note', () => {
+      const { survey, hash } = standardSurvey();
+      const facts = computeSurveyFacts(survey, standardFields, hash);
+      expect(facts.nonresponseLimitation).toContain('cannot distinguish semantic missingness');
+    });
+
+    it('skips id and timestamp fields in statistics', () => {
+      const { survey, hash } = standardSurvey();
+      const facts = computeSurveyFacts(survey, standardFields, hash);
+
+      expect(facts.fieldStats.find(f => f.fieldName === 'response_id')).toBeUndefined();
+      expect(facts.fieldStats.find(f => f.fieldName === 'timestamp')).toBeUndefined();
+    });
+  });
+
+  describe('cross-tabs', () => {
+    it('computes completion × difficulty cross-tab', () => {
+      const { survey, hash } = standardSurvey();
+      const facts = computeSurveyFacts(survey, standardFields, hash);
+
+      const ct = facts.crossTabs.find(
+        c => c.rowField === 'completion_status' && c.colField === 'difficulty_rating'
+      );
+      expect(ct).toBeDefined();
+      expect(ct!.cells['Complete']['Easy']).toBe(3);
+      expect(ct!.totalN).toBeGreaterThan(0);
+    });
+
+    it('computes completion × satisfaction cross-tab', () => {
+      const { survey, hash } = standardSurvey();
+      const facts = computeSurveyFacts(survey, standardFields, hash);
+
+      const ct = facts.crossTabs.find(
+        c => c.rowField === 'completion_status' && c.colField === 'overall_satisfaction'
+      );
+      expect(ct).toBeDefined();
+    });
+  });
+
+  describe('determinism', () => {
+    it('same CSV + same schema produces identical facts 3 times', () => {
+      const { survey, hash } = standardSurvey();
+
+      const run1 = computeSurveyFacts(survey, standardFields, hash);
+      const run2 = computeSurveyFacts(survey, standardFields, hash);
+      const run3 = computeSurveyFacts(survey, standardFields, hash);
+
+      expect(run1).toEqual(run2);
+      expect(run2).toEqual(run3);
+    });
+  });
+
+  describe('extractOpenTextContent', () => {
+    it('extracts open-text field content with respondent labels', () => {
+      const { survey } = standardSurvey();
+      const labels = survey.rows.map((_, i) => `R${String(i + 1).padStart(3, '0')}`);
+      const openTextFields = standardFields.filter(f => f.confirmedRole === 'open_text');
+
+      const content = extractOpenTextContent(survey, openTextFields, labels);
+      expect(content).toContain('R001');
+      expect(content).toContain('biggest_challenge');
+      expect(content).toContain('Finding the right form');
+    });
+
+    it('returns message when no open-text fields', () => {
+      const { survey } = standardSurvey();
+      const labels = survey.rows.map((_, i) => `R${String(i + 1).padStart(3, '0')}`);
+
+      const content = extractOpenTextContent(survey, [], labels);
+      expect(content).toContain('No open-text fields');
+    });
+  });
+});

--- a/backend/src/database/index.ts
+++ b/backend/src/database/index.ts
@@ -20,6 +20,7 @@ import DispositionAuditLog from './models/disposition_audit_log';
 import EvidenceSource from './models/evidence_source';
 import EvidenceConstruct from './models/evidence_construct';
 import EvidenceRelationship from './models/evidence_relationship';
+import SurveyFieldSchema from './models/survey_field_schema';
 
 
 // Set environment and configuration
@@ -50,6 +51,7 @@ const modelDefiners = [
   EvidenceSource,
   EvidenceConstruct,
   EvidenceRelationship,
+  SurveyFieldSchema,
 ];
 
 // Register all models with Sequelize

--- a/backend/src/database/migrations/20260816100000-create-survey-field-schemas.js
+++ b/backend/src/database/migrations/20260816100000-create-survey-field-schemas.js
@@ -85,15 +85,6 @@ module.exports = {
         allowNull: true,
       },
 
-      // Staged CSV content — quarantine pattern per study_notes.pending_content.
-      // Stored on the first field row for a given evidence_source_id.
-      // Cleared to NULL on schema confirmation.
-      pending_csv_content: {
-        type: Sequelize.TEXT,
-        allowNull: true,
-        comment: 'Staged raw CSV text; cleared on confirmation. Only set on first field row per source.',
-      },
-
       created_at: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/backend/src/database/migrations/20260816100000-create-survey-field-schemas.js
+++ b/backend/src/database/migrations/20260816100000-create-survey-field-schemas.js
@@ -1,0 +1,130 @@
+'use strict';
+
+/**
+ * Migration: Create survey_field_schemas table
+ *
+ * Per Survey Vertical Slice 1: stores researcher-reviewed field role
+ * assignments for CSV survey data. One row per field per evidence source.
+ *
+ * pending_csv_content follows the study_notes.pending_content quarantine
+ * pattern: holds staged CSV text between upload and schema confirmation,
+ * then cleared to NULL. Only stored on the first field row for a given
+ * evidence_source_id.
+ *
+ * FK: evidence_source_id → evidence_sources (CASCADE)
+ */
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('survey_field_schemas', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+
+      evidence_source_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'evidence_sources', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+
+      field_name: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+
+      inferred_role: {
+        type: Sequelize.STRING(20),
+        allowNull: false,
+        comment: 'id | nominal | ordinal | continuous | multi_select | open_text | timestamp',
+      },
+
+      confirmed_role: {
+        type: Sequelize.STRING(20),
+        allowNull: true,
+        comment: 'Set after researcher review; NULL while pending',
+      },
+
+      order_metadata: {
+        type: Sequelize.JSONB,
+        allowNull: true,
+        comment: 'For ordinal: confirmed category order array. For multi_select: option list.',
+      },
+
+      is_demographic: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+        comment: 'Whether this field represents demographic information',
+      },
+
+      inference_source: {
+        type: Sequelize.STRING(20),
+        allowNull: false,
+        defaultValue: 'heuristic',
+        comment: 'heuristic | declared',
+      },
+
+      review_status: {
+        type: Sequelize.STRING(20),
+        allowNull: false,
+        defaultValue: 'pending',
+        comment: 'pending | confirmed | expired',
+      },
+
+      reviewed_by: {
+        type: Sequelize.STRING(50),
+        allowNull: true,
+        comment: 'Slack user ID of reviewer',
+      },
+
+      reviewed_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+
+      // Staged CSV content — quarantine pattern per study_notes.pending_content.
+      // Stored on the first field row for a given evidence_source_id.
+      // Cleared to NULL on schema confirmation.
+      pending_csv_content: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+        comment: 'Staged raw CSV text; cleared on confirmation. Only set on first field row per source.',
+      },
+
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+
+    await queryInterface.addConstraint('survey_field_schemas', {
+      fields: ['evidence_source_id', 'field_name'],
+      type: 'unique',
+      name: 'uq_survey_field_schemas_source_field',
+    });
+
+    await queryInterface.addIndex('survey_field_schemas', ['evidence_source_id'], {
+      name: 'idx_survey_field_schemas_source',
+    });
+
+    await queryInterface.addIndex('survey_field_schemas', ['review_status'], {
+      name: 'idx_survey_field_schemas_status',
+    });
+
+    console.log('Created survey_field_schemas table with indexes');
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('survey_field_schemas');
+    console.log('Dropped survey_field_schemas table');
+  },
+};

--- a/backend/src/database/models/evidence_construct.ts
+++ b/backend/src/database/models/evidence_construct.ts
@@ -33,6 +33,9 @@ export type ConstructType =
   | 'stakeholder_constraint'
   | 'nugget'
   | 'survey_pattern'
+  | 'survey_dataset_summary'
+  | 'field_distribution'
+  | 'cross_tab'
   | 'usability_finding'
   | 'journey_stage'
   | 'recommendation'
@@ -119,6 +122,7 @@ export default (sequelize: Sequelize) => {
           isIn: [[
             'knowledge_gap', 'barrier', 'research_question',
             'stakeholder_constraint', 'nugget', 'survey_pattern',
+            'survey_dataset_summary', 'field_distribution', 'cross_tab',
             'usability_finding', 'journey_stage', 'recommendation',
             'finding', 'theme', 'persona', 'ticket_candidate',
           ]],

--- a/backend/src/database/models/survey_field_schema.ts
+++ b/backend/src/database/models/survey_field_schema.ts
@@ -1,0 +1,128 @@
+/**
+ * SurveyFieldSchema Model
+ *
+ * Per Survey Slice 1: stores researcher-reviewed field role assignments
+ * for CSV survey data. One row per field per evidence source.
+ *
+ * pending_csv_content follows the study_notes.pending_content quarantine
+ * pattern for staging CSV data between upload and schema confirmation.
+ */
+
+import {
+  DataTypes,
+  Model,
+  type InferAttributes,
+  type InferCreationAttributes,
+  type CreationOptional,
+  type Sequelize,
+} from 'sequelize';
+import type { SurveyFieldRole } from '../../types/survey';
+
+export type SchemaReviewStatus = 'pending' | 'confirmed' | 'expired';
+
+class SurveyFieldSchema extends Model<
+  InferAttributes<SurveyFieldSchema>,
+  InferCreationAttributes<SurveyFieldSchema>
+> {
+  declare id: CreationOptional<number>;
+  declare evidence_source_id: number;
+  declare field_name: string;
+  declare inferred_role: SurveyFieldRole;
+  declare confirmed_role: SurveyFieldRole | null;
+  declare order_metadata: string[] | null;
+  declare is_demographic: CreationOptional<boolean>;
+  declare inference_source: CreationOptional<string>;
+  declare review_status: CreationOptional<SchemaReviewStatus>;
+  declare reviewed_by: string | null;
+  declare reviewed_at: Date | null;
+  declare pending_csv_content: string | null;
+  declare created_at: CreationOptional<Date>;
+  declare updated_at: CreationOptional<Date>;
+
+  static associate(models: Record<string, any>) {
+    this.belongsTo(models.EvidenceSource, {
+      foreignKey: 'evidence_source_id',
+      as: 'evidenceSource',
+      onDelete: 'CASCADE',
+    });
+  }
+}
+
+export default (sequelize: Sequelize) => {
+  SurveyFieldSchema.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      evidence_source_id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      field_name: {
+        type: DataTypes.STRING(255),
+        allowNull: false,
+      },
+      inferred_role: {
+        type: DataTypes.STRING(20),
+        allowNull: false,
+      },
+      confirmed_role: {
+        type: DataTypes.STRING(20),
+        allowNull: true,
+      },
+      order_metadata: {
+        type: DataTypes.JSONB,
+        allowNull: true,
+      },
+      is_demographic: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+      inference_source: {
+        type: DataTypes.STRING(20),
+        allowNull: false,
+        defaultValue: 'heuristic',
+      },
+      review_status: {
+        type: DataTypes.STRING(20),
+        allowNull: false,
+        defaultValue: 'pending',
+      },
+      reviewed_by: {
+        type: DataTypes.STRING(50),
+        allowNull: true,
+      },
+      reviewed_at: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+      pending_csv_content: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    },
+    {
+      tableName: 'survey_field_schemas',
+      underscored: true,
+      timestamps: false,
+      sequelize,
+    },
+  );
+
+  return SurveyFieldSchema;
+};
+
+export type { SurveyFieldSchema };

--- a/backend/src/database/models/survey_field_schema.ts
+++ b/backend/src/database/models/survey_field_schema.ts
@@ -4,8 +4,7 @@
  * Per Survey Slice 1: stores researcher-reviewed field role assignments
  * for CSV survey data. One row per field per evidence source.
  *
- * pending_csv_content follows the study_notes.pending_content quarantine
- * pattern for staging CSV data between upload and schema confirmation.
+ * Raw CSV staging uses Redis with TTL (pendingCsvStore.ts), not this table.
  */
 
 import {
@@ -35,7 +34,6 @@ class SurveyFieldSchema extends Model<
   declare review_status: CreationOptional<SchemaReviewStatus>;
   declare reviewed_by: string | null;
   declare reviewed_at: Date | null;
-  declare pending_csv_content: string | null;
   declare created_at: CreationOptional<Date>;
   declare updated_at: CreationOptional<Date>;
 
@@ -97,10 +95,6 @@ export default (sequelize: Sequelize) => {
       },
       reviewed_at: {
         type: DataTypes.DATE,
-        allowNull: true,
-      },
-      pending_csv_content: {
-        type: DataTypes.TEXT,
         allowNull: true,
       },
       created_at: {

--- a/backend/src/helpers/slack/commands/discoverHandler.ts
+++ b/backend/src/helpers/slack/commands/discoverHandler.ts
@@ -25,6 +25,7 @@ import { parseDocuments, validateDocuments } from '../../documentParser';
 import { getProjectByChannelId, getProjectById } from '../../../services/project.service';
 import type { VariableContext } from '../../studyVariables';
 import { postEphemeralOrDM } from '../slackHelpers';
+import { handleSurveyUploadPhase } from './surveySubmissionHandler';
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -129,7 +130,7 @@ const DISCOVERY_TYPES: Record<DiscoveryTypeKey, DiscoveryTypeConfig> = {
     yaml: 'survey_synthesis.yaml',
     type: 'survey-synthesis',
     fileSlug: 'survey-synthesis',
-    filetypes: ['csv', 'xlsx', 'xls'],
+    filetypes: ['csv'],
     label: 'Survey synthesis',
   },
 };
@@ -401,6 +402,31 @@ async function handleDiscoverSubmission({ ack, view, body, client }: SlackViewMi
 
   const typeConfig = DISCOVERY_TYPES[discoveryType as DiscoveryTypeKey];
   let topicSlug = slugifyTopic(topic);
+
+  // Survey path forks to structured ingestion handler (Survey Slice 1)
+  if (discoveryType === 'survey_synthesis') {
+    await handleSurveyUploadPhase(
+      {
+        userId,
+        projectId: projectId!,
+        projectSlug: projectSlug!,
+        channelId: channelId || userId,
+        topic: topic!,
+        topicSlug,
+        surveyName: surveyName || topic!,
+        questionFocus: questionFocus || '',
+        sourceIntent: description || topic!,
+        uploadedFiles: uploadedFiles.map(f => ({
+          id: f.id,
+          name: f.name,
+          mimetype: f.mimetype,
+          url: f.url,
+        })),
+      },
+      client,
+    );
+    return;
+  }
 
   // Duplicate handling — use project slug for folder path (Phase 2D)
   const dateIso: string = format(new Date(), 'yyyy-MM-dd');

--- a/backend/src/helpers/slack/commands/surveySubmissionHandler.ts
+++ b/backend/src/helpers/slack/commands/surveySubmissionHandler.ts
@@ -161,8 +161,16 @@ export async function handleSurveyUploadPhase(
     const confirmedSchemas = await SurveyFieldSchemaModel.findAll({
       where: { evidence_source_id: existingSource.id, review_status: 'confirmed' },
     });
+    const pendingCount = await SurveyFieldSchemaModel.count({
+      where: { evidence_source_id: existingSource.id, review_status: 'pending' },
+    });
 
-    if (confirmedSchemas.length > 0) {
+    // Reuse ONLY when schema is complete: all fields confirmed, none pending
+    const isCompleteAccepted = confirmedSchemas.length > 0
+      && pendingCount === 0
+      && confirmedSchemas.length === survey.headers.length;
+
+    if (isCompleteAccepted) {
       await client.chat.postMessage({
         channel: userId,
         text: '✅ Same survey file detected (content hash match). Reusing accepted schema and recomputing statistics...',

--- a/backend/src/helpers/slack/commands/surveySubmissionHandler.ts
+++ b/backend/src/helpers/slack/commands/surveySubmissionHandler.ts
@@ -1,0 +1,642 @@
+/**
+ * Survey Submission Handler — two-phase survey ingestion.
+ *
+ * Phase 1 (handleSurveyUploadPhase):
+ *   CSV upload → parse → infer schema → create evidence_source →
+ *   store pending_csv_content → send DM with "Review Schema" button
+ *
+ * Phase 2 (handleSurveySchemaConfirmation):
+ *   Schema review modal submission → read confirmed fields →
+ *   read pending_csv_content → compute deterministic stats →
+ *   create evidence constructs + lineage → inject computed facts
+ *   into template → render → clear pending_csv_content
+ *
+ * Per ADR 0028: all statistics computed in code, never by LLM.
+ * Per ADR 0029: evidence entities created for canonical state.
+ */
+
+import type {
+  SlackActionMiddlewareArgs,
+  BlockAction,
+  ButtonAction,
+  SlackViewMiddlewareArgs,
+  ViewSubmitAction,
+  AllMiddlewareArgs,
+} from '@slack/bolt';
+import type { CreationAttributes } from 'sequelize';
+import sequelize from '../../../database';
+import type { EvidenceSource } from '../../../database/models/evidence_source';
+import type { SurveyFieldSchema } from '../../../database/models/survey_field_schema';
+import type { ConfirmedField, SurveyField } from '../../../types/survey';
+import {
+  parseCsvBuffer,
+  CsvParseError,
+  computeContentHash,
+  inferFieldSchema,
+  computeSurveyFacts,
+  extractOpenTextContent,
+  assignRespondentIdentities,
+  getUniqueValues,
+} from '../../survey';
+import {
+  buildSchemaReviewModal,
+  parseSchemaReviewValues,
+  type SchemaReviewMeta,
+} from '../ui/surveySchemaReviewModal';
+import { processSlackFile } from '../../pdfProcessor';
+import { createSourceToConstruct } from '../../../services/evidence.service';
+import { fetchFileFromRepo, getConfigRepo, YAML_TEMPLATE_PATH } from '../../github';
+import { processYamlTemplate } from '../../yamlProcessor';
+import { getProjectById } from '../../../services/project.service';
+import { format } from 'date-fns';
+
+// Models
+const EvidenceSourceModel = sequelize.models.EvidenceSource as typeof EvidenceSource;
+const EvidenceConstructModel = sequelize.models.EvidenceConstruct;
+const SurveyFieldSchemaModel = sequelize.models.SurveyFieldSchema as typeof SurveyFieldSchema;
+
+// ═══════════════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════════════
+
+interface SurveyUploadContext {
+  userId: string;
+  projectId: number;
+  projectSlug: string;
+  channelId: string;
+  topic: string;
+  topicSlug: string;
+  surveyName: string;
+  questionFocus: string;
+  sourceIntent: string;
+  uploadedFiles: Array<{ id: string; name: string; mimetype: string; url: string }>;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// PHASE 1: Upload → Parse → Infer → DM with Review Button
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * Called from discoverHandler when discoveryType is 'survey_synthesis'.
+ * Downloads CSV, parses, infers schema, creates evidence_source,
+ * stores pending CSV content, sends DM with schema review button.
+ */
+export async function handleSurveyUploadPhase(
+  ctx: SurveyUploadContext,
+  client: AllMiddlewareArgs['client'],
+): Promise<void> {
+  const { userId, projectId, projectSlug, channelId, topic, topicSlug, surveyName, questionFocus, sourceIntent, uploadedFiles } = ctx;
+
+  // Download first CSV file
+  const csvFile = uploadedFiles.find(f => f.name.toLowerCase().endsWith('.csv'));
+  if (!csvFile) {
+    await client.chat.postMessage({
+      channel: userId,
+      text: '❌ No CSV file found in upload. Please upload a .csv file.',
+    });
+    return;
+  }
+
+  await client.chat.postMessage({
+    channel: userId,
+    text: `Parsing survey CSV "${csvFile.name}"...`,
+  });
+
+  let rawContent: string;
+  try {
+    rawContent = await processSlackFile(csvFile.url, process.env.SLACK_BOT_TOKEN!, 'text/csv');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await client.chat.postMessage({
+      channel: userId,
+      text: `❌ Failed to download survey file: ${message}`,
+    });
+    return;
+  }
+
+  // Parse CSV
+  let survey;
+  try {
+    survey = parseCsvBuffer(rawContent, csvFile.name);
+  } catch (err) {
+    if (err instanceof CsvParseError) {
+      await client.chat.postMessage({
+        channel: userId,
+        text: `❌ CSV parse error: ${err.message}`,
+      });
+      return;
+    }
+    throw err;
+  }
+
+  const contentHash = computeContentHash(rawContent);
+
+  // Check for existing source with same content hash in this project
+  const existingSource = await EvidenceSourceModel.findOne({
+    where: {
+      project_id: projectId,
+      source_type: 'survey_dataset',
+    },
+  });
+
+  let existingHash: string | null = null;
+  if (existingSource) {
+    const ref = existingSource.artifact_ref as Record<string, unknown> | null;
+    existingHash = ref?.content_hash as string | null;
+  }
+
+  // Reuse existing source + schema if same content
+  if (existingSource && existingHash === contentHash) {
+    const confirmedSchemas = await SurveyFieldSchemaModel.findAll({
+      where: {
+        evidence_source_id: existingSource.id,
+        review_status: 'confirmed',
+      },
+    });
+
+    if (confirmedSchemas.length > 0) {
+      await client.chat.postMessage({
+        channel: userId,
+        text: `✅ Same survey file detected (content hash match). Reusing accepted schema and recomputing statistics...`,
+      });
+
+      // Skip to Phase 2 directly — reuse confirmed schema
+      const confirmedFields: ConfirmedField[] = confirmedSchemas.map((s: SurveyFieldSchema) => ({
+        fieldName: s.field_name,
+        confirmedRole: s.confirmed_role!,
+        orderMetadata: s.order_metadata,
+        isDemographic: s.is_demographic,
+      }));
+
+      await executeSurveyAnalysis(
+        survey, confirmedFields, contentHash, existingSource.id,
+        { userId, projectId, projectSlug, channelId, topic, topicSlug, surveyName, questionFocus, sourceIntent },
+        client,
+      );
+      return;
+    }
+  }
+
+  // Create evidence_source
+  const evidenceSource = await EvidenceSourceModel.create({
+    project_id: projectId,
+    study_id: null, // Discovery is project-scoped
+    source_type: 'survey_dataset',
+    label: `${surveyName} — ${csvFile.name}`,
+    artifact_ref: {
+      filename: csvFile.name,
+      content_hash: contentHash,
+      slack_file_id: csvFile.id,
+    },
+    metadata: {
+      row_count: survey.rowCount,
+      column_count: survey.headers.length,
+      headers: survey.headers,
+      parse_warnings: survey.parseWarnings,
+    },
+    created_by: userId,
+  } as CreationAttributes<EvidenceSource>);
+
+  // Infer field schema
+  const inferredFields = inferFieldSchema(survey);
+
+  // Persist inferred fields + pending CSV content
+  await sequelize.transaction(async (t) => {
+    for (let i = 0; i < inferredFields.length; i++) {
+      const field = inferredFields[i];
+      await SurveyFieldSchemaModel.create({
+        evidence_source_id: evidenceSource.id,
+        field_name: field.fieldName,
+        inferred_role: field.inferredRole,
+        inference_source: 'heuristic',
+        review_status: 'pending',
+        // Store pending CSV on first field row only
+        pending_csv_content: i === 0 ? rawContent : null,
+      } as CreationAttributes<SurveyFieldSchema>, { transaction: t });
+    }
+  });
+
+  // Build schema summary for DM
+  const summaryLines = inferredFields.map(f =>
+    `• *${f.fieldName}* → ${f.inferredRole} (${f.presentCount}/${survey.rowCount} present)`
+  );
+
+  const meta: SchemaReviewMeta = {
+    evidenceSourceId: evidenceSource.id,
+    projectId, projectSlug, channelId,
+    topic, topicSlug, surveyName, questionFocus, sourceIntent,
+  };
+
+  // Send DM with schema review button
+  await client.chat.postMessage({
+    channel: userId,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `📊 *Survey parsed:* ${survey.rowCount} respondents, ${survey.headers.length} fields\n\n*Inferred field roles:*\n${summaryLines.join('\n')}`,
+        },
+      },
+      { type: 'divider' },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: 'Review and confirm field roles before analysis proceeds. Ordinal fields need category order confirmation.',
+        },
+        accessory: {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Review & Confirm Schema' },
+          style: 'primary',
+          action_id: 'survey_review_schema',
+          value: JSON.stringify(meta),
+        },
+      },
+    ],
+    text: `Survey parsed: ${survey.rowCount} respondents, ${survey.headers.length} fields. Click "Review & Confirm Schema" to proceed.`,
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// SCHEMA REVIEW BUTTON → Open Modal
+// ═══════════════════════════════════════════════════════════════════════
+
+export async function handleSurveySchemaReviewAction(
+  args: SlackActionMiddlewareArgs<BlockAction<ButtonAction>> & AllMiddlewareArgs,
+): Promise<void> {
+  const { ack, action, client, body } = args;
+  await ack();
+
+  const meta: SchemaReviewMeta = JSON.parse(action.value || '{}');
+
+  // Load inferred fields from DB
+  const fieldSchemas = await SurveyFieldSchemaModel.findAll({
+    where: { evidence_source_id: meta.evidenceSourceId },
+    order: [['id', 'ASC']],
+  });
+
+  if (fieldSchemas.length === 0) {
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: '❌ Survey schema not found. The upload may have expired. Please re-upload via `/qori-discover`.',
+    });
+    return;
+  }
+
+  // Convert to SurveyField shape for modal builder
+  const fields: SurveyField[] = fieldSchemas.map((s: SurveyFieldSchema) => ({
+    fieldName: s.field_name,
+    inferredRole: s.inferred_role,
+    sampleValues: [], // Samples not stored — role and counts sufficient for review
+    distinctCount: 0,
+    presentCount: 0,
+    missingCount: 0,
+  }));
+
+  const modal = buildSchemaReviewModal(fields, meta);
+
+  await client.views.open({
+    trigger_id: body.trigger_id,
+    view: modal as unknown as import('@slack/types').View,
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// PHASE 2: Schema Confirmation → Compute → Evidence → Render
+// ═══════════════════════════════════════════════════════════════════════
+
+export async function handleSurveySchemaConfirmation(
+  args: SlackViewMiddlewareArgs<ViewSubmitAction> & AllMiddlewareArgs,
+): Promise<void> {
+  const { ack, view, body, client } = args;
+  await ack();
+
+  const meta: SchemaReviewMeta = JSON.parse(view.private_metadata || '{}');
+  const userId = body.user.id;
+
+  // Load existing field schemas
+  const fieldSchemas = await SurveyFieldSchemaModel.findAll({
+    where: { evidence_source_id: meta.evidenceSourceId },
+    order: [['id', 'ASC']],
+  });
+
+  if (fieldSchemas.length === 0) {
+    await client.chat.postMessage({
+      channel: userId,
+      text: '❌ Survey schema expired. Please re-upload via `/qori-discover`.',
+    });
+    return;
+  }
+
+  // Build original fields for parsing
+  const originalFields: SurveyField[] = fieldSchemas.map((s: SurveyFieldSchema) => ({
+    fieldName: s.field_name,
+    inferredRole: s.inferred_role,
+    sampleValues: [],
+    distinctCount: 0,
+    presentCount: 0,
+    missingCount: 0,
+  }));
+
+  // Parse confirmed roles from modal
+  const confirmedRoles = parseSchemaReviewValues(
+    view.state.values as unknown as Record<string, Record<string, Record<string, unknown>>>,
+    originalFields,
+  );
+
+  // Read pending CSV content from first field row
+  const firstField = fieldSchemas[0] as SurveyFieldSchema;
+  const pendingCsv = firstField.pending_csv_content;
+
+  if (!pendingCsv) {
+    await client.chat.postMessage({
+      channel: userId,
+      text: '❌ Survey data expired. Please re-upload via `/qori-discover`.',
+    });
+    return;
+  }
+
+  // Re-parse CSV from staged content
+  let survey;
+  try {
+    survey = parseCsvBuffer(pendingCsv, 'staged-csv');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await client.chat.postMessage({
+      channel: userId,
+      text: `❌ Error re-parsing staged CSV: ${message}`,
+    });
+    return;
+  }
+
+  const contentHash = computeContentHash(pendingCsv);
+
+  // For ordinal fields, detect unique values for order metadata
+  const confirmedFields: ConfirmedField[] = confirmedRoles.map(r => {
+    let orderMetadata: string[] | null = null;
+    if (r.confirmedRole === 'ordinal') {
+      // Auto-detect category order from unique values (researcher can adjust in future)
+      orderMetadata = getUniqueValues(survey, r.fieldName);
+    }
+    return {
+      fieldName: r.fieldName,
+      confirmedRole: r.confirmedRole,
+      orderMetadata,
+      isDemographic: r.isDemographic,
+    };
+  });
+
+  // Update field schemas in DB
+  await sequelize.transaction(async (t) => {
+    for (const field of confirmedFields) {
+      await SurveyFieldSchemaModel.update(
+        {
+          confirmed_role: field.confirmedRole,
+          order_metadata: field.orderMetadata,
+          is_demographic: field.isDemographic,
+          review_status: 'confirmed',
+          reviewed_by: userId,
+          reviewed_at: new Date(),
+          pending_csv_content: null, // Clear staged data
+        },
+        {
+          where: {
+            evidence_source_id: meta.evidenceSourceId,
+            field_name: field.fieldName,
+          },
+          transaction: t,
+        },
+      );
+    }
+    // Clear pending_csv_content from first row explicitly
+    await SurveyFieldSchemaModel.update(
+      { pending_csv_content: null },
+      { where: { evidence_source_id: meta.evidenceSourceId }, transaction: t },
+    );
+  });
+
+  await client.chat.postMessage({
+    channel: userId,
+    text: 'Schema confirmed. Computing survey statistics...',
+  });
+
+  await executeSurveyAnalysis(
+    survey, confirmedFields, contentHash, meta.evidenceSourceId,
+    { userId, projectId: meta.projectId, projectSlug: meta.projectSlug, channelId: meta.channelId, topic: meta.topic, topicSlug: meta.topicSlug, surveyName: meta.surveyName, questionFocus: meta.questionFocus, sourceIntent: meta.sourceIntent },
+    client,
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// SHARED: Compute → Evidence → Template Render
+// ═══════════════════════════════════════════════════════════════════════
+
+async function executeSurveyAnalysis(
+  survey: ReturnType<typeof parseCsvBuffer>,
+  confirmedFields: ConfirmedField[],
+  contentHash: string,
+  evidenceSourceId: number,
+  ctx: {
+    userId: string;
+    projectId: number;
+    projectSlug: string;
+    channelId: string;
+    topic: string;
+    topicSlug: string;
+    surveyName: string;
+    questionFocus: string;
+    sourceIntent: string;
+  },
+  client: AllMiddlewareArgs['client'],
+): Promise<void> {
+  try {
+    // Compute deterministic facts (ADR 0028)
+    const computedFacts = computeSurveyFacts(survey, confirmedFields, contentHash);
+
+    // Assign respondent identities
+    const identities = assignRespondentIdentities(survey, confirmedFields, contentHash);
+    const displayLabels = identities.map(id => id.displayLabel);
+
+    // Extract open-text content for LLM interpretation
+    const openTextContent = extractOpenTextContent(survey, confirmedFields, displayLabels);
+
+    // Create evidence constructs (deterministic, auto-accepted)
+    await sequelize.transaction(async (t) => {
+      // Survey dataset summary construct
+      const summaryConstruct = await EvidenceConstructModel.create({
+        project_id: ctx.projectId,
+        study_id: null,
+        construct_type: 'survey_dataset_summary',
+        label: `${ctx.surveyName} — ${computedFacts.totalRespondents} respondents`,
+        payload: {
+          total_respondents: computedFacts.totalRespondents,
+          schema_summary: computedFacts.schemaSummary,
+          nonresponse_limitation: computedFacts.nonresponseLimitation,
+          source_content_hash: contentHash,
+        },
+        derivation_type: 'deterministic',
+        derivation_context: { method: 'survey_structured_ingestion', version: '1.0' },
+        status: 'accepted',
+        created_by: ctx.userId,
+      }, { transaction: t });
+
+      await createSourceToConstruct({
+        from_source_id: evidenceSourceId,
+        to_construct_id: (summaryConstruct as unknown as { id: number }).id,
+        relationship_type: 'DERIVED_FROM',
+        provenance: { method: 'survey_structured_ingestion' },
+      }, t);
+
+      // Field distribution constructs
+      for (const stat of computedFacts.fieldStats) {
+        if (!stat.distribution && stat.nValidNumeric === null) continue;
+
+        const distConstruct = await EvidenceConstructModel.create({
+          project_id: ctx.projectId,
+          study_id: null,
+          construct_type: 'field_distribution',
+          label: `${stat.fieldName} distribution`,
+          payload: stat,
+          derivation_type: 'deterministic',
+          derivation_context: { method: 'survey_structured_ingestion', version: '1.0' },
+          status: 'accepted',
+          created_by: ctx.userId,
+        }, { transaction: t });
+
+        await createSourceToConstruct({
+          from_source_id: evidenceSourceId,
+          to_construct_id: (distConstruct as unknown as { id: number }).id,
+          relationship_type: 'DERIVED_FROM',
+        }, t);
+      }
+
+      // Cross-tab constructs
+      for (const ct of computedFacts.crossTabs) {
+        const ctConstruct = await EvidenceConstructModel.create({
+          project_id: ctx.projectId,
+          study_id: null,
+          construct_type: 'cross_tab',
+          label: `${ct.rowField} × ${ct.colField}`,
+          payload: ct,
+          derivation_type: 'deterministic',
+          derivation_context: { method: 'survey_structured_ingestion', version: '1.0' },
+          status: 'accepted',
+          created_by: ctx.userId,
+        }, { transaction: t });
+
+        await createSourceToConstruct({
+          from_source_id: evidenceSourceId,
+          to_construct_id: (ctConstruct as unknown as { id: number }).id,
+          relationship_type: 'DERIVED_FROM',
+        }, t);
+      }
+    });
+
+    // Proceed with template rendering via existing discover flow
+    const project = await getProjectById(ctx.projectId);
+    const projectProblemStatement = project?.problem_statement || null;
+
+    const dateIso = format(new Date(), 'yyyy-MM-dd');
+
+    // Build template input with computed facts
+    const data: Record<string, unknown> = {
+      topic: ctx.topic,
+      effective_topic: ctx.topic,
+      topic_slug: ctx.topicSlug,
+      project_slug: ctx.projectSlug,
+      project_problem_statement: projectProblemStatement,
+      source_intent: ctx.sourceIntent,
+      description: ctx.sourceIntent || ctx.topic,
+      survey_name: ctx.surveyName,
+      question_focus: ctx.questionFocus || '',
+      selected_study: `discovery-${ctx.topicSlug}`,
+      study_name: ctx.topic,
+      document_count: 1,
+      document_names: [survey.sourceFilename],
+      document_types: ['CSV'],
+      _discovery_type: 'survey-synthesis',
+      // Computed facts — deterministic, code-computed (ADR 0028)
+      computed_facts: computedFacts,
+      // Open-text content for LLM qualitative interpretation
+      open_text_content: openTextContent,
+      // Keep combined_file_content for backward compat with template
+      combined_file_content: openTextContent,
+    };
+
+    const file = await fetchFileFromRepo(getConfigRepo(), YAML_TEMPLATE_PATH, 'survey_synthesis.yaml');
+
+    const variableContext = { projectId: ctx.projectId };
+
+    const renderedYaml = await processYamlTemplate(
+      file.content,
+      data,
+      '',
+      '',
+      false,
+      variableContext,
+    );
+
+    // Await extraction (ADR 0019)
+    if (renderedYaml.extractionPromise) {
+      const extractResult = await renderedYaml.extractionPromise;
+      if (!extractResult.success) {
+        throw new Error(`Cascade variable extraction failed: ${extractResult.error}`);
+      }
+      console.log(`✅ Survey cascade variables committed: ${extractResult.variableCount} items (${extractResult.keys?.join(', ')})`);
+    }
+
+    const url = renderedYaml.result.url;
+
+    await client.chat.postMessage({
+      channel: ctx.userId,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `✅ *Survey synthesis complete*\n\n*Survey:* ${ctx.surveyName}\n*Respondents:* ${computedFacts.totalRespondents}\n*Fields analyzed:* ${computedFacts.fieldStats.length}\n*Cross-tabs:* ${computedFacts.crossTabs.length}`,
+          },
+        },
+        {
+          type: 'actions',
+          elements: [
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: 'View on GitHub' },
+              style: 'primary',
+              url,
+              action_id: 'view_discovery_result',
+            },
+          ],
+        },
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: `Evidence entities created: 1 source, ${computedFacts.fieldStats.length + computedFacts.crossTabs.length + 1} constructs with lineage`,
+            },
+          ],
+        },
+        { type: 'divider' },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*Next:* Run `/qori-brief` to start your study — all discovery feeds in automatically.',
+          },
+        },
+      ],
+      text: `Survey synthesis complete for "${ctx.surveyName}". View: ${url}`,
+    });
+
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Error in survey analysis:', error);
+    await client.chat.postMessage({
+      channel: ctx.userId,
+      text: `❌ Error running survey analysis: ${message}\n\nPlease try again or contact support.`,
+    });
+  }
+}

--- a/backend/src/helpers/slack/commands/surveySubmissionHandler.ts
+++ b/backend/src/helpers/slack/commands/surveySubmissionHandler.ts
@@ -3,16 +3,21 @@
  *
  * Phase 1 (handleSurveyUploadPhase):
  *   CSV upload → parse → infer schema → create evidence_source →
- *   store pending_csv_content → send DM with "Review Schema" button
+ *   stage raw CSV in Redis (TTL 2h) → send DM with "Review Schema" button
  *
  * Phase 2 (handleSurveySchemaConfirmation):
- *   Schema review modal submission → read confirmed fields →
- *   read pending_csv_content → compute deterministic stats →
+ *   Schema review modal page(s) → researcher confirms ALL fields →
+ *   read CSV from Redis → compute deterministic stats →
  *   create evidence constructs + lineage → inject computed facts
- *   into template → render → clear pending_csv_content
+ *   into template → render → delete Redis staging
  *
  * Per ADR 0028: all statistics computed in code, never by LLM.
  * Per ADR 0029: evidence entities created for canonical state.
+ *
+ * Corrections applied:
+ * - Ordinal fields require explicit category order confirmation
+ * - ALL fields must be reviewed (paginated modal or fail closed)
+ * - Raw CSV staged in Redis with TTL, not in Postgres
  */
 
 import type {
@@ -23,6 +28,7 @@ import type {
   ViewSubmitAction,
   AllMiddlewareArgs,
 } from '@slack/bolt';
+import type { View } from '@slack/types';
 import type { CreationAttributes } from 'sequelize';
 import sequelize from '../../../database';
 import type { EvidenceSource } from '../../../database/models/evidence_source';
@@ -37,10 +43,16 @@ import {
   extractOpenTextContent,
   assignRespondentIdentities,
   getUniqueValues,
+  stagePendingCsv,
+  getPendingCsv,
+  deletePendingCsv,
 } from '../../survey';
 import {
   buildSchemaReviewModal,
   parseSchemaReviewValues,
+  checkFieldCountSupported,
+  getTotalPages,
+  OrdinalOrderValidationError,
   type SchemaReviewMeta,
 } from '../ui/surveySchemaReviewModal';
 import { processSlackFile } from '../../pdfProcessor';
@@ -73,21 +85,15 @@ interface SurveyUploadContext {
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// PHASE 1: Upload → Parse → Infer → DM with Review Button
+// PHASE 1: Upload → Parse → Infer → Stage in Redis → DM with Button
 // ═══════════════════════════════════════════════════════════════════════
 
-/**
- * Called from discoverHandler when discoveryType is 'survey_synthesis'.
- * Downloads CSV, parses, infers schema, creates evidence_source,
- * stores pending CSV content, sends DM with schema review button.
- */
 export async function handleSurveyUploadPhase(
   ctx: SurveyUploadContext,
   client: AllMiddlewareArgs['client'],
 ): Promise<void> {
   const { userId, projectId, projectSlug, channelId, topic, topicSlug, surveyName, questionFocus, sourceIntent, uploadedFiles } = ctx;
 
-  // Download first CSV file
   const csvFile = uploadedFiles.find(f => f.name.toLowerCase().endsWith('.csv'));
   if (!csvFile) {
     await client.chat.postMessage({
@@ -114,7 +120,6 @@ export async function handleSurveyUploadPhase(
     return;
   }
 
-  // Parse CSV
   let survey;
   try {
     survey = parseCsvBuffer(rawContent, csvFile.name);
@@ -129,14 +134,21 @@ export async function handleSurveyUploadPhase(
     throw err;
   }
 
+  // Check field count is supported for complete review
+  const fieldCountError = checkFieldCountSupported(survey.headers.length);
+  if (fieldCountError) {
+    await client.chat.postMessage({
+      channel: userId,
+      text: `❌ ${fieldCountError}`,
+    });
+    return;
+  }
+
   const contentHash = computeContentHash(rawContent);
 
-  // Check for existing source with same content hash in this project
+  // Check for existing source with same content hash for reuse
   const existingSource = await EvidenceSourceModel.findOne({
-    where: {
-      project_id: projectId,
-      source_type: 'survey_dataset',
-    },
+    where: { project_id: projectId, source_type: 'survey_dataset' },
   });
 
   let existingHash: string | null = null;
@@ -145,22 +157,17 @@ export async function handleSurveyUploadPhase(
     existingHash = ref?.content_hash as string | null;
   }
 
-  // Reuse existing source + schema if same content
   if (existingSource && existingHash === contentHash) {
     const confirmedSchemas = await SurveyFieldSchemaModel.findAll({
-      where: {
-        evidence_source_id: existingSource.id,
-        review_status: 'confirmed',
-      },
+      where: { evidence_source_id: existingSource.id, review_status: 'confirmed' },
     });
 
     if (confirmedSchemas.length > 0) {
       await client.chat.postMessage({
         channel: userId,
-        text: `✅ Same survey file detected (content hash match). Reusing accepted schema and recomputing statistics...`,
+        text: '✅ Same survey file detected (content hash match). Reusing accepted schema and recomputing statistics...',
       });
 
-      // Skip to Phase 2 directly — reuse confirmed schema
       const confirmedFields: ConfirmedField[] = confirmedSchemas.map((s: SurveyFieldSchema) => ({
         fieldName: s.field_name,
         confirmedRole: s.confirmed_role!,
@@ -180,7 +187,7 @@ export async function handleSurveyUploadPhase(
   // Create evidence_source
   const evidenceSource = await EvidenceSourceModel.create({
     project_id: projectId,
-    study_id: null, // Discovery is project-scoped
+    study_id: null,
     source_type: 'survey_dataset',
     label: `${surveyName} — ${csvFile.name}`,
     artifact_ref: {
@@ -200,34 +207,36 @@ export async function handleSurveyUploadPhase(
   // Infer field schema
   const inferredFields = inferFieldSchema(survey);
 
-  // Persist inferred fields + pending CSV content
+  // Persist inferred fields
   await sequelize.transaction(async (t) => {
-    for (let i = 0; i < inferredFields.length; i++) {
-      const field = inferredFields[i];
+    for (const field of inferredFields) {
       await SurveyFieldSchemaModel.create({
         evidence_source_id: evidenceSource.id,
         field_name: field.fieldName,
         inferred_role: field.inferredRole,
         inference_source: 'heuristic',
         review_status: 'pending',
-        // Store pending CSV on first field row only
-        pending_csv_content: i === 0 ? rawContent : null,
       } as CreationAttributes<SurveyFieldSchema>, { transaction: t });
     }
   });
 
-  // Build schema summary for DM
+  // Stage raw CSV in Redis with TTL (2 hours)
+  await stagePendingCsv(projectId, evidenceSource.public_id, userId, rawContent);
+
   const summaryLines = inferredFields.map(f =>
     `• *${f.fieldName}* → ${f.inferredRole} (${f.presentCount}/${survey.rowCount} present)`
   );
+
+  const totalPages = getTotalPages(inferredFields.length);
 
   const meta: SchemaReviewMeta = {
     evidenceSourceId: evidenceSource.id,
     projectId, projectSlug, channelId,
     topic, topicSlug, surveyName, questionFocus, sourceIntent,
+    page: 0,
+    totalFields: inferredFields.length,
   };
 
-  // Send DM with schema review button
   await client.chat.postMessage({
     channel: userId,
     blocks: [
@@ -243,7 +252,9 @@ export async function handleSurveyUploadPhase(
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: 'Review and confirm field roles before analysis proceeds. Ordinal fields need category order confirmation.',
+          text: totalPages > 1
+            ? `Review all fields across ${totalPages} pages before analysis proceeds. Ordinal fields need category order confirmation.`
+            : 'Review and confirm field roles before analysis proceeds. Ordinal fields need category order confirmation.',
         },
         accessory: {
           type: 'button',
@@ -259,7 +270,7 @@ export async function handleSurveyUploadPhase(
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// SCHEMA REVIEW BUTTON → Open Modal
+// SCHEMA REVIEW BUTTON → Open Modal (page 0)
 // ═══════════════════════════════════════════════════════════════════════
 
 export async function handleSurveySchemaReviewAction(
@@ -270,7 +281,6 @@ export async function handleSurveySchemaReviewAction(
 
   const meta: SchemaReviewMeta = JSON.parse(action.value || '{}');
 
-  // Load inferred fields from DB
   const fieldSchemas = await SurveyFieldSchemaModel.findAll({
     where: { evidence_source_id: meta.evidenceSourceId },
     order: [['id', 'ASC']],
@@ -284,26 +294,49 @@ export async function handleSurveySchemaReviewAction(
     return;
   }
 
-  // Convert to SurveyField shape for modal builder
-  const fields: SurveyField[] = fieldSchemas.map((s: SurveyFieldSchema) => ({
-    fieldName: s.field_name,
-    inferredRole: s.inferred_role,
-    sampleValues: [], // Samples not stored — role and counts sufficient for review
-    distinctCount: 0,
-    presentCount: 0,
-    missingCount: 0,
-  }));
+  // Load the parsed survey to get sample values for the modal
+  const pendingCsv = await getPendingCsv(meta.projectId, '', body.user.id);
+  // Try with source public_id
+  const source = await EvidenceSourceModel.findByPk(meta.evidenceSourceId);
+  const sourcePublicId = source ? source.public_id : '';
+  const csvContent = await getPendingCsv(meta.projectId, sourcePublicId, body.user.id);
 
+  let fields: SurveyField[];
+  if (csvContent) {
+    try {
+      const survey = parseCsvBuffer(csvContent, 'staged-csv');
+      fields = inferFieldSchema(survey);
+    } catch {
+      fields = fieldSchemas.map((s: SurveyFieldSchema) => ({
+        fieldName: s.field_name,
+        inferredRole: s.inferred_role,
+        sampleValues: [],
+        distinctCount: 0,
+        presentCount: 0,
+        missingCount: 0,
+      }));
+    }
+  } else {
+    // CSV expired from Redis
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: '❌ Survey data has expired (2-hour staging window). Please re-upload via `/qori-discover`.',
+    });
+    return;
+  }
+
+  meta.page = 0;
+  meta.totalFields = fields.length;
   const modal = buildSchemaReviewModal(fields, meta);
 
   await client.views.open({
     trigger_id: body.trigger_id,
-    view: modal as unknown as import('@slack/types').View,
+    view: modal as unknown as View,
   });
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// PHASE 2: Schema Confirmation → Compute → Evidence → Render
+// PHASE 2: Schema Confirmation (paginated) → Compute → Evidence → Render
 // ═══════════════════════════════════════════════════════════════════════
 
 export async function handleSurveySchemaConfirmation(
@@ -315,13 +348,23 @@ export async function handleSurveySchemaConfirmation(
   const meta: SchemaReviewMeta = JSON.parse(view.private_metadata || '{}');
   const userId = body.user.id;
 
-  // Load existing field schemas
-  const fieldSchemas = await SurveyFieldSchemaModel.findAll({
+  // Load source for Redis key
+  const source = await EvidenceSourceModel.findByPk(meta.evidenceSourceId);
+  if (!source) {
+    await client.chat.postMessage({
+      channel: userId,
+      text: '❌ Survey source not found. Please re-upload via `/qori-discover`.',
+    });
+    return;
+  }
+
+  // Load field schemas
+  const allFieldSchemas = await SurveyFieldSchemaModel.findAll({
     where: { evidence_source_id: meta.evidenceSourceId },
     order: [['id', 'ASC']],
   });
 
-  if (fieldSchemas.length === 0) {
+  if (allFieldSchemas.length === 0) {
     await client.chat.postMessage({
       channel: userId,
       text: '❌ Survey schema expired. Please re-upload via `/qori-discover`.',
@@ -329,38 +372,19 @@ export async function handleSurveySchemaConfirmation(
     return;
   }
 
-  // Build original fields for parsing
-  const originalFields: SurveyField[] = fieldSchemas.map((s: SurveyFieldSchema) => ({
-    fieldName: s.field_name,
-    inferredRole: s.inferred_role,
-    sampleValues: [],
-    distinctCount: 0,
-    presentCount: 0,
-    missingCount: 0,
-  }));
-
-  // Parse confirmed roles from modal
-  const confirmedRoles = parseSchemaReviewValues(
-    view.state.values as unknown as Record<string, Record<string, Record<string, unknown>>>,
-    originalFields,
-  );
-
-  // Read pending CSV content from first field row
-  const firstField = fieldSchemas[0] as SurveyFieldSchema;
-  const pendingCsv = firstField.pending_csv_content;
-
-  if (!pendingCsv) {
+  // Read CSV from Redis to get field values for ordinal order validation
+  const csvContent = await getPendingCsv(meta.projectId, source.public_id, userId);
+  if (!csvContent) {
     await client.chat.postMessage({
       channel: userId,
-      text: '❌ Survey data expired. Please re-upload via `/qori-discover`.',
+      text: '❌ Survey data has expired (2-hour staging window). Please re-upload via `/qori-discover`.',
     });
     return;
   }
 
-  // Re-parse CSV from staged content
   let survey;
   try {
-    survey = parseCsvBuffer(pendingCsv, 'staged-csv');
+    survey = parseCsvBuffer(csvContent, 'staged-csv');
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     await client.chat.postMessage({
@@ -370,56 +394,122 @@ export async function handleSurveySchemaConfirmation(
     return;
   }
 
-  const contentHash = computeContentHash(pendingCsv);
+  // Get current page's fields
+  const FIELDS_PER_PAGE = 20;
+  const startIdx = meta.page * FIELDS_PER_PAGE;
+  const endIdx = Math.min(startIdx + FIELDS_PER_PAGE, allFieldSchemas.length);
+  const pageFieldSchemas = allFieldSchemas.slice(startIdx, endIdx);
+  const isLastPage = endIdx >= allFieldSchemas.length;
 
-  // For ordinal fields, detect unique values for order metadata
-  const confirmedFields: ConfirmedField[] = confirmedRoles.map(r => {
-    let orderMetadata: string[] | null = null;
-    if (r.confirmedRole === 'ordinal') {
-      // Auto-detect category order from unique values (researcher can adjust in future)
-      orderMetadata = getUniqueValues(survey, r.fieldName);
-    }
+  const pageFields: SurveyField[] = pageFieldSchemas.map((s: SurveyFieldSchema) => {
+    const fieldValues = survey.rows.map(r => r.values[s.field_name]?.trim() ?? '').filter(v => v !== '');
     return {
-      fieldName: r.fieldName,
-      confirmedRole: r.confirmedRole,
-      orderMetadata,
-      isDemographic: r.isDemographic,
+      fieldName: s.field_name,
+      inferredRole: s.inferred_role,
+      sampleValues: [...new Set(fieldValues)].slice(0, 5),
+      distinctCount: new Set(fieldValues).size,
+      presentCount: fieldValues.length,
+      missingCount: survey.rowCount - fieldValues.length,
     };
   });
 
-  // Update field schemas in DB
+  // Build map of all field values for ordinal order validation
+  const allFieldValues = new Map<string, string[]>();
+  for (const s of allFieldSchemas) {
+    const vals = survey.rows.map(r => r.values[s.field_name]?.trim() ?? '').filter(v => v !== '');
+    allFieldValues.set(s.field_name, [...new Set(vals)]);
+  }
+
+  // Parse confirmed roles from this page
+  let pageResults;
+  try {
+    pageResults = parseSchemaReviewValues(
+      view.state.values as unknown as Record<string, Record<string, Record<string, unknown>>>,
+      pageFields,
+      allFieldValues,
+    );
+  } catch (err) {
+    if (err instanceof OrdinalOrderValidationError) {
+      await client.chat.postMessage({
+        channel: userId,
+        text: `❌ ${err.message}`,
+      });
+      return;
+    }
+    throw err;
+  }
+
+  // Persist this page's confirmed fields
   await sequelize.transaction(async (t) => {
-    for (const field of confirmedFields) {
+    for (const result of pageResults) {
       await SurveyFieldSchemaModel.update(
         {
-          confirmed_role: field.confirmedRole,
-          order_metadata: field.orderMetadata,
-          is_demographic: field.isDemographic,
+          confirmed_role: result.confirmedRole,
+          order_metadata: result.orderMetadata,
+          is_demographic: result.isDemographic,
           review_status: 'confirmed',
           reviewed_by: userId,
           reviewed_at: new Date(),
-          pending_csv_content: null, // Clear staged data
         },
         {
           where: {
             evidence_source_id: meta.evidenceSourceId,
-            field_name: field.fieldName,
+            field_name: result.fieldName,
           },
           transaction: t,
         },
       );
     }
-    // Clear pending_csv_content from first row explicitly
-    await SurveyFieldSchemaModel.update(
-      { pending_csv_content: null },
-      { where: { evidence_source_id: meta.evidenceSourceId }, transaction: t },
-    );
   });
+
+  // If not last page, open next page
+  if (!isLastPage) {
+    const allFields = inferFieldSchema(survey);
+    const nextMeta = { ...meta, page: meta.page + 1 };
+    const nextModal = buildSchemaReviewModal(allFields, nextMeta);
+
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: nextModal as unknown as View,
+    });
+    return;
+  }
+
+  // All pages complete — verify every field is confirmed
+  const unconfirmed = await SurveyFieldSchemaModel.count({
+    where: { evidence_source_id: meta.evidenceSourceId, review_status: 'pending' },
+  });
+
+  if (unconfirmed > 0) {
+    await client.chat.postMessage({
+      channel: userId,
+      text: `❌ ${unconfirmed} field(s) have not been reviewed. All fields must be confirmed before analysis can proceed. Please re-upload and review all pages.`,
+    });
+    return;
+  }
 
   await client.chat.postMessage({
     channel: userId,
-    text: 'Schema confirmed. Computing survey statistics...',
+    text: 'All fields confirmed. Computing survey statistics...',
   });
+
+  // Load all confirmed fields
+  const confirmedSchemas = await SurveyFieldSchemaModel.findAll({
+    where: { evidence_source_id: meta.evidenceSourceId, review_status: 'confirmed' },
+    order: [['id', 'ASC']],
+  });
+
+  const confirmedFields: ConfirmedField[] = confirmedSchemas.map((s: SurveyFieldSchema) => ({
+    fieldName: s.field_name,
+    confirmedRole: s.confirmed_role!,
+    orderMetadata: s.order_metadata,
+    isDemographic: s.is_demographic,
+  }));
+
+  const contentHash = computeContentHash(csvContent);
+
+  // Delete staged CSV from Redis immediately
+  await deletePendingCsv(meta.projectId, source.public_id, userId);
 
   await executeSurveyAnalysis(
     survey, confirmedFields, contentHash, meta.evidenceSourceId,
@@ -451,19 +541,13 @@ async function executeSurveyAnalysis(
   client: AllMiddlewareArgs['client'],
 ): Promise<void> {
   try {
-    // Compute deterministic facts (ADR 0028)
     const computedFacts = computeSurveyFacts(survey, confirmedFields, contentHash);
-
-    // Assign respondent identities
     const identities = assignRespondentIdentities(survey, confirmedFields, contentHash);
     const displayLabels = identities.map(id => id.displayLabel);
-
-    // Extract open-text content for LLM interpretation
     const openTextContent = extractOpenTextContent(survey, confirmedFields, displayLabels);
 
     // Create evidence constructs (deterministic, auto-accepted)
     await sequelize.transaction(async (t) => {
-      // Survey dataset summary construct
       const summaryConstruct = await EvidenceConstructModel.create({
         project_id: ctx.projectId,
         study_id: null,
@@ -488,7 +572,6 @@ async function executeSurveyAnalysis(
         provenance: { method: 'survey_structured_ingestion' },
       }, t);
 
-      // Field distribution constructs
       for (const stat of computedFacts.fieldStats) {
         if (!stat.distribution && stat.nValidNumeric === null) continue;
 
@@ -511,7 +594,6 @@ async function executeSurveyAnalysis(
         }, t);
       }
 
-      // Cross-tab constructs
       for (const ct of computedFacts.crossTabs) {
         const ctConstruct = await EvidenceConstructModel.create({
           project_id: ctx.projectId,
@@ -533,13 +615,11 @@ async function executeSurveyAnalysis(
       }
     });
 
-    // Proceed with template rendering via existing discover flow
+    // Template rendering
     const project = await getProjectById(ctx.projectId);
     const projectProblemStatement = project?.problem_statement || null;
-
     const dateIso = format(new Date(), 'yyyy-MM-dd');
 
-    // Build template input with computed facts
     const data: Record<string, unknown> = {
       topic: ctx.topic,
       effective_topic: ctx.topic,
@@ -556,28 +636,18 @@ async function executeSurveyAnalysis(
       document_names: [survey.sourceFilename],
       document_types: ['CSV'],
       _discovery_type: 'survey-synthesis',
-      // Computed facts — deterministic, code-computed (ADR 0028)
       computed_facts: computedFacts,
-      // Open-text content for LLM qualitative interpretation
       open_text_content: openTextContent,
-      // Keep combined_file_content for backward compat with template
       combined_file_content: openTextContent,
     };
 
     const file = await fetchFileFromRepo(getConfigRepo(), YAML_TEMPLATE_PATH, 'survey_synthesis.yaml');
-
     const variableContext = { projectId: ctx.projectId };
 
     const renderedYaml = await processYamlTemplate(
-      file.content,
-      data,
-      '',
-      '',
-      false,
-      variableContext,
+      file.content, data, '', '', false, variableContext,
     );
 
-    // Await extraction (ADR 0019)
     if (renderedYaml.extractionPromise) {
       const extractResult = await renderedYaml.extractionPromise;
       if (!extractResult.success) {
@@ -630,7 +700,6 @@ async function executeSurveyAnalysis(
       ],
       text: `Survey synthesis complete for "${ctx.surveyName}". View: ${url}`,
     });
-
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error('Error in survey analysis:', error);

--- a/backend/src/helpers/slack/events.ts
+++ b/backend/src/helpers/slack/events.ts
@@ -553,6 +553,11 @@ slackApp.view('discover_desk_research_modal', handleDiscoverSubmission);
 slackApp.view('discover_stakeholder_modal', handleDiscoverSubmission);
 slackApp.view('discover_survey_modal', handleDiscoverSubmission);
 
+// Survey schema review (Survey Slice 1)
+import { handleSurveySchemaReviewAction, handleSurveySchemaConfirmation } from './commands/surveySubmissionHandler';
+slackApp.action('survey_review_schema', handleSurveySchemaReviewAction);
+slackApp.view('survey_schema_review_modal', handleSurveySchemaConfirmation);
+
 // ─── Fieldwork & participants ───────────────────────────────────
 
 slackApp.view('fieldwork_study_picker', handleFieldworkStudyPickerSubmit);

--- a/backend/src/helpers/slack/ui/discoverTypeModals.ts
+++ b/backend/src/helpers/slack/ui/discoverTypeModals.ts
@@ -307,12 +307,12 @@ export const discoverSurveyModal = {
       },
       hint: {
         type: "plain_text",
-        text: "CSV or Excel — up to 10 files",
+        text: "CSV format only — up to 10 files",
       },
       element: {
         type: "file_input",
         action_id: "file_upload",
-        filetypes: ["csv", "xlsx", "xls"],
+        filetypes: ["csv"],
         max_files: 10,
       },
     },

--- a/backend/src/helpers/slack/ui/surveySchemaReviewModal.ts
+++ b/backend/src/helpers/slack/ui/surveySchemaReviewModal.ts
@@ -1,0 +1,151 @@
+/**
+ * Survey Schema Review Modal — dynamic modal for researcher confirmation
+ * of inferred field roles.
+ *
+ * Modal contract (ADR 0031):
+ *   DERIVES: inferred field schema from CSV parsing
+ *   ASKS: field role corrections, ordinal category order, demographic flags
+ *   COMMITS: confirmed field schema (survey_field_schemas)
+ */
+
+import type { SurveyField, SurveyFieldRole } from '../../../types/survey';
+
+const ROLE_OPTIONS: Array<{ text: string; value: SurveyFieldRole }> = [
+  { text: 'ID (Respondent identifier)', value: 'id' },
+  { text: 'Nominal (Unordered category)', value: 'nominal' },
+  { text: 'Ordinal (Ordered scale)', value: 'ordinal' },
+  { text: 'Continuous (Numeric)', value: 'continuous' },
+  { text: 'Multi-select', value: 'multi_select' },
+  { text: 'Open text', value: 'open_text' },
+  { text: 'Timestamp', value: 'timestamp' },
+];
+
+export interface SchemaReviewMeta {
+  evidenceSourceId: number;
+  projectId: number;
+  projectSlug: string;
+  channelId: string;
+  topic: string;
+  topicSlug: string;
+  surveyName: string;
+  questionFocus: string;
+  sourceIntent: string;
+}
+
+/**
+ * Build a dynamic schema review modal from inferred fields.
+ *
+ * Each field gets a role dropdown and sample values context.
+ * Ordinal fields show unique values for category order input.
+ * Slack modal limit: 100 blocks — supports ~30 fields.
+ */
+export function buildSchemaReviewModal(
+  fields: SurveyField[],
+  meta: SchemaReviewMeta,
+): Record<string, unknown> {
+  const blocks: Record<string, unknown>[] = [
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `Qori detected *${fields.length} fields* in your CSV. Review the inferred roles below and adjust if needed.\n\n• *Ordinal* fields will compute a median — confirm the category order after selection.\n• Mark fields as *demographic* if they describe respondent characteristics.`,
+        },
+      ],
+    },
+    { type: 'divider' },
+  ];
+
+  // Limit to ~30 fields (each uses ~3 blocks = 90 blocks max with header)
+  const displayFields = fields.slice(0, 30);
+
+  for (const field of displayFields) {
+    // Sample values context
+    const sampleText = field.sampleValues.length > 0
+      ? `Sample: ${field.sampleValues.slice(0, 3).join(', ')}  |  ${field.presentCount} present, ${field.missingCount} missing`
+      : `${field.presentCount} present, ${field.missingCount} missing`;
+
+    blocks.push({
+      type: 'context',
+      elements: [{ type: 'mrkdwn', text: `*${field.fieldName}* — ${sampleText}` }],
+    });
+
+    // Role selector
+    blocks.push({
+      type: 'input',
+      block_id: `field_role_${field.fieldName}`,
+      label: { type: 'plain_text', text: `Role for "${field.fieldName}"` },
+      element: {
+        type: 'static_select',
+        action_id: 'role_select',
+        initial_option: {
+          text: { type: 'plain_text', text: ROLE_OPTIONS.find(o => o.value === field.inferredRole)?.text ?? 'Nominal' },
+          value: field.inferredRole,
+        },
+        options: ROLE_OPTIONS.map(o => ({
+          text: { type: 'plain_text', text: o.text },
+          value: o.value,
+        })),
+      },
+    });
+
+    // Demographic checkbox
+    blocks.push({
+      type: 'input',
+      block_id: `field_demo_${field.fieldName}`,
+      optional: true,
+      label: { type: 'plain_text', text: ' ' },
+      element: {
+        type: 'checkboxes',
+        action_id: 'demo_check',
+        options: [
+          {
+            text: { type: 'plain_text', text: 'This is a demographic field' },
+            value: 'demographic',
+          },
+        ],
+      },
+    });
+  }
+
+  if (fields.length > 30) {
+    blocks.push({
+      type: 'context',
+      elements: [{
+        type: 'mrkdwn',
+        text: `_${fields.length - 30} additional fields will use their inferred roles._`,
+      }],
+    });
+  }
+
+  return {
+    type: 'modal',
+    callback_id: 'survey_schema_review_modal',
+    private_metadata: JSON.stringify(meta),
+    title: { type: 'plain_text', text: 'Review Survey Schema' },
+    submit: { type: 'plain_text', text: 'Confirm & Analyze' },
+    close: { type: 'plain_text', text: 'Cancel' },
+    blocks,
+  };
+}
+
+/**
+ * Parse confirmed field roles from the schema review modal submission.
+ */
+export function parseSchemaReviewValues(
+  values: Record<string, Record<string, Record<string, unknown>>>,
+  originalFields: SurveyField[],
+): Array<{ fieldName: string; confirmedRole: SurveyFieldRole; isDemographic: boolean }> {
+  return originalFields.map(field => {
+    const roleBlock = values[`field_role_${field.fieldName}`];
+    const demoBlock = values[`field_demo_${field.fieldName}`];
+
+    const selectedOption = roleBlock?.role_select?.selected_option as { value: string } | null | undefined;
+    const confirmedRole = (selectedOption?.value as SurveyFieldRole) ?? field.inferredRole;
+
+    const selectedOptions = demoBlock?.demo_check?.selected_options as Array<{ value: string }> | undefined;
+    const isDemographic = selectedOptions?.some(o => o.value === 'demographic') ?? false;
+
+    return { fieldName: field.fieldName, confirmedRole, isDemographic };
+  });
+}

--- a/backend/src/helpers/slack/ui/surveySchemaReviewModal.ts
+++ b/backend/src/helpers/slack/ui/surveySchemaReviewModal.ts
@@ -2,13 +2,24 @@
  * Survey Schema Review Modal — dynamic modal for researcher confirmation
  * of inferred field roles.
  *
+ * Corrections applied:
+ * - Ordinal fields show a plain_text_input for explicit category order
+ * - ALL fields must be reviewed — no unreviewed inference becomes authoritative
+ * - Multi-page review for >20 fields (20 fields per page)
+ * - Fail closed: if field count exceeds supported limit, tell researcher to reduce
+ *
  * Modal contract (ADR 0031):
  *   DERIVES: inferred field schema from CSV parsing
- *   ASKS: field role corrections, ordinal category order, demographic flags
+ *   ASKS: field role corrections, ordinal order, demographic flags
  *   COMMITS: confirmed field schema (survey_field_schemas)
  */
 
 import type { SurveyField, SurveyFieldRole } from '../../../types/survey';
+
+/** Maximum fields per modal page (Slack limit ~100 blocks; 4 blocks per field = 25 max). */
+const FIELDS_PER_PAGE = 20;
+/** Maximum supported fields total (5 pages × 20 = 100 fields). */
+const MAX_SUPPORTED_FIELDS = 100;
 
 const ROLE_OPTIONS: Array<{ text: string; value: SurveyFieldRole }> = [
   { text: 'ID (Respondent identifier)', value: 'id' },
@@ -30,39 +41,68 @@ export interface SchemaReviewMeta {
   surveyName: string;
   questionFocus: string;
   sourceIntent: string;
+  /** Current page (0-based). */
+  page: number;
+  /** Total number of fields. */
+  totalFields: number;
 }
 
 /**
- * Build a dynamic schema review modal from inferred fields.
+ * Check if a survey's field count is supported for complete review.
+ * Returns an error message if too many fields, null if OK.
+ */
+export function checkFieldCountSupported(fieldCount: number): string | null {
+  if (fieldCount > MAX_SUPPORTED_FIELDS) {
+    return `Your CSV has ${fieldCount} columns, which exceeds the ${MAX_SUPPORTED_FIELDS}-column limit for schema review. Please reduce the number of columns or split the survey into smaller files.`;
+  }
+  return null;
+}
+
+/**
+ * Get total number of pages needed for complete schema review.
+ */
+export function getTotalPages(fieldCount: number): number {
+  return Math.ceil(fieldCount / FIELDS_PER_PAGE);
+}
+
+/**
+ * Build a schema review modal page showing a subset of fields.
  *
- * Each field gets a role dropdown and sample values context.
- * Ordinal fields show unique values for category order input.
- * Slack modal limit: 100 blocks — supports ~30 fields.
+ * Each field gets: sample values context, role dropdown, demographic checkbox.
+ * Ordinal fields also get a plain_text_input for category order confirmation.
+ *
+ * If not the last page, submit button says "Continue →" instead of "Confirm & Analyze".
  */
 export function buildSchemaReviewModal(
-  fields: SurveyField[],
+  allFields: SurveyField[],
   meta: SchemaReviewMeta,
 ): Record<string, unknown> {
+  const page = meta.page;
+  const totalPages = getTotalPages(allFields.length);
+  const startIdx = page * FIELDS_PER_PAGE;
+  const endIdx = Math.min(startIdx + FIELDS_PER_PAGE, allFields.length);
+  const pageFields = allFields.slice(startIdx, endIdx);
+  const isLastPage = endIdx >= allFields.length;
+
   const blocks: Record<string, unknown>[] = [
     {
       type: 'context',
       elements: [
         {
           type: 'mrkdwn',
-          text: `Qori detected *${fields.length} fields* in your CSV. Review the inferred roles below and adjust if needed.\n\n• *Ordinal* fields will compute a median — confirm the category order after selection.\n• Mark fields as *demographic* if they describe respondent characteristics.`,
+          text: totalPages > 1
+            ? `Page ${page + 1} of ${totalPages} — reviewing fields ${startIdx + 1}–${endIdx} of ${allFields.length}.\n\n*All fields must be reviewed before analysis can proceed.*`
+            : `Reviewing all *${allFields.length} fields*. Confirm roles below.\n\n• *Ordinal* fields: enter the category order (low → high) separated by |\n• Mark *demographic* fields that describe respondent characteristics.`,
         },
       ],
     },
     { type: 'divider' },
   ];
 
-  // Limit to ~30 fields (each uses ~3 blocks = 90 blocks max with header)
-  const displayFields = fields.slice(0, 30);
-
-  for (const field of displayFields) {
+  for (const field of pageFields) {
     // Sample values context
     const sampleText = field.sampleValues.length > 0
-      ? `Sample: ${field.sampleValues.slice(0, 3).join(', ')}  |  ${field.presentCount} present, ${field.missingCount} missing`
+      ? `Sample: ${field.sampleValues.slice(0, 3).join(', ')}  |  ${field.presentCount}/${field.presentCount + field.missingCount} present`
       : `${field.presentCount} present, ${field.missingCount} missing`;
 
     blocks.push({
@@ -89,6 +129,26 @@ export function buildSchemaReviewModal(
       },
     });
 
+    // Ordinal category order input (shown for fields inferred as ordinal)
+    if (field.inferredRole === 'ordinal') {
+      const suggestedOrder = field.sampleValues.join(' | ');
+      blocks.push({
+        type: 'input',
+        block_id: `field_order_${field.fieldName}`,
+        optional: true,
+        label: { type: 'plain_text', text: `Category order (low → high) for "${field.fieldName}"` },
+        element: {
+          type: 'plain_text_input',
+          action_id: 'order_input',
+          placeholder: {
+            type: 'plain_text',
+            text: 'e.g., Very Difficult | Difficult | Neutral | Easy | Very Easy',
+          },
+          ...(suggestedOrder ? { initial_value: suggestedOrder } : {}),
+        },
+      });
+    }
+
     // Demographic checkbox
     blocks.push({
       type: 'input',
@@ -108,37 +168,42 @@ export function buildSchemaReviewModal(
     });
   }
 
-  if (fields.length > 30) {
-    blocks.push({
-      type: 'context',
-      elements: [{
-        type: 'mrkdwn',
-        text: `_${fields.length - 30} additional fields will use their inferred roles._`,
-      }],
-    });
-  }
-
   return {
     type: 'modal',
     callback_id: 'survey_schema_review_modal',
     private_metadata: JSON.stringify(meta),
-    title: { type: 'plain_text', text: 'Review Survey Schema' },
-    submit: { type: 'plain_text', text: 'Confirm & Analyze' },
+    title: { type: 'plain_text', text: totalPages > 1 ? `Schema (${page + 1}/${totalPages})` : 'Review Survey Schema' },
+    submit: { type: 'plain_text', text: isLastPage ? 'Confirm & Analyze' : 'Continue →' },
     close: { type: 'plain_text', text: 'Cancel' },
     blocks,
   };
 }
 
+export class OrdinalOrderValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly fieldName: string,
+  ) {
+    super(message);
+    this.name = 'OrdinalOrderValidationError';
+  }
+}
+
 /**
- * Parse confirmed field roles from the schema review modal submission.
+ * Parse confirmed field roles from one page of the schema review modal.
+ * Validates ordinal category order.
+ *
+ * @throws OrdinalOrderValidationError if ordinal order is incomplete or has duplicates
  */
 export function parseSchemaReviewValues(
   values: Record<string, Record<string, Record<string, unknown>>>,
-  originalFields: SurveyField[],
-): Array<{ fieldName: string; confirmedRole: SurveyFieldRole; isDemographic: boolean }> {
-  return originalFields.map(field => {
+  pageFields: SurveyField[],
+  allFieldValues: Map<string, string[]>,
+): Array<{ fieldName: string; confirmedRole: SurveyFieldRole; isDemographic: boolean; orderMetadata: string[] | null }> {
+  return pageFields.map(field => {
     const roleBlock = values[`field_role_${field.fieldName}`];
     const demoBlock = values[`field_demo_${field.fieldName}`];
+    const orderBlock = values[`field_order_${field.fieldName}`];
 
     const selectedOption = roleBlock?.role_select?.selected_option as { value: string } | null | undefined;
     const confirmedRole = (selectedOption?.value as SurveyFieldRole) ?? field.inferredRole;
@@ -146,6 +211,37 @@ export function parseSchemaReviewValues(
     const selectedOptions = demoBlock?.demo_check?.selected_options as Array<{ value: string }> | undefined;
     const isDemographic = selectedOptions?.some(o => o.value === 'demographic') ?? false;
 
-    return { fieldName: field.fieldName, confirmedRole, isDemographic };
+    // Parse ordinal order if role is ordinal
+    let orderMetadata: string[] | null = null;
+    if (confirmedRole === 'ordinal') {
+      const orderValue = orderBlock?.order_input?.value as string | undefined;
+      if (orderValue && orderValue.trim()) {
+        const categories = orderValue.split('|').map(c => c.trim()).filter(c => c !== '');
+        // Validate: no duplicates
+        const uniqueCategories = new Set(categories.map(c => c.toLowerCase()));
+        if (uniqueCategories.size !== categories.length) {
+          throw new OrdinalOrderValidationError(
+            `Duplicate categories in order for "${field.fieldName}". Each category must appear exactly once.`,
+            field.fieldName,
+          );
+        }
+        // Validate: all observed values represented
+        const observedValues = allFieldValues.get(field.fieldName) ?? [];
+        const orderLower = new Set(categories.map(c => c.toLowerCase()));
+        const missing = observedValues.filter(v => !orderLower.has(v.toLowerCase()));
+        if (missing.length > 0) {
+          throw new OrdinalOrderValidationError(
+            `Category order for "${field.fieldName}" is incomplete. Missing observed values: ${missing.join(', ')}`,
+            field.fieldName,
+          );
+        }
+
+        orderMetadata = categories;
+      }
+      // If no order provided for ordinal field, orderMetadata stays null
+      // → stats engine will NOT compute median (fail closed per correction 1)
+    }
+
+    return { fieldName: field.fieldName, confirmedRole, isDemographic, orderMetadata };
   });
 }

--- a/backend/src/helpers/survey/csvParser.ts
+++ b/backend/src/helpers/survey/csvParser.ts
@@ -1,0 +1,129 @@
+/**
+ * CSV Parser — structured survey ingestion.
+ *
+ * Uses csv-parse/sync for deterministic parsing. Same input buffer
+ * always produces identical output (ADR 0028).
+ *
+ * Handles: RFC-style quoted fields, commas inside quotes, embedded
+ * newlines, escaped quotes, UTF-8 BOM, empty cells, malformed rows.
+ */
+
+import { parse } from 'csv-parse/sync';
+import type { ParsedSurvey, SurveyRow } from '../../types/survey';
+
+/** Errors specific to CSV parsing. */
+export class CsvParseError extends Error {
+  constructor(
+    message: string,
+    public readonly details?: string,
+  ) {
+    super(message);
+    this.name = 'CsvParseError';
+  }
+}
+
+/**
+ * Parse a CSV buffer into a ParsedSurvey.
+ *
+ * @param buffer — raw CSV file content (Buffer or string)
+ * @param filename — source filename for metadata
+ * @returns ParsedSurvey with headers, rows, and parse warnings
+ * @throws CsvParseError on empty file, no headers, or fatal parse failure
+ */
+export function parseCsvBuffer(
+  buffer: Buffer | string,
+  filename: string,
+): ParsedSurvey {
+  let content = typeof buffer === 'string' ? buffer : buffer.toString('utf-8');
+
+  // Strip UTF-8 BOM if present
+  if (content.charCodeAt(0) === 0xFEFF) {
+    content = content.slice(1);
+  }
+
+  const trimmed = content.trim();
+  if (!trimmed) {
+    throw new CsvParseError('CSV file is empty', filename);
+  }
+
+  const warnings: string[] = [];
+
+  let records: string[][];
+  try {
+    records = parse(content, {
+      bom: true,
+      skip_empty_lines: false,
+      relax_column_count: true,
+      relax_quotes: true,
+      trim: true,
+      columns: false,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new CsvParseError(`Failed to parse CSV: ${message}`, filename);
+  }
+
+  if (records.length === 0) {
+    throw new CsvParseError('CSV file contains no data', filename);
+  }
+
+  const rawHeaders = records[0];
+  if (!rawHeaders || rawHeaders.length === 0) {
+    throw new CsvParseError('CSV file has no header row', filename);
+  }
+
+  // Detect duplicate headers
+  const headers: string[] = [];
+  const headerCounts = new Map<string, number>();
+  for (const h of rawHeaders) {
+    const name = h.trim() || 'unnamed';
+    const count = (headerCounts.get(name) ?? 0) + 1;
+    headerCounts.set(name, count);
+    if (count > 1) {
+      const deduped = `${name}_${count}`;
+      headers.push(deduped);
+      warnings.push(`Duplicate header "${name}" renamed to "${deduped}"`);
+    } else {
+      headers.push(name);
+    }
+  }
+
+  // Parse data rows
+  const dataRecords = records.slice(1);
+
+  if (dataRecords.length === 0) {
+    throw new CsvParseError('CSV file contains headers but no data rows', filename);
+  }
+
+  const rows: SurveyRow[] = [];
+  for (let i = 0; i < dataRecords.length; i++) {
+    const record = dataRecords[i];
+
+    // Skip completely empty rows
+    if (record.every(cell => cell.trim() === '')) {
+      continue;
+    }
+
+    // Warn on column count mismatch
+    if (record.length !== headers.length) {
+      warnings.push(
+        `Row ${i + 2} has ${record.length} columns (expected ${headers.length})`,
+      );
+    }
+
+    const values: Record<string, string> = {};
+    for (let j = 0; j < headers.length; j++) {
+      values[headers[j]] = (record[j] ?? '').trim();
+    }
+
+    rows.push({ values, rowIndex: rows.length });
+  }
+
+  return {
+    sourceFilename: filename,
+    headers,
+    rows,
+    rowCount: rows.length,
+    parseWarnings: warnings,
+  };
+}

--- a/backend/src/helpers/survey/index.ts
+++ b/backend/src/helpers/survey/index.ts
@@ -3,3 +3,4 @@ export { computeContentHash } from './sourceHash';
 export { assignRespondentIdentities, DuplicateRespondentIdError } from './respondentIdentity';
 export { inferFieldSchema, getUniqueValues } from './schemaInference';
 export { computeSurveyFacts, extractOpenTextContent } from './statsEngine';
+export { stagePendingCsv, getPendingCsv, deletePendingCsv, STAGING_TTL_SECONDS } from './pendingCsvStore';

--- a/backend/src/helpers/survey/index.ts
+++ b/backend/src/helpers/survey/index.ts
@@ -1,0 +1,5 @@
+export { parseCsvBuffer, CsvParseError } from './csvParser';
+export { computeContentHash } from './sourceHash';
+export { assignRespondentIdentities, DuplicateRespondentIdError } from './respondentIdentity';
+export { inferFieldSchema, getUniqueValues } from './schemaInference';
+export { computeSurveyFacts, extractOpenTextContent } from './statsEngine';

--- a/backend/src/helpers/survey/pendingCsvStore.ts
+++ b/backend/src/helpers/survey/pendingCsvStore.ts
@@ -1,0 +1,122 @@
+/**
+ * Pending CSV Store — Redis-backed temporary staging for survey CSV content.
+ *
+ * Lifecycle:
+ *   upload → Redis SET with TTL
+ *   schema confirmation → Redis DEL immediately
+ *   cancel → Redis DEL (where Slack lifecycle exposes cancellation)
+ *   TTL reached → automatic deletion
+ *   expired → clear user-facing error asking researcher to re-upload
+ *
+ * Key format: survey:pending:{projectId}:{sourcePublicId}:{userId}
+ *
+ * TTL: 2 hours — schema review typically happens immediately after upload.
+ * 2 hours provides margin for researcher interruptions without retaining
+ * PII-bearing content indefinitely.
+ *
+ * PII implications: Survey CSVs may contain respondent names/emails.
+ * The TTL guarantees automatic deletion even if the researcher never
+ * completes review. On confirmation, content is deleted immediately —
+ * no PII persists beyond the review step.
+ *
+ * The staged CSV is NOT exposed to:
+ *   - /qori-ask
+ *   - study_variables
+ *   - generated artifacts
+ *   - model prompts
+ *   - evidence metadata
+ */
+
+import { createClient, type RedisClientType } from 'redis';
+
+/** TTL for pending CSV staging: 2 hours (7200 seconds). */
+const PENDING_CSV_TTL_SECONDS = 7200;
+
+let client: RedisClientType | null = null;
+
+/**
+ * Get or create the Redis client. Lazy initialization — only connects
+ * when survey upload actually occurs.
+ */
+async function getClient(): Promise<RedisClientType> {
+  if (client && client.isOpen) return client;
+
+  const url = process.env.REDIS_URI
+    || `redis://${process.env.REDIS_HOST || 'localhost'}:${process.env.REDIS_PORT || '6379'}`;
+
+  client = createClient({ url });
+  client.on('error', (err) => console.error('[survey-pending-csv] Redis error:', err));
+  await client.connect();
+  return client;
+}
+
+function buildKey(projectId: number, sourcePublicId: string, userId: string): string {
+  return `survey:pending:${projectId}:${sourcePublicId}:${userId}`;
+}
+
+/**
+ * Stage raw CSV content in Redis with automatic TTL expiry.
+ */
+export async function stagePendingCsv(
+  projectId: number,
+  sourcePublicId: string,
+  userId: string,
+  csvContent: string,
+): Promise<void> {
+  const redis = await getClient();
+  const key = buildKey(projectId, sourcePublicId, userId);
+  await redis.set(key, csvContent, { EX: PENDING_CSV_TTL_SECONDS });
+}
+
+/**
+ * Retrieve staged CSV content. Returns null if expired or not found.
+ */
+export async function getPendingCsv(
+  projectId: number,
+  sourcePublicId: string,
+  userId: string,
+): Promise<string | null> {
+  const redis = await getClient();
+  const key = buildKey(projectId, sourcePublicId, userId);
+  return redis.get(key);
+}
+
+/**
+ * Delete staged CSV content immediately (on confirmation or cancellation).
+ */
+export async function deletePendingCsv(
+  projectId: number,
+  sourcePublicId: string,
+  userId: string,
+): Promise<void> {
+  const redis = await getClient();
+  const key = buildKey(projectId, sourcePublicId, userId);
+  await redis.del(key);
+}
+
+/**
+ * Check remaining TTL for a pending CSV key (for diagnostics/testing).
+ * Returns -2 if key doesn't exist, -1 if no TTL, otherwise seconds.
+ */
+export async function getPendingCsvTtl(
+  projectId: number,
+  sourcePublicId: string,
+  userId: string,
+): Promise<number> {
+  const redis = await getClient();
+  const key = buildKey(projectId, sourcePublicId, userId);
+  return redis.ttl(key);
+}
+
+/** Exported for testing. */
+export const STAGING_TTL_SECONDS = PENDING_CSV_TTL_SECONDS;
+
+/**
+ * Close the Redis client (for graceful shutdown / test cleanup).
+ */
+export async function closePendingCsvStore(): Promise<void> {
+  if (client && client.isOpen) {
+    await client.quit();
+    client = null;
+  }
+}

--- a/backend/src/helpers/survey/respondentIdentity.ts
+++ b/backend/src/helpers/survey/respondentIdentity.ts
@@ -1,0 +1,107 @@
+/**
+ * Respondent Identity — stable identification for survey respondents.
+ *
+ * Identity precedence:
+ *   1. Researcher-declared ID field (confirmed_role = 'id')
+ *   2. Generated stable key: SHA-256(source_content_hash + row_index)
+ *
+ * Generated identity is deterministic for identical source content
+ * regardless of which evidence_source record holds it. It does NOT
+ * depend on evidence_source.public_id (which can change across records).
+ *
+ * Human-facing labels (R001, R002) map to canonical keys but are NOT identity.
+ */
+
+import { createHash } from 'crypto';
+import type { ParsedSurvey, ConfirmedField, RespondentIdentity } from '../../types/survey';
+
+export class DuplicateRespondentIdError extends Error {
+  constructor(
+    public readonly duplicateValue: string,
+    public readonly rowIndices: number[],
+  ) {
+    super(`Duplicate respondent ID "${duplicateValue}" found at rows ${rowIndices.map(i => i + 2).join(', ')}`);
+    this.name = 'DuplicateRespondentIdError';
+  }
+}
+
+/**
+ * Assign canonical respondent identities to all survey rows.
+ *
+ * @param survey — parsed survey data
+ * @param confirmedFields — researcher-confirmed field schema
+ * @param sourceContentHash — SHA-256 of raw CSV content (for generated keys)
+ * @returns One RespondentIdentity per row, in order
+ * @throws DuplicateRespondentIdError if declared ID field has duplicates
+ */
+export function assignRespondentIdentities(
+  survey: ParsedSurvey,
+  confirmedFields: ConfirmedField[],
+  sourceContentHash: string,
+): RespondentIdentity[] {
+  const idField = confirmedFields.find(f => f.confirmedRole === 'id');
+
+  if (idField) {
+    return assignFromDeclaredId(survey, idField.fieldName);
+  }
+
+  return assignGeneratedKeys(survey, sourceContentHash);
+}
+
+function assignFromDeclaredId(
+  survey: ParsedSurvey,
+  idFieldName: string,
+): RespondentIdentity[] {
+  // Check for duplicates
+  const valuesToIndices = new Map<string, number[]>();
+  for (const row of survey.rows) {
+    const value = row.values[idFieldName]?.trim() || '';
+    if (!value) continue;
+    const existing = valuesToIndices.get(value) ?? [];
+    existing.push(row.rowIndex);
+    valuesToIndices.set(value, existing);
+  }
+
+  for (const [value, indices] of valuesToIndices) {
+    if (indices.length > 1) {
+      throw new DuplicateRespondentIdError(value, indices);
+    }
+  }
+
+  return survey.rows.map((row, i) => {
+    const declaredId = row.values[idFieldName]?.trim() || '';
+    return {
+      canonicalKey: declaredId || generateKey(sourceContentHashPlaceholder, row.rowIndex),
+      displayLabel: `R${String(i + 1).padStart(3, '0')}`,
+      source: declaredId ? 'declared' as const : 'generated' as const,
+      rowIndex: row.rowIndex,
+    };
+  });
+}
+
+// Placeholder — only used when a declared ID row has an empty value
+const sourceContentHashPlaceholder = 'no-declared-id-fallback';
+
+function assignGeneratedKeys(
+  survey: ParsedSurvey,
+  sourceContentHash: string,
+): RespondentIdentity[] {
+  return survey.rows.map((row, i) => ({
+    canonicalKey: generateKey(sourceContentHash, row.rowIndex),
+    displayLabel: `R${String(i + 1).padStart(3, '0')}`,
+    source: 'generated' as const,
+    rowIndex: row.rowIndex,
+  }));
+}
+
+/**
+ * Generate a stable deterministic respondent key.
+ * SHA-256(source_content_hash + ":" + row_index)
+ * Truncated to 16 hex chars for readability while retaining uniqueness.
+ */
+function generateKey(sourceContentHash: string, rowIndex: number): string {
+  return createHash('sha256')
+    .update(`${sourceContentHash}:${rowIndex}`)
+    .digest('hex')
+    .slice(0, 16);
+}

--- a/backend/src/helpers/survey/schemaInference.ts
+++ b/backend/src/helpers/survey/schemaInference.ts
@@ -1,0 +1,184 @@
+/**
+ * Schema Inference — heuristic field role detection for survey columns.
+ *
+ * No LLM. All inference is deterministic.
+ *
+ * Inference proposes candidate roles. Researchers must confirm via
+ * the schema review modal before computation proceeds.
+ *
+ * Ordinal inference requires researcher confirmation + explicit
+ * category order metadata before median computation is permitted.
+ */
+
+import type { ParsedSurvey, SurveyField, SurveyFieldRole } from '../../types/survey';
+
+const LIKERT_LABELS = new Set([
+  'strongly agree', 'agree', 'neutral', 'disagree', 'strongly disagree',
+  'very satisfied', 'satisfied', 'dissatisfied', 'very dissatisfied',
+  'very easy', 'easy', 'moderate', 'difficult', 'very difficult',
+  'excellent', 'good', 'fair', 'poor', 'very poor',
+  'always', 'often', 'sometimes', 'rarely', 'never',
+  'very likely', 'likely', 'unlikely', 'very unlikely',
+]);
+
+const TIMESTAMP_PATTERNS = [
+  /^\d{4}-\d{2}-\d{2}/,                      // 2026-01-15
+  /^\d{1,2}\/\d{1,2}\/\d{2,4}/,              // 1/15/2026
+  /^\d{1,2}-\w{3}-\d{2,4}/,                  // 15-Jan-2026
+  /^\w{3}\s+\d{1,2},?\s+\d{4}/,              // Jan 15, 2026
+];
+
+const ID_FIELD_NAMES = new Set([
+  'response_id', 'respondent_id', 'id', 'response id', 'respondent id',
+  'submission_id', 'entry_id', 'record_id', 'participant_id',
+]);
+
+const MAX_SAMPLE_VALUES = 5;
+
+/**
+ * Infer field roles for all columns in a parsed survey.
+ * Returns one SurveyField per header, in header order.
+ */
+export function inferFieldSchema(survey: ParsedSurvey): SurveyField[] {
+  return survey.headers.map(header => inferSingleField(header, survey));
+}
+
+function inferSingleField(fieldName: string, survey: ParsedSurvey): SurveyField {
+  const values = survey.rows.map(r => r.values[fieldName] ?? '');
+  const nonEmpty = values.filter(v => v.trim() !== '');
+  const presentCount = nonEmpty.length;
+  const missingCount = values.length - presentCount;
+  const distinctValues = new Set(nonEmpty.map(v => v.toLowerCase().trim()));
+  const distinctCount = distinctValues.size;
+
+  const sampleValues = [...new Set(nonEmpty)]
+    .slice(0, MAX_SAMPLE_VALUES);
+
+  const role = classifyField(fieldName, nonEmpty, distinctCount, survey.rowCount);
+
+  return {
+    fieldName,
+    inferredRole: role,
+    sampleValues,
+    distinctCount,
+    presentCount,
+    missingCount,
+  };
+}
+
+function classifyField(
+  fieldName: string,
+  nonEmptyValues: string[],
+  distinctCount: number,
+  totalRows: number,
+): SurveyFieldRole {
+  if (nonEmptyValues.length === 0) return 'nominal'; // all empty — default
+
+  const normalizedName = fieldName.toLowerCase().trim();
+
+  // 1. ID field — by name pattern
+  if (ID_FIELD_NAMES.has(normalizedName)) {
+    return 'id';
+  }
+
+  // 2. Timestamp — by value pattern
+  if (isTimestamp(nonEmptyValues)) {
+    return 'timestamp';
+  }
+
+  // 3. Ordinal — Likert labels
+  if (isLikertScale(nonEmptyValues)) {
+    return 'ordinal';
+  }
+
+  // 4. Ordinal — small integer range (1-5, 1-7, 1-10)
+  if (isSmallIntegerRange(nonEmptyValues)) {
+    return 'ordinal';
+  }
+
+  // 5. Continuous — mostly numeric, not a small range
+  if (isContinuous(nonEmptyValues)) {
+    return 'continuous';
+  }
+
+  // 6. Multi-select — contains delimiters (semicolons or pipes)
+  if (isMultiSelect(nonEmptyValues)) {
+    return 'multi_select';
+  }
+
+  // 7. Open text — high cardinality or long responses
+  if (isOpenText(nonEmptyValues, distinctCount, totalRows)) {
+    return 'open_text';
+  }
+
+  // 8. Default — nominal (low-cardinality categorical)
+  return 'nominal';
+}
+
+function isTimestamp(values: string[]): boolean {
+  const sampleSize = Math.min(values.length, 20);
+  const sample = values.slice(0, sampleSize);
+  const matches = sample.filter(v =>
+    TIMESTAMP_PATTERNS.some(p => p.test(v.trim()))
+  );
+  return matches.length >= sampleSize * 0.8;
+}
+
+function isLikertScale(values: string[]): boolean {
+  const normalized = values.map(v => v.toLowerCase().trim());
+  const matches = normalized.filter(v => LIKERT_LABELS.has(v));
+  return matches.length >= values.length * 0.8;
+}
+
+function isSmallIntegerRange(values: string[]): boolean {
+  const parsed = values.map(v => parseInt(v.trim(), 10));
+  const valid = parsed.filter(n => !isNaN(n));
+  if (valid.length < values.length * 0.8) return false;
+
+  const min = Math.min(...valid);
+  const max = Math.max(...valid);
+  const range = max - min;
+
+  // 1-5, 1-7, 1-10, 0-10 are typical Likert/ordinal ranges
+  return min >= 0 && max <= 10 && range >= 2 && range <= 10;
+}
+
+function isContinuous(values: string[]): boolean {
+  const parsed = values.map(v => parseFloat(v.trim()));
+  const valid = parsed.filter(n => !isNaN(n));
+  return valid.length >= values.length * 0.8;
+}
+
+function isMultiSelect(values: string[]): boolean {
+  const withDelimiters = values.filter(v =>
+    v.includes(';') || v.includes('|')
+  );
+  return withDelimiters.length >= values.length * 0.3;
+}
+
+function isOpenText(
+  values: string[],
+  distinctCount: number,
+  totalRows: number,
+): boolean {
+  // High cardinality: most values are unique
+  if (distinctCount > totalRows * 0.5) return true;
+
+  // Long responses: average word count > 5
+  const wordCounts = values.map(v => v.split(/\s+/).length);
+  const avgWordCount = wordCounts.reduce((a, b) => a + b, 0) / wordCounts.length;
+  return avgWordCount > 5;
+}
+
+/**
+ * Extract sorted unique values from a field, useful for ordinal
+ * category order detection.
+ */
+export function getUniqueValues(
+  survey: ParsedSurvey,
+  fieldName: string,
+): string[] {
+  const values = survey.rows.map(r => r.values[fieldName]?.trim() ?? '');
+  const nonEmpty = values.filter(v => v !== '');
+  return [...new Set(nonEmpty)];
+}

--- a/backend/src/helpers/survey/sourceHash.ts
+++ b/backend/src/helpers/survey/sourceHash.ts
@@ -1,0 +1,19 @@
+/**
+ * Source content hash — deterministic identity for survey files.
+ *
+ * SHA-256 of raw file content. Used for:
+ * - Idempotence: detect re-upload of identical file
+ * - Respondent identity: stable base for generated respondent keys
+ * - Evidence source versioning: same hash = same content
+ */
+
+import { createHash } from 'crypto';
+
+/**
+ * Compute SHA-256 hash of raw file content.
+ * Deterministic: same content always produces identical hash.
+ */
+export function computeContentHash(content: Buffer | string): string {
+  const buffer = typeof content === 'string' ? Buffer.from(content, 'utf-8') : content;
+  return createHash('sha256').update(buffer).digest('hex');
+}

--- a/backend/src/helpers/survey/statsEngine.ts
+++ b/backend/src/helpers/survey/statsEngine.ts
@@ -1,0 +1,296 @@
+/**
+ * Deterministic Statistics Engine — survey computed facts.
+ *
+ * All operations are pure functions on arrays. No randomness, no LLM.
+ * Same input always produces identical output (ADR 0028).
+ *
+ * Ordinal median requires confirmed_role='ordinal' AND order_metadata.
+ * Without confirmed order, ordinal fields are treated as nominal.
+ */
+
+import type {
+  ParsedSurvey,
+  ConfirmedField,
+  SurveyComputedFacts,
+  FieldStatSummary,
+  FieldStat,
+  CrossTab,
+} from '../../types/survey';
+
+/**
+ * Compute deterministic survey statistics from parsed data + confirmed schema.
+ *
+ * @param survey — parsed CSV data
+ * @param confirmedFields — researcher-confirmed field schema
+ * @param sourceContentHash — for provenance
+ * @returns SurveyComputedFacts — deterministic, reproducible
+ */
+export function computeSurveyFacts(
+  survey: ParsedSurvey,
+  confirmedFields: ConfirmedField[],
+  sourceContentHash: string,
+): SurveyComputedFacts {
+  const totalRespondents = survey.rowCount;
+  const fieldMap = new Map(confirmedFields.map(f => [f.fieldName, f]));
+
+  const schemaSummary: FieldStatSummary[] = [];
+  const fieldStats: FieldStat[] = [];
+
+  for (const field of confirmedFields) {
+    if (field.confirmedRole === 'id' || field.confirmedRole === 'timestamp') {
+      continue; // No statistics for ID or timestamp fields
+    }
+
+    const values = survey.rows.map(r => r.values[field.fieldName] ?? '');
+    const nonEmpty = values.filter(v => v.trim() !== '');
+    const nPresent = nonEmpty.length;
+    const nMissing = totalRespondents - nPresent;
+
+    schemaSummary.push({
+      fieldName: field.fieldName,
+      role: field.confirmedRole,
+      nPresent,
+      nMissing,
+    });
+
+    const stat = computeFieldStat(field, values, totalRespondents);
+    fieldStats.push(stat);
+  }
+
+  const crossTabs = computeCrossTabs(survey, confirmedFields);
+
+  return {
+    sourceContentHash,
+    totalRespondents,
+    schemaSummary,
+    fieldStats,
+    crossTabs,
+    nonresponseLimitation:
+      'Bare CSV cannot distinguish semantic missingness. Empty cells are reported as empty_or_missing without distinction between not_asked, no_response, or intentional blank.',
+  };
+}
+
+function computeFieldStat(
+  field: ConfirmedField,
+  values: string[],
+  totalRespondents: number,
+): FieldStat {
+  const nonEmpty = values.filter(v => v.trim() !== '');
+  const nPresent = nonEmpty.length;
+  const nMissing = totalRespondents - nPresent;
+
+  const base: FieldStat = {
+    fieldName: field.fieldName,
+    role: field.confirmedRole,
+    totalRespondents,
+    nPresent,
+    nMissing,
+    distribution: null,
+    median: null,
+    nValidNumeric: null,
+    nInvalidNumeric: null,
+  };
+
+  switch (field.confirmedRole) {
+    case 'ordinal':
+      return computeOrdinalStat(base, field, nonEmpty);
+    case 'nominal':
+      return computeNominalStat(base, nonEmpty);
+    case 'continuous':
+      return computeContinuousStat(base, nonEmpty);
+    case 'multi_select':
+      return computeNominalStat(base, nonEmpty); // Treat as nominal for now
+    case 'open_text':
+      return base; // No statistics for open text in Slice 1
+    default:
+      return base;
+  }
+}
+
+function computeOrdinalStat(
+  base: FieldStat,
+  field: ConfirmedField,
+  nonEmpty: string[],
+): FieldStat {
+  const distribution = computeDistribution(nonEmpty);
+  base.distribution = distribution;
+
+  // Median requires confirmed category order
+  if (field.orderMetadata && field.orderMetadata.length > 0) {
+    base.median = computeOrdinalMedian(nonEmpty, field.orderMetadata);
+  }
+  // Without orderMetadata, no median — field treated as nominal for statistics
+
+  return base;
+}
+
+function computeNominalStat(base: FieldStat, nonEmpty: string[]): FieldStat {
+  base.distribution = computeDistribution(nonEmpty);
+  return base;
+}
+
+function computeContinuousStat(base: FieldStat, nonEmpty: string[]): FieldStat {
+  const parsed = nonEmpty.map(v => ({ raw: v, num: parseFloat(v.trim()) }));
+  const valid = parsed.filter(p => !isNaN(p.num));
+  const invalid = parsed.filter(p => isNaN(p.num));
+
+  base.nValidNumeric = valid.length;
+  base.nInvalidNumeric = invalid.length;
+
+  if (valid.length > 0) {
+    const sorted = valid.map(v => v.num).sort((a, b) => a - b);
+    base.median = computeNumericMedian(sorted);
+  }
+
+  // Distribution for continuous: not computed (would require binning)
+  return base;
+}
+
+function computeDistribution(values: string[]): Record<string, number> {
+  const dist: Record<string, number> = {};
+  for (const v of values) {
+    const key = v.trim();
+    if (key === '') continue;
+    dist[key] = (dist[key] ?? 0) + 1;
+  }
+  return dist;
+}
+
+/**
+ * Compute median for ordinal field using researcher-confirmed category order.
+ * Returns the category value at the median position.
+ */
+function computeOrdinalMedian(values: string[], categoryOrder: string[]): string | null {
+  // Map values to their ordinal position
+  const orderMap = new Map(categoryOrder.map((cat, i) => [cat.toLowerCase().trim(), i]));
+
+  const indexed = values
+    .map(v => orderMap.get(v.toLowerCase().trim()))
+    .filter((i): i is number => i !== undefined);
+
+  if (indexed.length === 0) return null;
+
+  indexed.sort((a, b) => a - b);
+  const midIdx = Math.floor(indexed.length / 2);
+
+  if (indexed.length % 2 === 0) {
+    // For ordinal, use lower of the two middle values
+    const medianPosition = indexed[midIdx - 1];
+    return categoryOrder[medianPosition] ?? null;
+  }
+
+  return categoryOrder[indexed[midIdx]] ?? null;
+}
+
+/**
+ * Compute numeric median for continuous fields.
+ * Expects a pre-sorted array of numbers.
+ */
+function computeNumericMedian(sorted: number[]): number {
+  if (sorted.length === 0) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid];
+}
+
+/**
+ * Compute structured cross-tabs for applicable field pairs.
+ *
+ * Only computes cross-tabs between fields where both have confirmed
+ * roles that produce distributions (ordinal or nominal).
+ *
+ * Identifies completion/status and difficulty/satisfaction fields
+ * by name pattern matching against confirmed fields.
+ */
+function computeCrossTabs(
+  survey: ParsedSurvey,
+  confirmedFields: ConfirmedField[],
+): CrossTab[] {
+  const crossTabs: CrossTab[] = [];
+
+  const distributable = confirmedFields.filter(f =>
+    f.confirmedRole === 'ordinal' || f.confirmedRole === 'nominal'
+  );
+
+  // Find completion/status fields and rating fields by name pattern
+  const completionFields = distributable.filter(f =>
+    /complet|status|finish/i.test(f.fieldName)
+  );
+  const ratingFields = distributable.filter(f =>
+    /difficult|satisf|rating|experience/i.test(f.fieldName)
+  );
+
+  for (const rowField of completionFields) {
+    for (const colField of ratingFields) {
+      if (rowField.fieldName === colField.fieldName) continue;
+      const ct = computeSingleCrossTab(survey, rowField.fieldName, colField.fieldName);
+      crossTabs.push(ct);
+    }
+  }
+
+  return crossTabs;
+}
+
+function computeSingleCrossTab(
+  survey: ParsedSurvey,
+  rowFieldName: string,
+  colFieldName: string,
+): CrossTab {
+  const cells: Record<string, Record<string, number>> = {};
+  let totalN = 0;
+
+  for (const row of survey.rows) {
+    const rowVal = row.values[rowFieldName]?.trim() ?? '';
+    const colVal = row.values[colFieldName]?.trim() ?? '';
+
+    if (rowVal === '' || colVal === '') continue;
+
+    if (!cells[rowVal]) cells[rowVal] = {};
+    cells[rowVal][colVal] = (cells[rowVal][colVal] ?? 0) + 1;
+    totalN++;
+  }
+
+  return { rowField: rowFieldName, colField: colFieldName, cells, totalN };
+}
+
+/**
+ * Extract open-text content from parsed survey for LLM interpretation.
+ *
+ * Formats open-text fields with respondent display labels for the
+ * template's qualitative analysis section.
+ */
+export function extractOpenTextContent(
+  survey: ParsedSurvey,
+  confirmedFields: ConfirmedField[],
+  displayLabels: string[],
+): string {
+  const openTextFields = confirmedFields.filter(f => f.confirmedRole === 'open_text');
+
+  if (openTextFields.length === 0) {
+    return '(No open-text fields identified in survey schema.)';
+  }
+
+  const sections: string[] = [];
+
+  for (const field of openTextFields) {
+    const entries: string[] = [];
+    for (let i = 0; i < survey.rows.length; i++) {
+      const value = survey.rows[i].values[field.fieldName]?.trim() ?? '';
+      if (value) {
+        entries.push(`${displayLabels[i]}: "${value}"`);
+      }
+    }
+
+    if (entries.length > 0) {
+      sections.push(
+        `### ${field.fieldName}\n\n${entries.join('\n')}`
+      );
+    }
+  }
+
+  return sections.length > 0
+    ? sections.join('\n\n---\n\n')
+    : '(All open-text fields are empty.)';
+}

--- a/backend/src/types/survey.ts
+++ b/backend/src/types/survey.ts
@@ -1,0 +1,163 @@
+/**
+ * Survey domain types for Slice 1: structured CSV ingestion.
+ *
+ * These types define the boundary between the CSV parser, schema inference,
+ * stats engine, and evidence persistence. Parser-library-specific structures
+ * do not leak beyond csvParser.ts.
+ */
+
+// ═══════════════════════════════════════════════════════════════════════
+// FIELD ROLES
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * Supported survey field roles per discovery-survey-spec-rev3.
+ *
+ * - id: Respondent identifier
+ * - nominal: Unordered categorical (e.g., department, role)
+ * - ordinal: Ordered categorical (e.g., satisfaction scale) — requires confirmed order
+ * - continuous: Numeric measurement
+ * - multi_select: Comma-separated or delimited multi-choice
+ * - open_text: Free-text response
+ * - timestamp: Date/time value
+ */
+export type SurveyFieldRole =
+  | 'id'
+  | 'nominal'
+  | 'ordinal'
+  | 'continuous'
+  | 'multi_select'
+  | 'open_text'
+  | 'timestamp';
+
+// ═══════════════════════════════════════════════════════════════════════
+// PARSED SURVEY
+// ═══════════════════════════════════════════════════════════════════════
+
+/** Output of the CSV parser — library-independent representation. */
+export interface ParsedSurvey {
+  sourceFilename: string;
+  headers: string[];
+  rows: SurveyRow[];
+  rowCount: number;
+  parseWarnings: string[];
+}
+
+/** A single survey row keyed by header name. */
+export interface SurveyRow {
+  /** Values keyed by header name. Empty cells are empty strings. */
+  values: Record<string, string>;
+  /** 0-based index in the parsed output order (for respondent identity). */
+  rowIndex: number;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// SURVEY FIELD (schema inference output)
+// ═══════════════════════════════════════════════════════════════════════
+
+export interface SurveyField {
+  fieldName: string;
+  inferredRole: SurveyFieldRole;
+  /** First N non-empty distinct values for researcher review. */
+  sampleValues: string[];
+  distinctCount: number;
+  presentCount: number;
+  missingCount: number;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// CONFIRMED FIELD SCHEMA (after researcher review)
+// ═══════════════════════════════════════════════════════════════════════
+
+export interface ConfirmedField {
+  fieldName: string;
+  confirmedRole: SurveyFieldRole;
+  /** For ordinal fields: researcher-confirmed category order. */
+  orderMetadata: string[] | null;
+  /** Whether the field is demographic (for potential sample_demographics projection). */
+  isDemographic: boolean;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// RESPONDENT IDENTITY
+// ═══════════════════════════════════════════════════════════════════════
+
+export interface RespondentIdentity {
+  /** Canonical identity — either declared ID value or SHA-256 derived key. */
+  canonicalKey: string;
+  /** Human-facing label (R001, R002, etc.). Not identity. */
+  displayLabel: string;
+  /** Source of identity: 'declared' (from ID field) or 'generated' (hash-based). */
+  source: 'declared' | 'generated';
+  /** 0-based row index in parsed order. */
+  rowIndex: number;
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// NONRESPONSE
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * Observable cell states for bare CSV (no semantic missingness).
+ * Per discovery-survey-spec-rev3: bare CSV cannot distinguish why
+ * a value is absent.
+ */
+export type CellPresence = 'value_present' | 'empty_or_missing';
+
+// ═══════════════════════════════════════════════════════════════════════
+// COMPUTED FACTS (deterministic output)
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * SurveyComputedFacts — the typed boundary passed to survey_synthesis.
+ *
+ * Contains ONLY authoritative code-computed values per ADR 0028.
+ * No free-text analysis. No interpretive content.
+ * Same CSV + same schema = identical output (deterministic invariant).
+ */
+export interface SurveyComputedFacts {
+  /** Evidence source identity (content hash). */
+  sourceContentHash: string;
+  /** Total respondent count. */
+  totalRespondents: number;
+  /** Schema summary for template context. */
+  schemaSummary: FieldStatSummary[];
+  /** Per-field statistics (ordinal, nominal, continuous). */
+  fieldStats: FieldStat[];
+  /** Structured cross-tabulations. */
+  crossTabs: CrossTab[];
+  /** Nonresponse limitation note. */
+  nonresponseLimitation: string;
+}
+
+export interface FieldStatSummary {
+  fieldName: string;
+  role: SurveyFieldRole;
+  nPresent: number;
+  nMissing: number;
+}
+
+/** Per-field statistics — varies by role. */
+export interface FieldStat {
+  fieldName: string;
+  role: SurveyFieldRole;
+  totalRespondents: number;
+  nPresent: number;
+  nMissing: number;
+  /** Category distribution (ordinal/nominal). Keys are category values. */
+  distribution: Record<string, number> | null;
+  /** Median for ordinal (confirmed order) or continuous fields. */
+  median: string | number | null;
+  /** For continuous: count of valid numeric values. */
+  nValidNumeric: number | null;
+  /** For continuous: count of non-numeric/invalid values. */
+  nInvalidNumeric: number | null;
+}
+
+export interface CrossTab {
+  rowField: string;
+  colField: string;
+  /** row_value → col_value → count */
+  cells: Record<string, Record<string, number>>;
+  totalN: number;
+}

--- a/config/prompts/survey_synthesis.yaml
+++ b/config/prompts/survey_synthesis.yaml
@@ -4,7 +4,7 @@
 id: survey_synthesis
 name: survey_response_synthesizer
 label: "Survey Synthesis"
-version: "v7.1"
+version: "v8.0"
 
 description: |
   Analyze open-ended survey responses using thematic analysis.
@@ -54,6 +54,14 @@ input_variables:
     type: textarea
     required: true
     description: "What the researcher needs this source to tell them — how it relates to the project problem."
+  - name: computed_facts
+    type: object
+    required: false
+    description: "Deterministic statistics computed from CSV data by code (ADR 0028). When present, all numeric claims must come from this object."
+  - name: open_text_content
+    type: textarea
+    required: false
+    description: "Open-text survey responses extracted from CSV, formatted with respondent labels for qualitative analysis."
 
 # ═══════════════════════════════════════════════════════════
 # CASCADE CONTRACT
@@ -230,7 +238,25 @@ ai_generation_tasks:
       Analyze ALL open-ended/text responses. Skip closed-ended questions.
       {% endif %}
 
-      RULE 8: EMPTY CONTENT
+      RULE 8: NUMERIC AUTHORITY (ADR 0028)
+      {% if computed_facts %}
+      Every number you report (count, percentage, frequency, median, ratio)
+      must appear EXACTLY in the COMPUTED FACTS section below. You may:
+      - quote a computed fact verbatim
+      - express a computed count as a proportion ("12 of 47")
+      - describe a computed distribution in words
+
+      You must NOT:
+      - calculate a new number from computed facts
+      - round a computed number differently than provided
+      - introduce a count based on your own reading of responses
+      - estimate or approximate any quantity
+
+      If a numeric claim you want to make is not present in COMPUTED FACTS,
+      state the qualitative observation without a number.
+      {% endif %}
+
+      RULE 9: EMPTY CONTENT
       If the survey data between BEGIN/END markers is empty or contains no
       text responses, respond ONLY with:
       "> **No survey responses provided.** Please upload survey data and try again."
@@ -245,9 +271,33 @@ ai_generation_tasks:
       **Focus Questions:** {{question_focus}}
       {% endif %}
 
-      **Survey Data:**
+      {% if computed_facts %}
+      ============================================================
+      COMPUTED FACTS (authoritative — do not recalculate)
+      ============================================================
+
+      Total respondents: {{computed_facts.totalRespondents}}
+
+      Field statistics:
+      {% for stat in computed_facts.fieldStats %}
+      - {{stat.fieldName}} ({{stat.role}}): {{stat.nPresent}} present, {{stat.nMissing}} missing{% if stat.median %}, median: {{stat.median}}{% endif %}{% if stat.distribution %}, distribution: {{stat.distribution}}{% endif %}
+      {% endfor %}
+
+      {% if computed_facts.crossTabs %}
+      Cross-tabulations:
+      {% for ct in computed_facts.crossTabs %}
+      - {{ct.rowField}} × {{ct.colField}} (n={{ct.totalN}}): {{ct.cells}}
+      {% endfor %}
+      {% endif %}
+
+      Note: {{computed_facts.nonresponseLimitation}}
+
+      ============================================================
+      {% endif %}
+
+      **Survey Data (open-text responses for qualitative analysis):**
       ---BEGIN DATA---
-      {{combined_file_content}}
+      {% if open_text_content %}{{open_text_content}}{% else %}{{combined_file_content}}{% endif %}
       ---END DATA---
 
       ============================================================
@@ -360,7 +410,7 @@ ai_generation_tasks:
 
       **Survey Data:**
       ---BEGIN DATA---
-      {{combined_file_content}}
+      {% if open_text_content %}{{open_text_content}}{% else %}{{combined_file_content}}{% endif %}
       ---END DATA---
 
       ============================================================

--- a/docs/decisions/survey-slice1-implementation.md
+++ b/docs/decisions/survey-slice1-implementation.md
@@ -18,13 +18,27 @@ Excel support removed from survey upload modal. CSV only for Slice 1.
 
 **Record:** Filetypes changed from `["csv", "xlsx", "xls"]` to `["csv"]` in both the modal definition and the DISCOVERY_TYPES config.
 
-## Schema Inference Requires Researcher Review
+## Schema Inference Requires Complete Researcher Review
 
 Field roles are inferred by heuristic, never declared authoritative without confirmation.
 
+**Complete review enforced:** ALL fields must be reviewed before computation proceeds. Surveys with >100 columns are rejected with a clear message. Surveys with 21-100 columns use paginated schema review (20 fields per page, multiple pages). No unreviewed inferred role becomes authoritative.
+
 **Heuristic categories:** id (by field name pattern), ordinal (Likert labels or small integer range), nominal (low cardinality), continuous (mostly numeric), open_text (high cardinality or long), timestamp (date patterns), multi_select (delimiter patterns).
 
-**Ordinal gate:** No ordinal median computed without confirmed role AND confirmed category order metadata. Missing order = treated as nominal (distribution only, no median).
+## Ordinal Fields Require Explicit Category Order
+
+**Rule:** No ordinal median computed without BOTH:
+1. Researcher confirms `confirmed_role = 'ordinal'`
+2. Researcher provides/confirms explicit category order via pipe-separated text input
+
+Appearance order, lexical order, and numeric-looking values are NOT treated as authoritative ordering without researcher confirmation.
+
+For numeric ordinal scales (e.g., 1-5), Qori proposes the detected values but the researcher must explicitly confirm.
+
+If an ordinal field has no confirmed order, it is treated as nominal for statistics: distribution is shown, but median is NOT computed.
+
+**Validation:** The confirmed order must include ALL observed non-missing category values. Duplicate categories fail. Incomplete orders fail.
 
 ## Bare CSV Missingness Limitations
 
@@ -32,9 +46,21 @@ Two observable states only: `value_present`, `empty_or_missing`.
 
 No semantic missingness (`not_asked`, `no_response`, `blank`) — bare CSV cannot distinguish why a value is absent. The nonresponse limitation is documented in SurveyComputedFacts and rendered in the output.
 
-## Pending CSV Storage: Quarantine Pattern
+## Pending CSV Storage: Redis with TTL
 
-Staged CSV text stored in `survey_field_schemas.pending_csv_content` TEXT column, following the `study_notes.pending_content` quarantine pattern. Cleared to NULL on schema confirmation. PII-bearing during its lifetime (survey CSVs may contain respondent names/emails); no PII persists beyond the review step.
+**Corrected from initial design.** Raw CSV staging uses Redis with automatic TTL expiry, NOT a Postgres column.
+
+**TTL:** 2 hours. Schema review typically happens immediately after upload; 2 hours provides margin for researcher interruptions without retaining PII-bearing content indefinitely.
+
+**Key format:** `survey:pending:{projectId}:{sourcePublicId}:{userId}`
+
+**Lifecycle:**
+- Upload → `Redis SET` with TTL
+- Schema confirmation → `Redis DEL` immediately
+- TTL reached → automatic deletion (no orphan data)
+- Expired review → clear error asking researcher to re-upload
+
+**PII implications:** Survey CSVs may contain respondent names/emails. The TTL guarantees automatic deletion even if the researcher never completes review. On confirmation, content is deleted immediately. No PII persists beyond the staging window. Staged content is NOT exposed to /qori-ask, study_variables, generated artifacts, model prompts, or evidence metadata.
 
 ## Deterministic Facts in Evidence Layer
 
@@ -42,7 +68,7 @@ Survey constructs use `derivation_type: 'deterministic'` and `status: 'accepted'
 
 ## No Cascade Projection in Slice 1
 
-No evidence constructs are projected into study_variables. `sample_demographics` is NOT auto-projected because `total_responses` alone is not demographic information. The LLM may still extract cascade variables from rendered prose (existing behavior).
+No evidence constructs are projected into study_variables. `sample_demographics` is NOT auto-projected because `total_responses` alone is not demographic information — projection requires researcher-confirmed genuinely demographic fields matching the cascade schema semantics. The LLM may still extract cascade variables from rendered prose (existing behavior).
 
 ## Qualitative Coding Deferred to Slice 2
 

--- a/docs/decisions/survey-slice1-implementation.md
+++ b/docs/decisions/survey-slice1-implementation.md
@@ -1,0 +1,49 @@
+# Survey Slice 1 Implementation Decisions
+
+Date: 2026-08-15
+
+## Parser Choice: csv-parse
+
+**Selected:** `csv-parse` v7 (npm `csv-parse`)
+
+**Why:** Server-side Node.js library with RFC 4180 compliance. Handles quoted fields, embedded newlines, escaped quotes, BOM, and delimiter detection. Synchronous API (`csv-parse/sync`) guarantees deterministic output. Well-maintained (part of the csv ecosystem). No browser-only dependencies.
+
+**Rejected:** `papaparse` (primarily browser-focused, Node support is secondary), hand-rolled parser (RFC compliance is non-trivial), `fast-csv` (less RFC-complete quoted field handling).
+
+## XLS/XLSX Intentionally Disabled
+
+Excel support removed from survey upload modal. CSV only for Slice 1.
+
+**Why:** The backend returned placeholder text for Excel files — accepting them in the UI while silently not parsing them was unsafe. Adding an Excel dependency (e.g., `xlsx`, `exceljs`) is not justified until researcher demand is confirmed. CSV is the universal survey export format.
+
+**Record:** Filetypes changed from `["csv", "xlsx", "xls"]` to `["csv"]` in both the modal definition and the DISCOVERY_TYPES config.
+
+## Schema Inference Requires Researcher Review
+
+Field roles are inferred by heuristic, never declared authoritative without confirmation.
+
+**Heuristic categories:** id (by field name pattern), ordinal (Likert labels or small integer range), nominal (low cardinality), continuous (mostly numeric), open_text (high cardinality or long), timestamp (date patterns), multi_select (delimiter patterns).
+
+**Ordinal gate:** No ordinal median computed without confirmed role AND confirmed category order metadata. Missing order = treated as nominal (distribution only, no median).
+
+## Bare CSV Missingness Limitations
+
+Two observable states only: `value_present`, `empty_or_missing`.
+
+No semantic missingness (`not_asked`, `no_response`, `blank`) — bare CSV cannot distinguish why a value is absent. The nonresponse limitation is documented in SurveyComputedFacts and rendered in the output.
+
+## Pending CSV Storage: Quarantine Pattern
+
+Staged CSV text stored in `survey_field_schemas.pending_csv_content` TEXT column, following the `study_notes.pending_content` quarantine pattern. Cleared to NULL on schema confirmation. PII-bearing during its lifetime (survey CSVs may contain respondent names/emails); no PII persists beyond the review step.
+
+## Deterministic Facts in Evidence Layer
+
+Survey constructs use `derivation_type: 'deterministic'` and `status: 'accepted'` (auto-accepted because they are code-computed, not model-interpreted). Three construct types: `survey_dataset_summary`, `field_distribution`, `cross_tab`.
+
+## No Cascade Projection in Slice 1
+
+No evidence constructs are projected into study_variables. `sample_demographics` is NOT auto-projected because `total_responses` alone is not demographic information. The LLM may still extract cascade variables from rendered prose (existing behavior).
+
+## Qualitative Coding Deferred to Slice 2
+
+No codebook generation, model coding, theme/category frequency from open-text, coding audit trail, or coded cross-tabs. Open-text content is passed to the LLM for qualitative interpretation only.

--- a/docs/methodology/discovery-survey-spec-rev3.md
+++ b/docs/methodology/discovery-survey-spec-rev3.md
@@ -1,0 +1,132 @@
+# Discovery Survey Methodology Specification — Revision 3
+
+## Overview
+
+Survey synthesis is a discovery workflow that analyzes survey response data to identify themes, findings, barriers, and knowledge gaps. It feeds into downstream research briefs and plans via the cascade variable system.
+
+The survey methodology distinguishes between structured (quantitative) and qualitative analysis. Structured analysis is deterministic and code-computed. Qualitative analysis (theme identification, sentiment interpretation) involves model-assisted generation with researcher oversight.
+
+## Principles
+
+1. **Structured data is not raw LLM context.** The LLM must not parse CSV structure or compute authoritative numbers. Code owns headers, rows, respondent identity, field roles, counts, distributions, medians, and cross-tabs.
+
+2. **Deterministic transformations occur outside the generative model (ADR 0028).** Same CSV + same accepted schema = identical structured facts. No randomness, no model-dependent variation in quantitative output.
+
+3. **Schema inference requires researcher review.** Heuristic classification is a candidate, not a decision. Researchers confirm or correct every field role before computation proceeds.
+
+4. **Ordinal computation requires explicit confirmed order.** Appearance order, lexical order, and numeric-looking values are not authoritative ordering without researcher confirmation.
+
+5. **Bare CSV cannot distinguish semantic missingness.** Two observable states: value_present, empty_or_missing. Reserved states (not_asked, no_response, blank, uncodable) require metadata not present in bare CSV exports.
+
+## Slices
+
+### Slice 1: Structured Ingestion + Deterministic Facts
+
+**Scope:**
+
+- CSV upload and parsing (RFC-compliant, csv-parse)
+- Field schema inference with complete researcher review
+- Deterministic statistics: distributions, medians, completion splits, cross-tabs
+- Evidence persistence: source → constructs → lineage
+- Computed facts injected into template; LLM interprets only
+- Redis-based temporary CSV staging with automatic TTL expiry
+
+**Field Roles:**
+
+| Role | Meaning |
+|------|---------|
+| id | Respondent identifier |
+| nominal | Unordered categorical (e.g., department, role) |
+| ordinal | Ordered categorical (e.g., satisfaction scale, difficulty rating) |
+| continuous | Numeric measurement |
+| multi_select | Comma-separated or delimited multi-choice |
+| open_text | Free-text response |
+| timestamp | Date/time value |
+
+**Deterministic Measures:**
+
+- Per-field: total respondents, n present, n missing
+- Ordinal (confirmed order): distribution by category, median using confirmed order
+- Ordinal (no confirmed order): distribution only, NO median
+- Nominal: distribution by category
+- Continuous: n valid numeric, n invalid, median
+- Cross-tabs: completion × difficulty, completion × satisfaction (counts only)
+- No means for ordinal fields
+- No inferential statistics
+- Percentages retain numerator + denominator when computed
+
+**Explicitly Excluded from Slice 1:**
+
+- Free-text coding and codebooks
+- Theme/category frequency from open-text analysis
+- Coded challenge cross-tabs
+- Researcher coding review/adjudication
+- Sentiment classification of open-text responses
+- Recurring pattern promotion
+- XLS/XLSX ingestion
+
+### Slice 2: Qualitative Coding + Adjudication (NOT BUILT)
+
+**Planned scope:**
+
+- Codebook generation from open-text responses
+- Model-assisted coding with researcher review
+- Theme frequency from coded responses
+- Coded challenge × completion cross-tabs
+- Coding audit trail
+- Researcher adjudication workflow (accept/reject/override)
+
+### Nonresponse Semantics
+
+**Slice 1 (bare CSV):**
+
+| State | Meaning |
+|-------|---------|
+| value_present | Cell contains a non-empty value |
+| empty_or_missing | Cell is empty or whitespace-only; reason unknown |
+
+**Future (metadata-aware):**
+
+| State | Meaning |
+|-------|---------|
+| not_asked | Question was not presented to this respondent |
+| no_response | Question was presented but respondent did not answer |
+| blank | Respondent submitted an empty response |
+| uncodable | Response exists but cannot be categorized (Slice 2 coding judgment) |
+
+### Respondent Identity
+
+**Precedence:**
+1. Researcher-declared ID field (confirmed_role = 'id')
+2. Generated stable key: SHA-256(source_content_hash + row_index)
+
+Generated identity is deterministic for identical source content regardless of which evidence_source record holds it.
+
+Human-facing labels (R001, R002) are presentation references, not canonical identity.
+
+### Source Versioning
+
+- SHA-256 of raw CSV buffer content
+- Same project + identical hash = eligible to reuse accepted schema (if complete and all fields confirmed)
+- Changed content = new source version requiring new review
+
+### Evidence Persistence
+
+Survey constructs:
+- `survey_dataset_summary` — overall survey statistics
+- `field_distribution` — per-field distribution
+- `cross_tab` — cross-tabulation result
+
+All: `derivation_type: 'deterministic'`, `status: 'accepted'`
+
+Linked to evidence_source via `DERIVED_FROM` relationship.
+
+### Cascade Integration
+
+Slice 1 produces zero study_variables projections from the evidence layer. `sample_demographics` is NOT auto-projected because `total_responses` alone is not demographic information. Projection requires researcher-confirmed genuinely demographic fields matching cascade schema semantics.
+
+The LLM may still extract cascade variables (survey_themes, survey_findings, discovered_barriers, etc.) from rendered template prose — that existing extraction path is unchanged.
+
+### Excel Support
+
+Intentionally disabled for Slice 1. CSV only. Excel support will be added when an XLSX parsing dependency is justified by researcher demand and a proper ingestion path is implemented.

--- a/docs/roadmaps/qori-consolidated-roadmap.md
+++ b/docs/roadmaps/qori-consolidated-roadmap.md
@@ -1,0 +1,60 @@
+# Qori Consolidated Roadmap
+
+Last updated: 2026-08-15
+
+## Evidence + Context Architecture
+
+| Phase | Status | Reference |
+|-------|--------|-----------|
+| Evidence foundation (tables, services, ADRs 0028-0031) | BUILT + VERIFIED IN DEV | PR #278 |
+| Survey deterministic ingestion (CSV parse, schema review, stats, evidence) | IMPLEMENTED IN PR #279 / AWAITING DEV VERIFICATION | PR #279 |
+| Survey qualitative coding + adjudication (codebooks, theme frequency, coding audit) | NOT BUILT / NEXT SURVEY SLICE | |
+| XLS/XLSX survey ingestion | DISABLED until proper ingestion exists | |
+| `/qori-ask` — evidence-backed research queries | NOT BUILT; evidence foundation intended to support it later | |
+| Staleness detection | NOT BUILT; deferred until evidence graph is populated | |
+| Discovery Cycle 2 — stakeholder guide | NOT BUILT | |
+| Session nugget → evidence migration | NOT BUILT | |
+| Affinity rewrite | NOT BUILT | |
+| Personas rewrite | NOT BUILT | |
+| Service blueprint rewrite | NOT BUILT | |
+| Readout rewrite | NOT BUILT | |
+| GitHub ticket lineage | NOT BUILT | |
+
+## Existing Systems (Operational)
+
+| System | Status |
+|--------|--------|
+| `/qori-start` project creation + GitHub scaffolding | Operational |
+| Discovery workflows (desk research, stakeholder synthesis, survey synthesis) | Operational |
+| Research brief / plan / guide generation | Operational |
+| Session notes / transcript workflows | Operational |
+| Analysis methods (affinity, personas, usability, etc.) | Operational |
+| Readouts (research, engineering, leadership, etc.) | Operational |
+| GitHub ticket creation | Operational |
+| Outreach generation | Operational |
+| Participant tracking | Operational |
+| Admin center | Operational |
+| PII review / disposition infrastructure | Operational |
+| Cascade variable system (study_variables) | Operational |
+| YAML consumes / emits / GET / CCA architecture | Operational |
+| Dev → production deployment flow (Railway) | Operational |
+
+## Four Cooperating Planes
+
+The architecture is organized into four planes:
+
+1. **Research Evidence Plane** — authoritative research state: sources, observations, constructs, findings, recommendations, evidence relationships, derivation metadata, review/adjudication state, provenance, method/version
+2. **Contextual Cascade Plane (GET/CCA)** — existing contextual propagation: consumes, asks, commits, emits, destination-specific transformation, artifact generation, downstream accumulation
+3. **Participant Operations Plane** — operational participant state: outreach, recruitment, participant tracker, scheduling/session assignment, participation status, participant codes
+4. **Governance / Control Plane** — PII review, approval/disposition, authorization, admin center, audit, deletion/DSAR, lifecycle/environment controls
+
+## Federal Readiness
+
+| Area | Status |
+|------|--------|
+| NARA-compliant disposition audit logging (ADR 0025) | Operational |
+| PII scrubbing at ingestion (ADR 0026) | Operational |
+| Owner-gated deletion with retention schedules | Operational |
+| Legal holds | Operational |
+| DSAR compliance | Operational |
+| Section 508 accessibility | Ongoing |


### PR DESCRIPTION
## Why

Survey synthesis currently accepts CSV uploads but returns placeholder text — the LLM does all counting, categorization, and statistics. This violates ADR 0028 (deterministic transformations outside generative models). Researchers need accurate, reproducible numeric facts.

## What

### Structured CSV ingestion
- `csv-parse` dependency for RFC-compliant CSV parsing
- Schema inference heuristics (id, ordinal, nominal, continuous, open_text, timestamp)
- Two-phase Slack flow: upload → DM with "Review Schema" button → schema review modal → compute
- Respondent identity: declared ID field > generated SHA-256(content_hash + row_index)
- Source content hash for idempotence (same file = reuse accepted schema)

### Deterministic statistics (ADR 0028)
- Ordinal distributions + median (only with confirmed order metadata)
- Nominal distributions
- Continuous median + valid/invalid counts
- Structured cross-tabs (completion × difficulty, completion × satisfaction)
- SurveyComputedFacts typed contract — same CSV + same schema = identical output

### Evidence persistence (ADRs 0029-0030)
- evidence_source for survey dataset (with content hash)
- survey_dataset_summary, field_distribution, cross_tab constructs
- Source → construct lineage via FK-backed relationships
- All constructs: derivation_type=deterministic, status=accepted

### Template contract (survey_synthesis.yaml v8.0)
- NUMERIC AUTHORITY rule: model may only report numbers from computed_facts
- COMPUTED FACTS section injected above survey data
- Open-text content replaces raw CSV for qualitative analysis
- Backward compatible: falls back to combined_file_content when absent

### Schema persistence
- survey_field_schemas table (FK to evidence_sources, CASCADE)
- pending_csv_content TEXT column (quarantine pattern per study_notes)
- One row per field per source, with inferred/confirmed roles

## What this does NOT change

- No qualitative coding/codebooks (Slice 2)
- No XLS/XLSX support (intentionally removed — CSV only)
- No cascade projection (no sample_demographics auto-projection)
- No existing workflow changes for desk research or stakeholder synthesis
- No study_variables migration
- No /qori-ask
- No staleness behavior

## Migration behavior

- Additive: 1 new table (survey_field_schemas)
- FK to evidence_sources (CASCADE)
- Reversible down()
- No existing data rewrite

## Verification

- **Typecheck:** clean
- **Unit tests:** 202 passed (43 new survey tests)
- **Integration tests:** 242 passed (10 new survey evidence tests)
- **Pattern enforcement:** any budget passes (zero new any in production code)
- **Determinism test:** same CSV run 3x = identical SurveyComputedFacts

## Test plan

- [x] Typecheck passes
- [x] Unit tests pass (parser, inference, identity, stats)
- [x] Integration tests pass (evidence, schema, lineage, determinism)
- [x] Pattern enforcement passes
- [x] Determinism invariant verified
- [ ] CI pipeline green
- [ ] Manual Slack-dev test after merge (script to be provided)

🤖 Generated with [Claude Code](https://claude.com/claude-code)