### PR TITLE
fix(survey): inject has_accepted_coding as top-level task variable

### DIFF
--- a/backend/src/__tests__/unit/survey/v10ArtifactContract.test.ts
+++ b/backend/src/__tests__/unit/survey/v10ArtifactContract.test.ts
@@ -244,13 +244,27 @@ describe('Method & Provenance with accepted coding', () => {
 // ═══════════════════════════════════════════════════════════════════════
 
 describe('qualitative_observations AI task behavior', () => {
-  it('skips when accepted coding exists', () => {
-    expect(yaml).toContain('skip_when: "qualitative_coding and qualitative_coding.hasAcceptedCoding"');
+  it('skips when accepted coding exists via top-level boolean', () => {
+    // skip_when uses top-level has_accepted_coding (not nested property)
+    // because assertSkipWhenVariablesDefined checks top-level keys only
+    expect(yaml).toContain('skip_when: "has_accepted_coding"');
+  });
+
+  it('has_accepted_coding declared as input variable', () => {
+    expect(yaml).toContain('name: has_accepted_coding');
+    expect(yaml).toContain('type: boolean');
   });
 
   it('skip_output is empty string (no fallback text)', () => {
-    // When coding is accepted, the preliminary section is replaced entirely
     expect(yaml).toContain('skip_output: ""');
+  });
+
+  it('handler injects has_accepted_coding as top-level boolean', () => {
+    const handlerFile = readFileSync(
+      join(__dirname, '../../../helpers/slack/commands/surveySubmissionHandler.ts'),
+      'utf-8',
+    );
+    expect(handlerFile).toContain('has_accepted_coding:');
   });
 });
 

--- a/backend/src/helpers/slack/commands/surveySubmissionHandler.ts
+++ b/backend/src/helpers/slack/commands/surveySubmissionHandler.ts
@@ -944,6 +944,9 @@ export async function runSurveyQualitativeSynthesis(
       combined_file_content: openTextContent,
       provenance,
       qualitative_coding: qualitativeCoding,
+      // Top-level boolean for skip_when evaluation (assertSkipWhenVariablesDefined
+      // checks top-level keys only — nested property access is not supported)
+      has_accepted_coding: qualitativeCoding !== null,
     };
 
     const file = await fetchFileFromRepo(getConfigRepo(), YAML_TEMPLATE_PATH, 'survey_synthesis.yaml');

--- a/config/prompts/survey_synthesis.yaml
+++ b/config/prompts/survey_synthesis.yaml
@@ -75,6 +75,10 @@ input_variables:
     type: object
     required: false
     description: "Accepted qualitative coding data from Slice 2B: recurring patterns, individual observations, review metadata, privacy counts. When present, replaces Preliminary Qualitative Observations with deterministic What Respondents Described."
+  - name: has_accepted_coding
+    type: boolean
+    required: false
+    description: "Top-level boolean for task skip_when evaluation. True when an accepted coding run exists for the current evidence source. Derived from Postgres, not from artifact text or Slack state."
 
 # ═══════════════════════════════════════════════════════════
 # CASCADE CONTRACT — aligned with v9 authority model
@@ -132,7 +136,7 @@ ai_generation_tasks:
   # NO counting, NO frequencies, NO themes, NO sentiment distributions.
   # NO soft prevalence language.
   - task_id: "qualitative_observations"
-    skip_when: "qualitative_coding and qualitative_coding.hasAcceptedCoding"
+    skip_when: "has_accepted_coding"
     skip_output: ""
     prompt: |
       You are interpreting open-text survey responses. Your output is


### PR DESCRIPTION
## Summary

- Fixes `skip_when references undefined variable "hasAcceptedCoding"` error during survey synthesis
- Root cause: `assertSkipWhenVariablesDefined()` validates top-level keys only; nested property access in `skip_when` is not supported
- Adds `has_accepted_coding` as a top-level boolean derived from Postgres (accepted coding run exists)
- YAML `skip_when` simplified from `"qualitative_coding and qualitative_coding.hasAcceptedCoding"` to `"has_accepted_coding"`

## Test plan

- [x] Typecheck passes
- [x] v10 artifact contract tests: 46 pass (2 new)
- [x] Full unit suite: 421 pass, 30 suites
- [x] Full integration suite: 283 pass, 23 suites
- [ ] CI green
- [ ] Manual: Create Survey Summary succeeds after accepted match review

🤖 Generated with [Claude Code](https://claude.com/claude-code)