### PR TITLE
fix(survey): pre-main microfix — prevalence, theme terminology, provenance

### DIFF
--- a/backend/src/__tests__/unit/survey/v9Contract.test.ts
+++ b/backend/src/__tests__/unit/survey/v9Contract.test.ts
@@ -317,6 +317,44 @@ describe('Method & Provenance display labels', () => {
   });
 });
 
+describe('pre-main prevalence hardening', () => {
+  const yaml = readFileSync(YAML_PATH, 'utf-8');
+
+  it('prohibits "at least some respondents"', () => {
+    expect(yaml).toContain('"at least some respondents,"');
+  });
+
+  it('prohibits "for at least some respondents"', () => {
+    expect(yaml).toContain('"for at least some respondents,"');
+  });
+
+  it('prohibits "for some respondents"', () => {
+    expect(yaml).toContain('"for some respondents,"');
+  });
+});
+
+describe('theme terminology prohibition', () => {
+  const yaml = readFileSync(YAML_PATH, 'utf-8');
+
+  it('qualitative prompt prohibits "theme/themes" for groupings', () => {
+    expect(yaml).toContain('Do not use "theme" or "themes" to describe qualitative');
+  });
+
+  it('qualitative prompt prohibits "friction themes"', () => {
+    expect(yaml).toContain('"friction themes,"');
+  });
+
+  it('evidence-gap prompt prohibits "theme/themes"', () => {
+    // The evidence_gaps task should also prohibit "theme"
+    expect(yaml).toContain('Do not use "theme" or "themes" to describe qualitative groupings');
+  });
+
+  it('suggests replacement terminology', () => {
+    expect(yaml).toContain('observation');
+    expect(yaml).toContain('preliminary grouping');
+  });
+});
+
 describe('determinism', () => {
   it('3 runs identical', () => {
     const r1 = computeStandardFacts();

--- a/backend/src/helpers/slack/commands/surveySubmissionHandler.ts
+++ b/backend/src/helpers/slack/commands/surveySubmissionHandler.ts
@@ -662,8 +662,8 @@ async function executeSurveyAnalysis(
       ).join(', '),
       ordinal_orders: ordinalFields.length > 0
         ? ordinalFields.map(f =>
-            `**${toDisplayLabel(f.fieldName)}**\n> ${f.orderMetadata!.join(' → ')}`
-          ).join('\n>\n')
+            `>\n> **${toDisplayLabel(f.fieldName)}**\n>\n> ${f.orderMetadata!.join(' → ')}`
+          ).join('\n')
         : 'No ordinal fields confirmed',
       model_used: process.env.ANTHROPIC_MODEL_NAME || 'claude-sonnet-4-6',
     };

--- a/config/prompts/survey_synthesis.yaml
+++ b/config/prompts/survey_synthesis.yaml
@@ -150,6 +150,8 @@ ai_generation_tasks:
         - Assign prevalence ("most respondents," "X of N," "60%")
         - Use ANY soft prevalence language, including but not limited to:
           "some respondents," "some participants," "some entries,"
+          "at least some respondents," "at least some participants,"
+          "for some respondents," "for at least some respondents,"
           "several respondents," "several participants,"
           "many respondents," "many participants,"
           "a recurring concern," "recurring pattern,"
@@ -157,10 +159,14 @@ ai_generation_tasks:
           "commonly," "frequently," "often,"
           "a small number," "a majority," "most respondents,"
           "predominant," "widespread"
-        - Claim themes (no "Theme 1," no "three themes emerged")
+        - Use the word "theme" or "themes" to describe qualitative
+          groupings. Before formal coding, use: "observation,"
+          "preliminary grouping," "category," "type," or "topic."
+          Reserve "theme/themes" for accepted coded analysis.
+        - Claim themes (no "Theme 1," no "three themes emerged,"
+          no "friction themes," no "distinct themes")
         - Perform sentiment classification or distribution
         - Produce frequency tables, sentiment tables, or coded counts
-        - Use the word "theme" to describe your groupings
 
       RULE 3 — RESPONDENT TERMINOLOGY
       The reporting unit is the unique respondent. Never count text
@@ -302,6 +308,11 @@ ai_generation_tasks:
         - Generic research-practice observations
         - Product actions, feature changes, or design implementations
         - Structured distributions that ARE available (see above)
+
+      RULE 3 — TERMINOLOGY
+      Do not use "theme" or "themes" to describe qualitative groupings.
+      Use: "observation types," "qualitative categories," "friction
+      types," "preliminary groupings."
 
       ============================================================
       OUTPUT FORMAT


### PR DESCRIPTION
Final pre-main corrections from smoke test.

1. **Prevalence hardening:** "at least some respondents," "for some respondents" added to prohibition list
2. **Theme terminology:** "theme/themes" prohibited for uncoded qualitative groupings in both AI tasks. Use: "observation types," "friction types," "preliminary groupings"
3. **Provenance rendering:** ordinal scales on separate blockquoted lines with display label headings

7 new contract tests. Unit: 275 | Integration: 244 | All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)