### PR TITLE
fix(survey): auto-scrub entries, fix review pagination, compact privacy UX

### DIFF
--- a/backend/src/__tests__/unit/survey/entryScrubber.test.ts
+++ b/backend/src/__tests__/unit/survey/entryScrubber.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Entry Scrubber tests — deterministic PII pattern detection.
+ */
+
+import { scrubEntryText, verifyRedactionConsistency } from '../../../helpers/survey/entryScrubber';
+
+describe('scrubEntryText', () => {
+  it('scrubs phone number → [PHONE]', () => {
+    const result = scrubEntryText('Please call me at 555-867-5309 if you need more detail.');
+    expect(result.scrubbedText).toContain('[PHONE]');
+    expect(result.scrubbedText).not.toContain('555-867-5309');
+    expect(result.detections.phoneCount).toBe(1);
+    expect(result.hasDetections).toBe(true);
+  });
+
+  it('scrubs email → [EMAIL]', () => {
+    const result = scrubEntryText('Email me at veteran.smoketest@example.com for details.');
+    expect(result.scrubbedText).toContain('[EMAIL]');
+    expect(result.scrubbedText).not.toContain('veteran.smoketest@example.com');
+    expect(result.detections.emailCount).toBe(1);
+    expect(result.hasDetections).toBe(true);
+  });
+
+  it('scrubs both phone and email', () => {
+    const result = scrubEntryText('Call 555-867-5309 or email test@example.com');
+    expect(result.scrubbedText).toContain('[PHONE]');
+    expect(result.scrubbedText).toContain('[EMAIL]');
+    expect(result.detections.phoneCount).toBe(1);
+    expect(result.detections.emailCount).toBe(1);
+  });
+
+  it('returns unchanged text when no patterns found', () => {
+    const result = scrubEntryText('The form was confusing and I gave up.');
+    expect(result.scrubbedText).toBe('The form was confusing and I gave up.');
+    expect(result.hasDetections).toBe(false);
+    expect(result.detections.phoneCount).toBe(0);
+    expect(result.detections.emailCount).toBe(0);
+  });
+
+  it('detectedValues contains original matched strings', () => {
+    const result = scrubEntryText('Call 555-867-5309');
+    expect(result.detectedValues).toContain('555-867-5309');
+  });
+
+  it('handles parenthesized phone numbers', () => {
+    const result = scrubEntryText('My number is (555) 867-5309.');
+    expect(result.scrubbedText).toContain('[PHONE]');
+    expect(result.scrubbedText).not.toContain('867-5309');
+  });
+});
+
+describe('verifyRedactionConsistency', () => {
+  it('returns true when no detected values appear in redacted text', () => {
+    expect(verifyRedactionConsistency(
+      'Call [PHONE] for details',
+      ['555-867-5309'],
+    )).toBe(true);
+  });
+
+  it('returns false when detected value still appears', () => {
+    expect(verifyRedactionConsistency(
+      'Call 555-867-5309 for details', // scrubbing failed
+      ['555-867-5309'],
+    )).toBe(false);
+  });
+
+  it('returns true when no values were detected', () => {
+    expect(verifyRedactionConsistency('Clean text', [])).toBe(true);
+  });
+});
+
+describe('qualitative entry scrubbing integration', () => {
+  it('entry_text remains original, redacted_text contains scrubbed derivative', () => {
+    const originalText = 'Please call me at 555-867-5309 if you need more detail about my experience.';
+    const result = scrubEntryText(originalText);
+
+    // entry_text would be the original
+    expect(originalText).toContain('555-867-5309');
+
+    // redacted_text would be the scrubbed version
+    expect(result.scrubbedText).not.toContain('555-867-5309');
+    expect(result.scrubbedText).toContain('[PHONE]');
+
+    // Detection metadata
+    expect(result.hasDetections).toBe(true);
+    expect(result.detections.phoneCount).toBe(1);
+  });
+});

--- a/backend/src/__tests__/unit/survey/entryScrubber.test.ts
+++ b/backend/src/__tests__/unit/survey/entryScrubber.test.ts
@@ -69,6 +69,17 @@ describe('verifyRedactionConsistency', () => {
   });
 });
 
+describe('shared pattern equivalence', () => {
+  it('survey scrubber uses same patterns as transcript scrubber', () => {
+    // Both paths use piiPatterns.ts — verify equivalent behavior
+    const surveyResult = scrubEntryText('Call 555-867-5309 or email test@va.gov');
+    // The same patterns produce the same substitutions
+    expect(surveyResult.scrubbedText).toBe('Call [PHONE] or email [EMAIL]');
+    expect(surveyResult.detections.phoneCount).toBe(1);
+    expect(surveyResult.detections.emailCount).toBe(1);
+  });
+});
+
 describe('qualitative entry scrubbing integration', () => {
   it('entry_text remains original, redacted_text contains scrubbed derivative', () => {
     const originalText = 'Please call me at 555-867-5309 if you need more detail about my experience.';

--- a/backend/src/helpers/piiPatterns.ts
+++ b/backend/src/helpers/piiPatterns.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared PII detection patterns — canonical deterministic rules.
+ *
+ * Used by both transcript scrubber and survey entry scrubber.
+ * One implementation, one set of patterns.
+ *
+ * These patterns detect STRUCTURED PII only. Incidental PII
+ * (names mentioned in conversation, locations, health details)
+ * requires human review — these patterns cannot detect it.
+ */
+
+// Phone: various US formats
+// - XXX-XXX-XXXX, (XXX) XXX-XXXX, XXX.XXX.XXXX (10 digit)
+// - XXX-XXXX (7 digit local)
+export const PHONE_PATTERN_10 = /\b(?:\+?1[-.\s]?)?\(?[0-9]{3}\)?[-.\s]?[0-9]{3}[-.\s]?[0-9]{4}\b/g;
+export const PHONE_PATTERN_7 = /\b[0-9]{3}[-.\s]?[0-9]{4}\b/g;
+
+// Email: standard format
+export const EMAIL_PATTERN = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g;
+
+/**
+ * Apply phone and email redaction to text.
+ * Returns scrubbed text + detection counts.
+ *
+ * This is the shared implementation used by both
+ * transcriptScrubber.ts and survey entryScrubber.ts.
+ */
+export function scrubPhoneAndEmail(text: string): {
+  scrubbed: string;
+  phoneCount: number;
+  emailCount: number;
+  detectedValues: string[];
+} {
+  let scrubbed = text;
+  let phoneCount = 0;
+  let emailCount = 0;
+  const detectedValues: string[] = [];
+
+  // Reset regex lastIndex (global flag)
+  PHONE_PATTERN_10.lastIndex = 0;
+  PHONE_PATTERN_7.lastIndex = 0;
+  EMAIL_PATTERN.lastIndex = 0;
+
+  scrubbed = scrubbed.replace(PHONE_PATTERN_10, (match) => {
+    phoneCount++;
+    detectedValues.push(match);
+    return '[PHONE]';
+  });
+  scrubbed = scrubbed.replace(PHONE_PATTERN_7, (match) => {
+    phoneCount++;
+    detectedValues.push(match);
+    return '[PHONE]';
+  });
+  scrubbed = scrubbed.replace(EMAIL_PATTERN, (match) => {
+    emailCount++;
+    detectedValues.push(match);
+    return '[EMAIL]';
+  });
+
+  return { scrubbed, phoneCount, emailCount, detectedValues };
+}

--- a/backend/src/helpers/slack/commands/surveyPrivacyHandler.ts
+++ b/backend/src/helpers/slack/commands/surveyPrivacyHandler.ts
@@ -190,11 +190,11 @@ function buildPrivacyReviewModal(
   ];
 
   if (unflagged.length > 0) {
-    blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: `*No identifiers detected* (${unflagged.length} entries)` }] });
+    blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: `*No phone or email patterns detected* (${unflagged.length} entries)\nQori did not detect phone or email patterns in these responses. Please review them before approving.` }] });
     blocks.push({
       type: 'input', block_id: 'bulk_clear_unflagged', optional: true,
       label: { type: 'plain_text', text: ' ' },
-      element: { type: 'checkboxes', action_id: 'bulk_clear_check', options: [{ text: { type: 'plain_text', text: `Use all ${unflagged.length} unflagged responses as written` }, value: 'bulk_clear' }] },
+      element: { type: 'checkboxes', action_id: 'bulk_clear_check', options: [{ text: { type: 'plain_text', text: `I reviewed these ${unflagged.length} responses and approve them as written` }, value: 'bulk_clear' }] },
     });
     for (const entry of unflagged) {
       const eid = (entry as unknown as { id: number }).id;

--- a/backend/src/helpers/slack/commands/surveyPrivacyHandler.ts
+++ b/backend/src/helpers/slack/commands/surveyPrivacyHandler.ts
@@ -2,11 +2,14 @@
  * Survey Privacy Review Handler — Slack adapter for content governance.
  *
  * Presents open-text entries for researcher privacy review.
- * Actions: USE AS WRITTEN (clear), EDIT SAFE VERSION (redacted), DO NOT USE (restricted).
+ * Distinguishes FLAGGED (phone/email detected) from UNFLAGGED entries.
  *
- * This handler is an ADAPTER to the content governance service.
- * Privacy state, disposition, and eligibility logic live in
- * content-governance.service.ts, not here.
+ * Actions:
+ *   USE AS WRITTEN (clear) — individual or bulk for unflagged
+ *   EDIT SAFE VERSION (redacted) — editable scrubbed derivative
+ *   DO NOT USE (restricted) — excluded from analysis
+ *
+ * Privacy state and disposition logic live in content-governance.service.ts.
  */
 
 import type {
@@ -29,6 +32,8 @@ import {
 
 const QualitativeEntryModel = sequelize.models.SurveyQualitativeEntry as typeof SurveyQualitativeEntry;
 
+const ENTRIES_PER_PAGE = 10;
+
 interface PrivacyReviewMeta {
   evidenceSourceId: number;
   projectId: number;
@@ -38,34 +43,41 @@ interface PrivacyReviewMeta {
   surveyName: string;
   questionFocus: string;
   sourceIntent: string;
+  entryIds: number[];
 }
 
-/**
- * Handle "Review Responses" button click — opens privacy review modal.
- */
 export async function handlePrivacyReviewAction(
   args: SlackActionMiddlewareArgs<BlockAction<ButtonAction>> & AllMiddlewareArgs,
 ): Promise<void> {
   const { ack, action, client, body } = args;
   await ack();
 
-  const meta: PrivacyReviewMeta = JSON.parse(action.value || '{}');
+  const rawMeta = JSON.parse(action.value || '{}');
 
   const entries = await QualitativeEntryModel.findAll({
-    where: { evidence_source_id: meta.evidenceSourceId, pii_status: 'pending' },
-    order: [['field_name', 'ASC'], ['source_row_index', 'ASC']],
-    limit: 10, // Review in batches for Slack block limits
+    where: { evidence_source_id: rawMeta.evidenceSourceId, pii_status: 'pending' },
+    order: [['source_row_index', 'ASC'], ['field_name', 'ASC'], ['id', 'ASC']],
+    limit: ENTRIES_PER_PAGE,
   });
 
   if (entries.length === 0) {
     await client.chat.postMessage({
       channel: body.user.id,
-      text: '✅ All open-text responses have been reviewed. Qualitative synthesis can proceed.',
+      text: '\u2705 All open-text responses have been reviewed.',
     });
     return;
   }
 
-  const modal = buildPrivacyReviewModal(entries as SurveyQualitativeEntry[], meta);
+  const remaining = await QualitativeEntryModel.count({
+    where: { evidence_source_id: rawMeta.evidenceSourceId, pii_status: 'pending' },
+  });
+
+  const meta: PrivacyReviewMeta = {
+    ...rawMeta,
+    entryIds: entries.map(e => (e as unknown as { id: number }).id),
+  };
+
+  const modal = buildPrivacyReviewModal(entries as SurveyQualitativeEntry[], meta, remaining);
 
   await client.views.open({
     trigger_id: body.trigger_id,
@@ -73,9 +85,6 @@ export async function handlePrivacyReviewAction(
   });
 }
 
-/**
- * Handle privacy review modal submission.
- */
 export async function handlePrivacyReviewSubmission(
   args: SlackViewMiddlewareArgs<ViewSubmitAction> & AllMiddlewareArgs,
 ): Promise<void> {
@@ -86,108 +95,78 @@ export async function handlePrivacyReviewSubmission(
   const userId = body.user.id;
   const values = view.state.values as unknown as Record<string, Record<string, Record<string, unknown>>>;
 
-  // Process each entry's disposition
+  // Load ONLY the entries whose IDs were in the modal
+  const entryIds = meta.entryIds ?? [];
   const entries = await QualitativeEntryModel.findAll({
-    where: { evidence_source_id: meta.evidenceSourceId, pii_status: 'pending' },
+    where: { id: entryIds },
     order: [['id', 'ASC']],
-    limit: 10,
   });
+
+  const bulkClearSelected = (values.bulk_clear_unflagged?.bulk_clear_check?.selected_options as Array<{ value: string }> | undefined);
+  const doBulkClear = bulkClearSelected?.some(o => o.value === 'bulk_clear') ?? false;
 
   for (const entry of entries) {
     const entryId = (entry as unknown as { id: number }).id;
-    const dispositionBlock = values[`disposition_${entryId}`];
-    const redactBlock = values[`redact_text_${entryId}`];
+    const entryMeta = (entry as SurveyQualitativeEntry).metadata as Record<string, unknown>;
+    const autoScrub = entryMeta?.auto_scrub as { has_detections?: boolean } | undefined;
+    const isFlagged = autoScrub?.has_detections ?? false;
 
-    const selectedAction = dispositionBlock?.disposition_select?.selected_option as { value: string } | null | undefined;
+    if (!isFlagged && doBulkClear) {
+      const dispositionBlock = values[`disposition_${entryId}`];
+      const override = (dispositionBlock?.disposition_select?.selected_option as { value: string } | null)?.value;
+      if (!override) {
+        await entry.update(buildDispositionUpdate('pending', 'clear', userId));
+        continue;
+      }
+    }
+
+    const dispositionBlock = values[`disposition_${entryId}`];
+    const selectedAction = (dispositionBlock?.disposition_select?.selected_option as { value: string } | null)?.value;
     if (!selectedAction) continue;
 
-    const newStatus = selectedAction.value as PiiStatus;
-    const editedRedactedText = redactBlock?.redact_input?.value as string | undefined;
+    const newStatus = selectedAction as PiiStatus;
+    const editedText = (values[`redact_text_${entryId}`]?.redact_input?.value as string | undefined);
 
     try {
       const update = buildDispositionUpdate(
-        'pending',
-        newStatus,
-        userId,
-        newStatus === 'redacted' ? editedRedactedText : undefined,
+        'pending', newStatus, userId,
+        newStatus === 'redacted' ? editedText : undefined,
       );
-
       await entry.update(update);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      await client.chat.postMessage({
-        channel: userId,
-        text: `❌ Error reviewing entry: ${msg}`,
-      });
+      await client.chat.postMessage({ channel: userId, text: `\u274C Error: ${msg}` });
       return;
     }
   }
 
-  // Check if more entries need review
   const remaining = await QualitativeEntryModel.count({
     where: { evidence_source_id: meta.evidenceSourceId, pii_status: 'pending' },
   });
 
   if (remaining > 0) {
+    const baseMeta = { evidenceSourceId: meta.evidenceSourceId, projectId: meta.projectId, projectSlug: meta.projectSlug, topic: meta.topic, topicSlug: meta.topicSlug, surveyName: meta.surveyName, questionFocus: meta.questionFocus, sourceIntent: meta.sourceIntent };
     await client.chat.postMessage({
       channel: userId,
       blocks: [
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: `✅ Batch reviewed. *${remaining} entries* remaining.`,
-          },
-          accessory: {
-            type: 'button',
-            text: { type: 'plain_text', text: 'Continue Review' },
-            style: 'primary',
-            action_id: 'survey_privacy_review',
-            value: JSON.stringify(meta),
-          },
-        },
+        { type: 'section', text: { type: 'mrkdwn', text: `\u2705 Batch reviewed. *${remaining} entries* remaining.` }, accessory: { type: 'button', text: { type: 'plain_text', text: 'Continue Review' }, style: 'primary', action_id: 'survey_privacy_review', value: JSON.stringify(baseMeta) } },
       ],
-      text: `${remaining} entries remaining for privacy review.`,
+      text: `${remaining} entries remaining.`,
     });
   } else {
-    // All reviewed — count statuses
-    const allEntries = await QualitativeEntryModel.findAll({
-      where: { evidence_source_id: meta.evidenceSourceId },
-    });
-    const statusCounts = countByStatus(
-      allEntries as Array<{ pii_status: PiiStatus }>,
-    );
-
+    const allEntries = await QualitativeEntryModel.findAll({ where: { evidence_source_id: meta.evidenceSourceId } });
+    const statusCounts = countByStatus(allEntries as Array<{ pii_status: PiiStatus }>);
+    const baseMeta = { evidenceSourceId: meta.evidenceSourceId, projectId: meta.projectId, projectSlug: meta.projectSlug, topic: meta.topic, topicSlug: meta.topicSlug, surveyName: meta.surveyName, questionFocus: meta.questionFocus, sourceIntent: meta.sourceIntent };
     await client.chat.postMessage({
       channel: userId,
       blocks: [
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: `✅ *Privacy review complete.*\n\n• Cleared: ${statusCounts.clear}\n• Redacted: ${statusCounts.redacted}\n• Restricted: ${statusCounts.restricted}\n\nQori can now analyze the approved responses.`,
-          },
-        },
-        {
-          type: 'actions',
-          elements: [
-            {
-              type: 'button',
-              text: { type: 'plain_text', text: 'Generate Survey Synthesis' },
-              style: 'primary',
-              action_id: 'survey_run_synthesis',
-              value: JSON.stringify(meta),
-            },
-            {
-              type: 'button',
-              text: { type: 'plain_text', text: 'Generate Response Categories' },
-              action_id: 'survey_generate_codebook',
-              value: JSON.stringify(meta),
-            },
-          ],
-        },
+        { type: 'section', text: { type: 'mrkdwn', text: `\u2705 *Privacy review complete.*\n\n\u2022 Cleared: ${statusCounts.clear}\n\u2022 Redacted: ${statusCounts.redacted}\n\u2022 Restricted: ${statusCounts.restricted}` } },
+        { type: 'actions', elements: [
+          { type: 'button', text: { type: 'plain_text', text: 'Generate Survey Synthesis' }, style: 'primary', action_id: 'survey_run_synthesis', value: JSON.stringify(baseMeta) },
+          { type: 'button', text: { type: 'plain_text', text: 'Generate Response Categories' }, action_id: 'survey_generate_codebook', value: JSON.stringify({ ...baseMeta, surveyName: meta.surveyName, questionFocus: meta.questionFocus }) },
+        ] },
       ],
-      text: 'Privacy review complete. Qori can now analyze the approved responses.',
+      text: 'Privacy review complete.',
     });
   }
 }
@@ -195,66 +174,78 @@ export async function handlePrivacyReviewSubmission(
 function buildPrivacyReviewModal(
   entries: SurveyQualitativeEntry[],
   meta: PrivacyReviewMeta,
+  totalPending: number,
 ): Record<string, unknown> {
+  const flagged: SurveyQualitativeEntry[] = [];
+  const unflagged: SurveyQualitativeEntry[] = [];
+  for (const entry of entries) {
+    const m = entry.metadata as Record<string, unknown>;
+    const s = m?.auto_scrub as { has_detections?: boolean } | undefined;
+    (s?.has_detections ? flagged : unflagged).push(entry);
+  }
+
   const blocks: Record<string, unknown>[] = [
-    {
-      type: 'context',
-      elements: [{
-        type: 'mrkdwn',
-        text: 'Review each response. Choose how Qori may use it:\n\n• *Use as written* — the response is safe\n• *Edit safe version* — remove sensitive information\n• *Do not use* — exclude from analysis',
-      }],
-    },
+    { type: 'context', elements: [{ type: 'mrkdwn', text: `*${totalPending} responses* need review (showing ${entries.length}).` }] },
     { type: 'divider' },
   ];
 
-  for (const entry of entries) {
-    const { originalText, suggestedSafeText } = getRawContentForReview(entry);
-    const entryId = (entry as unknown as { id: number }).id;
-    const truncated = (originalText ?? '').slice(0, 200) + ((originalText?.length ?? 0) > 200 ? '...' : '');
-
+  if (unflagged.length > 0) {
+    blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: `*No identifiers detected* (${unflagged.length} entries)` }] });
     blocks.push({
-      type: 'context',
-      elements: [{
-        type: 'mrkdwn',
-        text: `*${entry.display_respondent_id}* — ${entry.field_display_name}\n"${truncated}"`,
-      }],
+      type: 'input', block_id: 'bulk_clear_unflagged', optional: true,
+      label: { type: 'plain_text', text: ' ' },
+      element: { type: 'checkboxes', action_id: 'bulk_clear_check', options: [{ text: { type: 'plain_text', text: `Use all ${unflagged.length} unflagged responses as written` }, value: 'bulk_clear' }] },
     });
-
-    blocks.push({
-      type: 'input',
-      block_id: `disposition_${entryId}`,
-      label: { type: 'plain_text', text: 'How should Qori use this response?' },
-      element: {
-        type: 'static_select',
-        action_id: 'disposition_select',
-        options: [
+    for (const entry of unflagged) {
+      const eid = (entry as unknown as { id: number }).id;
+      const excerpt = (entry.entry_text ?? '').slice(0, 120) + ((entry.entry_text?.length ?? 0) > 120 ? '...' : '');
+      blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: `*${entry.display_respondent_id}* \u2014 ${entry.field_display_name}\n"${excerpt}"` }] });
+      blocks.push({
+        type: 'input', block_id: `disposition_${eid}`, optional: true,
+        label: { type: 'plain_text', text: `Override for ${entry.display_respondent_id}` },
+        element: { type: 'static_select', action_id: 'disposition_select', placeholder: { type: 'plain_text', text: 'Use bulk action above' }, options: [
           { text: { type: 'plain_text', text: 'Use as written' }, value: 'clear' },
           { text: { type: 'plain_text', text: 'Edit safe version' }, value: 'redacted' },
           { text: { type: 'plain_text', text: 'Do not use' }, value: 'restricted' },
-        ],
-      },
-    });
-
-    // Editable redacted text field (visible for all — used only when "Edit safe version" selected)
-    blocks.push({
-      type: 'input',
-      block_id: `redact_text_${entryId}`,
-      optional: true,
-      label: { type: 'plain_text', text: 'Edited safe version (only used with "Edit safe version")' },
-      element: {
-        type: 'plain_text_input',
-        action_id: 'redact_input',
-        multiline: true,
-        initial_value: suggestedSafeText ?? '',
-      },
-    });
-
+        ] },
+      });
+    }
     blocks.push({ type: 'divider' });
   }
 
+  if (flagged.length > 0) {
+    blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: `*\u26A0\uFE0F Identifiers detected* (${flagged.length} entries) \u2014 individual review required` }] });
+    for (const entry of flagged) {
+      const eid = (entry as unknown as { id: number }).id;
+      const { originalText, suggestedSafeText } = getRawContentForReview(entry);
+      const m = entry.metadata as Record<string, unknown>;
+      const s = m?.auto_scrub as { phone_count?: number; email_count?: number } | undefined;
+      const reasons: string[] = [];
+      if ((s?.phone_count ?? 0) > 0) reasons.push('Phone detected');
+      if ((s?.email_count ?? 0) > 0) reasons.push('Email detected');
+      const truncOrig = (originalText ?? '').slice(0, 200) + ((originalText?.length ?? 0) > 200 ? '...' : '');
+
+      blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: `*${entry.display_respondent_id}* \u2014 ${entry.field_display_name}\n*Reason:* ${reasons.join(', ')}\n*Original:* "${truncOrig}"` }] });
+      blocks.push({
+        type: 'input', block_id: `disposition_${eid}`,
+        label: { type: 'plain_text', text: 'How should Qori use this response?' },
+        element: { type: 'static_select', action_id: 'disposition_select', options: [
+          { text: { type: 'plain_text', text: 'Use suggested safe version' }, value: 'redacted' },
+          { text: { type: 'plain_text', text: 'Use original as written' }, value: 'clear' },
+          { text: { type: 'plain_text', text: 'Do not use' }, value: 'restricted' },
+        ] },
+      });
+      blocks.push({
+        type: 'input', block_id: `redact_text_${eid}`, optional: true,
+        label: { type: 'plain_text', text: 'Suggested safe version (edit if needed)' },
+        element: { type: 'plain_text_input', action_id: 'redact_input', multiline: true, initial_value: suggestedSafeText ?? '' },
+      });
+      blocks.push({ type: 'divider' });
+    }
+  }
+
   return {
-    type: 'modal',
-    callback_id: 'survey_privacy_review_modal',
+    type: 'modal', callback_id: 'survey_privacy_review_modal',
     private_metadata: JSON.stringify(meta),
     title: { type: 'plain_text', text: 'Review Responses' },
     submit: { type: 'plain_text', text: 'Save Review' },

--- a/backend/src/helpers/survey/entryScrubber.ts
+++ b/backend/src/helpers/survey/entryScrubber.ts
@@ -2,20 +2,15 @@
  * Survey Entry Scrubber — deterministic PII pattern detection + redaction
  * for open-text survey entries.
  *
- * Reuses phone and email regex patterns from transcriptScrubber.ts.
- * Does NOT require participant real names (survey respondents use system codes).
+ * Uses shared piiPatterns.ts (canonical phone/email patterns used by
+ * both transcript and survey paths — no duplicate regexes).
  *
  * Detection metadata is persisted alongside redacted text for consistency
  * verification: if a pattern was detected, the redacted text must not
  * contain the original pattern value.
  */
 
-// Phone patterns (from transcriptScrubber.ts)
-const PHONE_PATTERN_10 = /\b(?:\+?1[-.\s]?)?\(?[0-9]{3}\)?[-.\s]?[0-9]{3}[-.\s]?[0-9]{4}\b/g;
-const PHONE_PATTERN_7 = /\b[0-9]{3}[-.\s]?[0-9]{4}\b/g;
-
-// Email pattern (from transcriptScrubber.ts)
-const EMAIL_PATTERN = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g;
+import { scrubPhoneAndEmail } from '../piiPatterns';
 
 export interface ScrubResult {
   /** Scrubbed text with patterns replaced */
@@ -42,35 +37,14 @@ export interface ScrubResult {
  * @returns ScrubResult with scrubbed text and detection metadata
  */
 export function scrubEntryText(text: string): ScrubResult {
-  let scrubbed = text;
-  let phoneCount = 0;
-  let emailCount = 0;
-  const detectedValues: string[] = [];
-
-  // Phone (10-digit first, then 7-digit)
-  scrubbed = scrubbed.replace(PHONE_PATTERN_10, (match) => {
-    phoneCount++;
-    detectedValues.push(match);
-    return '[PHONE]';
-  });
-  scrubbed = scrubbed.replace(PHONE_PATTERN_7, (match) => {
-    phoneCount++;
-    detectedValues.push(match);
-    return '[PHONE]';
-  });
-
-  // Email
-  scrubbed = scrubbed.replace(EMAIL_PATTERN, (match) => {
-    emailCount++;
-    detectedValues.push(match);
-    return '[EMAIL]';
-  });
+  // Use shared canonical phone/email scrubber (same patterns as transcriptScrubber)
+  const result = scrubPhoneAndEmail(text);
 
   return {
-    scrubbedText: scrubbed,
-    hasDetections: phoneCount > 0 || emailCount > 0,
-    detections: { phoneCount, emailCount },
-    detectedValues,
+    scrubbedText: result.scrubbed,
+    hasDetections: result.phoneCount > 0 || result.emailCount > 0,
+    detections: { phoneCount: result.phoneCount, emailCount: result.emailCount },
+    detectedValues: result.detectedValues,
   };
 }
 

--- a/backend/src/helpers/survey/entryScrubber.ts
+++ b/backend/src/helpers/survey/entryScrubber.ts
@@ -1,0 +1,98 @@
+/**
+ * Survey Entry Scrubber — deterministic PII pattern detection + redaction
+ * for open-text survey entries.
+ *
+ * Reuses phone and email regex patterns from transcriptScrubber.ts.
+ * Does NOT require participant real names (survey respondents use system codes).
+ *
+ * Detection metadata is persisted alongside redacted text for consistency
+ * verification: if a pattern was detected, the redacted text must not
+ * contain the original pattern value.
+ */
+
+// Phone patterns (from transcriptScrubber.ts)
+const PHONE_PATTERN_10 = /\b(?:\+?1[-.\s]?)?\(?[0-9]{3}\)?[-.\s]?[0-9]{3}[-.\s]?[0-9]{4}\b/g;
+const PHONE_PATTERN_7 = /\b[0-9]{3}[-.\s]?[0-9]{4}\b/g;
+
+// Email pattern (from transcriptScrubber.ts)
+const EMAIL_PATTERN = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g;
+
+export interface ScrubResult {
+  /** Scrubbed text with patterns replaced */
+  scrubbedText: string;
+  /** Whether any pattern was detected */
+  hasDetections: boolean;
+  /** Detection counts by type */
+  detections: {
+    phoneCount: number;
+    emailCount: number;
+  };
+  /** Original matched values (for consistency verification, never persisted externally) */
+  detectedValues: string[];
+}
+
+/**
+ * Apply deterministic PII pattern scrubbing to a survey entry.
+ *
+ * Replaces:
+ *   Phone numbers → [PHONE]
+ *   Email addresses → [EMAIL]
+ *
+ * @param text — raw entry text
+ * @returns ScrubResult with scrubbed text and detection metadata
+ */
+export function scrubEntryText(text: string): ScrubResult {
+  let scrubbed = text;
+  let phoneCount = 0;
+  let emailCount = 0;
+  const detectedValues: string[] = [];
+
+  // Phone (10-digit first, then 7-digit)
+  scrubbed = scrubbed.replace(PHONE_PATTERN_10, (match) => {
+    phoneCount++;
+    detectedValues.push(match);
+    return '[PHONE]';
+  });
+  scrubbed = scrubbed.replace(PHONE_PATTERN_7, (match) => {
+    phoneCount++;
+    detectedValues.push(match);
+    return '[PHONE]';
+  });
+
+  // Email
+  scrubbed = scrubbed.replace(EMAIL_PATTERN, (match) => {
+    emailCount++;
+    detectedValues.push(match);
+    return '[EMAIL]';
+  });
+
+  return {
+    scrubbedText: scrubbed,
+    hasDetections: phoneCount > 0 || emailCount > 0,
+    detections: { phoneCount, emailCount },
+    detectedValues,
+  };
+}
+
+/**
+ * Verify consistency between detection metadata and redacted text.
+ *
+ * If a phone or email was detected, the redacted text must NOT contain
+ * the original value. If it does, the entry is inconsistent and should
+ * fail closed (remain pending).
+ *
+ * @param redactedText — the scrubbed or researcher-edited text
+ * @param detectedValues — original matched values from scrubbing
+ * @returns true if consistent (no detected values appear in redacted text)
+ */
+export function verifyRedactionConsistency(
+  redactedText: string,
+  detectedValues: string[],
+): boolean {
+  for (const value of detectedValues) {
+    if (redactedText.includes(value)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/backend/src/helpers/survey/qualitativeEntryWriter.ts
+++ b/backend/src/helpers/survey/qualitativeEntryWriter.ts
@@ -17,6 +17,7 @@ import type { Transaction, CreationAttributes } from 'sequelize';
 import type { ParsedSurvey, ConfirmedField, RespondentIdentity } from '../../types/survey';
 import type { SurveyQualitativeEntry } from '../../database/models/survey_qualitative_entry';
 import { toDisplayLabel } from './displayLabels';
+import { scrubEntryText, verifyRedactionConsistency } from './entryScrubber';
 
 export interface QualitativeEntryInput {
   evidenceSourceId: number;
@@ -57,6 +58,12 @@ export function buildQualitativeEntries(
 
       const entryHash = createHash('sha256').update(text).digest('hex');
 
+      // Apply deterministic scrubbing (phone/email patterns)
+      const scrubResult = scrubEntryText(text);
+      const isConsistent = verifyRedactionConsistency(
+        scrubResult.scrubbedText, scrubResult.detectedValues,
+      );
+
       entries.push({
         evidence_source_id: ctx.evidenceSourceId,
         project_id: ctx.projectId,
@@ -68,9 +75,16 @@ export function buildQualitativeEntries(
         entry_text: text,
         entry_hash: entryHash,
         pii_status: 'pending',
-        redacted_text: text, // initial: same as original (auto-scrub applied separately if needed)
+        redacted_text: scrubResult.scrubbedText,
         source_row_index: row.rowIndex,
-        metadata: {},
+        metadata: {
+          auto_scrub: {
+            has_detections: scrubResult.hasDetections,
+            phone_count: scrubResult.detections.phoneCount,
+            email_count: scrubResult.detections.emailCount,
+            is_consistent: isConsistent,
+          },
+        },
       } as CreationAttributes<SurveyQualitativeEntry>);
     }
   }

--- a/backend/src/helpers/transcriptScrubber.ts
+++ b/backend/src/helpers/transcriptScrubber.ts
@@ -97,14 +97,9 @@ function decomposeNameVariants(fullName: string): string[] {
 
 // ─── Regex Patterns ──────────────────────────────────────────────
 
-// Phone: various formats including 7-digit local numbers
-// - XXX-XXX-XXXX, (XXX) XXX-XXXX, XXX.XXX.XXXX (10 digit)
-// - XXX-XXXX (7 digit local)
-const PHONE_PATTERN_10 = /\b(?:\+?1[-.\s]?)?\(?[0-9]{3}\)?[-.\s]?[0-9]{3}[-.\s]?[0-9]{4}\b/g;
-const PHONE_PATTERN_7 = /\b[0-9]{3}[-.\s]?[0-9]{4}\b/g;
-
-// Email: standard format
-const EMAIL_PATTERN = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g;
+// Phone and email patterns shared with survey entry scrubber via piiPatterns.ts.
+// Imported here for consistency — one canonical set of patterns.
+import { PHONE_PATTERN_10, PHONE_PATTERN_7, EMAIL_PATTERN } from './piiPatterns';
 
 // Speaker label: "XX:" at start of line or after timestamp, where XX is 2-4 uppercase letters
 const SPEAKER_LABEL_PATTERN = /^(\[[^\]]+\]\s*)?([A-Z]{2,4}):\s/gm;


### PR DESCRIPTION
## Blocking defects from manual Slack-dev testing

### 1. Auto-redaction broken (root cause + fix)
**Root cause:** `qualitativeEntryWriter.ts` line 71 set `redacted_text: text` — raw original copied without scrubbing. `scrubEntryText()` was never called.
**Fix:** New `entryScrubber.ts` applies phone→[PHONE], email→[EMAIL] regex patterns (reused from transcriptScrubber.ts). Called at ingestion. Detection metadata persisted in `entry.metadata.auto_scrub`.

### 2. Reviewed entries reappearing (root cause + fix)
**Root cause:** Submission handler re-queried `pii_status: 'pending', limit: 10` instead of processing the entries actually shown in the modal. Different entries could be returned.
**Fix:** Modal entry IDs passed through `private_metadata.entryIds`. Submission handler loads ONLY those IDs.

### 3. Compact review UX
- **Unflagged** (no detections): compact display + bulk "Use all unflagged as written" checkbox
- **Flagged** (phone/email): original + suggested safe version, individual review, detection reason shown
- Safe version pre-populated with scrubbed text (not raw original)

### 4. Consistency verification
`verifyRedactionConsistency()` ensures detected patterns don't survive in redacted_text.

## Tests
- 324 unit (10 new scrubber), 252 integration — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)