### PR TITLE
fix(survey): idempotent facts, source-scoped reconstruction, artifact corrections

### DIFF
--- a/backend/scripts/repair-duplicate-constructs.ts
+++ b/backend/scripts/repair-duplicate-constructs.ts
@@ -1,0 +1,297 @@
+/**
+ * DEV-ONLY: Repair duplicate deterministic constructs + backfill metadata.
+ *
+ * Three repair operations:
+ *
+ * 1. DUPLICATE CONSTRUCTS: Retries of persistSurveyFoundation() created
+ *    duplicate evidence constructs. Groups by semantic identity, reports
+ *    duplicates, and with --fix retains oldest canonical per identity.
+ *
+ * 2. CODEBOOK ANALYTIC RELEVANCE: Backfills analytic_relevance into
+ *    survey_codes.metadata for accepted codebooks that predate the
+ *    governance/research classification.
+ *
+ * 3. SURVEY CONTEXT: Backfills evidence_source.metadata.survey_context
+ *    for sources that predate context persistence.
+ *
+ * Usage:
+ *   npx ts-node scripts/repair-duplicate-constructs.ts          # dry run
+ *   npx ts-node scripts/repair-duplicate-constructs.ts --fix    # apply
+ */
+
+import '../src/database'; // initialize sequelize + models
+import sequelize from '../src/database';
+import { Op } from 'sequelize';
+import type { EvidenceSource } from '../src/database/models/evidence_source';
+import type { EvidenceConstruct } from '../src/database/models/evidence_construct';
+import type { EvidenceRelationship } from '../src/database/models/evidence_relationship';
+import type { SurveyCode } from '../src/database/models/survey_code';
+import type { SurveyCodebook } from '../src/database/models/survey_codebook';
+
+const EvidenceSourceModel = sequelize.models.EvidenceSource as typeof EvidenceSource;
+const EvidenceConstructModel = sequelize.models.EvidenceConstruct as typeof EvidenceConstruct;
+const EvidenceRelationshipModel = sequelize.models.EvidenceRelationship as typeof EvidenceRelationship;
+const CodebookModel = sequelize.models.SurveyCodebook as typeof SurveyCodebook;
+const CodeModel = sequelize.models.SurveyCode as typeof SurveyCode;
+
+const dryRun = !process.argv.includes('--fix');
+
+interface ConstructInfo {
+  id: number;
+  public_id: string;
+  construct_type: string;
+  semanticKey: string;
+  created_at: Date;
+}
+
+function getSemanticKey(construct: EvidenceConstruct): string {
+  const type = (construct as unknown as { construct_type: string }).construct_type;
+  const payload = (construct as unknown as { payload: Record<string, unknown> | null }).payload;
+
+  switch (type) {
+    case 'survey_dataset_summary':
+      return 'dataset_summary';
+    case 'field_distribution':
+      return `field_distribution:${(payload as Record<string, unknown>)?.fieldName ?? 'unknown'}`;
+    case 'cross_tab':
+      return `cross_tab:${(payload as Record<string, unknown>)?.rowField ?? 'unknown'}:${(payload as Record<string, unknown>)?.colField ?? 'unknown'}`;
+    default:
+      return `${type}:${construct.id}`;
+  }
+}
+
+async function main() {
+  console.log(dryRun ? '=== DRY RUN ===' : '=== APPLYING FIXES ===');
+
+  // Find all survey_dataset sources
+  const sources = await EvidenceSourceModel.findAll({
+    where: { source_type: 'survey_dataset' },
+    order: [['created_at', 'ASC']],
+  });
+
+  console.log(`Found ${sources.length} survey_dataset evidence source(s)\n`);
+
+  for (const source of sources) {
+    console.log(`\n--- Source: ${source.public_id} (id=${source.id}) "${source.label}" ---`);
+
+    // Get constructs via lineage
+    const relationships = await EvidenceRelationshipModel.findAll({
+      where: {
+        from_source_id: source.id,
+        relationship_type: 'DERIVED_FROM',
+      },
+    });
+
+    const constructIds = relationships
+      .map(r => (r as unknown as { to_construct_id: number | null }).to_construct_id)
+      .filter((id): id is number => id !== null);
+
+    if (constructIds.length === 0) {
+      console.log('  No linked constructs');
+      continue;
+    }
+
+    const constructs = await EvidenceConstructModel.findAll({
+      where: { id: { [Op.in]: constructIds } },
+      order: [['created_at', 'ASC']],
+    });
+
+    // Group by semantic key
+    const groups = new Map<string, ConstructInfo[]>();
+    for (const c of constructs) {
+      const key = getSemanticKey(c);
+      const info: ConstructInfo = {
+        id: c.id,
+        public_id: c.public_id,
+        construct_type: (c as unknown as { construct_type: string }).construct_type,
+        semanticKey: key,
+        created_at: c.created_at,
+      };
+      const list = groups.get(key) ?? [];
+      list.push(info);
+      groups.set(key, list);
+    }
+
+    // Report
+    let totalDuplicates = 0;
+    const toDelete: number[] = [];
+
+    for (const [key, items] of groups) {
+      if (items.length > 1) {
+        totalDuplicates += items.length - 1;
+        console.log(`  DUPLICATE: ${key} — ${items.length} copies`);
+        for (const item of items) {
+          console.log(`    id=${item.id} public_id=${item.public_id} created_at=${item.created_at.toISOString()}`);
+        }
+        // Keep oldest (first by created_at ASC), mark rest for deletion
+        for (let i = 1; i < items.length; i++) {
+          toDelete.push(items[i].id);
+        }
+      } else {
+        console.log(`  OK: ${key}`);
+      }
+    }
+
+    console.log(`\n  Total constructs: ${constructs.length}`);
+    console.log(`  Unique semantic keys: ${groups.size}`);
+    console.log(`  Duplicates to remove: ${totalDuplicates}`);
+
+    if (toDelete.length > 0 && !dryRun) {
+      await sequelize.transaction(async (t) => {
+        // Delete relationships pointing to duplicate constructs
+        await EvidenceRelationshipModel.destroy({
+          where: {
+            [Op.or]: [
+              { to_construct_id: { [Op.in]: toDelete } },
+              { from_construct_id: { [Op.in]: toDelete } },
+            ],
+          },
+          transaction: t,
+        });
+        // Delete duplicate constructs
+        await EvidenceConstructModel.destroy({
+          where: { id: { [Op.in]: toDelete } },
+          transaction: t,
+        });
+        console.log(`  ✅ Removed ${toDelete.length} duplicate constructs and their relationships`);
+      });
+    }
+
+    // Add semantic_key to remaining constructs that lack it
+    if (!dryRun) {
+      const remaining = await EvidenceConstructModel.findAll({
+        where: {
+          id: { [Op.in]: constructIds.filter(id => !toDelete.includes(id)) },
+          derivation_type: 'deterministic',
+        },
+      });
+      for (const c of remaining) {
+        const dc = (c as unknown as { derivation_context: Record<string, unknown> | null }).derivation_context;
+        if (!dc?.semantic_key) {
+          const key = getSemanticKey(c);
+          await c.update({
+            derivation_context: { ...(dc ?? {}), semantic_key: key },
+          });
+          console.log(`  ✅ Added semantic_key "${key}" to construct ${c.id}`);
+        }
+      }
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // PART 2: CODEBOOK ANALYTIC RELEVANCE BACKFILL
+  // ═══════════════════════════════════════════════════════════════════
+
+  console.log('\n\n=== CODEBOOK ANALYTIC RELEVANCE ===\n');
+
+  const codebooks = await CodebookModel.findAll({
+    where: { status: 'accepted' },
+    order: [['created_at', 'ASC']],
+  });
+
+  for (const cb of codebooks) {
+    const cbId = (cb as unknown as { id: number }).id;
+    console.log(`Codebook ${cbId} (v${(cb as unknown as { version: number }).version})`);
+
+    const codes = await CodeModel.findAll({
+      where: { codebook_id: cbId, status: 'accepted' },
+      order: [['sort_order', 'ASC']],
+    });
+
+    for (const code of codes) {
+      const meta = code.metadata as Record<string, unknown>;
+      const currentRelevance = meta?.analytic_relevance as string | undefined;
+      const label = code.label;
+      const definition = code.definition;
+
+      // Inspect for governance-only indicators in the code definition/label.
+      // This is for DIAGNOSTIC REPORTING only — classification requires review.
+      const governanceIndicators = [
+        /\bcontact\s+information\b/i,
+        /\bpersonal\s+contact\b/i,
+        /\bfollow[\s-]?up\s+contact\b/i,
+        /\bsensitive\s+(personal\s+)?disclosure\b/i,
+        /\bthird[\s-]?party\b.*\bdisclosure\b/i,
+        /\bPII\b/i,
+        /\bredact/i,
+      ];
+
+      const suggestedRelevance = governanceIndicators.some(p =>
+        p.test(label) || p.test(definition),
+      ) ? 'governance_only' : 'research';
+
+      if (currentRelevance) {
+        console.log(`  ${code.public_id}: "${label}" → ${currentRelevance} (already set)`);
+      } else {
+        console.log(`  ${code.public_id}: "${label}" → MISSING (suggested: ${suggestedRelevance})`);
+        if (!dryRun && suggestedRelevance === 'governance_only') {
+          await code.update({
+            metadata: { ...meta, analytic_relevance: suggestedRelevance },
+          });
+          console.log(`    ✅ Set analytic_relevance = governance_only`);
+        }
+      }
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // PART 3: SURVEY CONTEXT BACKFILL
+  // ═══════════════════════════════════════════════════════════════════
+
+  console.log('\n\n=== SURVEY CONTEXT METADATA ===\n');
+
+  for (const source of sources) {
+    const meta = source.metadata as Record<string, unknown> | null;
+    const surveyContext = meta?.survey_context as Record<string, string> | undefined;
+
+    if (surveyContext) {
+      console.log(`Source ${source.public_id}: survey_context PRESENT`);
+      console.log(`  topic: "${surveyContext.topic}"`);
+      console.log(`  topicSlug: "${surveyContext.topicSlug}"`);
+      console.log(`  surveyName: "${surveyContext.surveyName}"`);
+    } else {
+      console.log(`Source ${source.public_id}: survey_context MISSING`);
+
+      // Attempt to reconstruct from canonical DB state
+      const label = source.label; // e.g., "Survey Name — filename.csv"
+      const labelParts = label.split(' — ');
+      const reconstructedName = labelParts[0] || 'Survey';
+
+      // Load project for projectSlug
+      const project = await sequelize.models.Project.findByPk(source.project_id);
+      const projectSlug = project
+        ? (project as unknown as { slug: string }).slug ?? ''
+        : '';
+
+      const reconstructed = {
+        topic: reconstructedName,
+        topicSlug: reconstructedName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, ''),
+        surveyName: reconstructedName,
+        questionFocus: '',
+        sourceIntent: '',
+        projectSlug,
+      };
+
+      console.log(`  Reconstructed: ${JSON.stringify(reconstructed)}`);
+
+      if (!dryRun) {
+        await source.update({
+          metadata: { ...(meta ?? {}), survey_context: reconstructed },
+        });
+        console.log(`  ✅ Backfilled survey_context`);
+      }
+    }
+  }
+
+  console.log('\nDone.');
+  if (dryRun) {
+    console.log('Run with --fix to apply changes.');
+  }
+
+  await sequelize.close();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/scripts/repair-duplicate-constructs.ts
+++ b/backend/scripts/repair-duplicate-constructs.ts
@@ -36,6 +36,18 @@ const CodeModel = sequelize.models.SurveyCode as typeof SurveyCode;
 
 const dryRun = !process.argv.includes('--fix');
 
+// Explicit allowlist for governance backfill: --governance-code-ids=uuid1,uuid2,...
+const governanceArg = process.argv.find(a => a.startsWith('--governance-code-ids='));
+const approvedGovernanceIds = new Set(
+  governanceArg ? governanceArg.split('=')[1].split(',').filter(Boolean) : [],
+);
+
+// Explicit approval for survey_context backfill: --backfill-context-ids=sourcePublicId,...
+const contextArg = process.argv.find(a => a.startsWith('--backfill-context-ids='));
+const approvedContextIds = new Set(
+  contextArg ? contextArg.split('=')[1].split(',').filter(Boolean) : [],
+);
+
 interface ConstructInfo {
   id: number;
   public_id: string;
@@ -179,10 +191,22 @@ async function main() {
   }
 
   // ═══════════════════════════════════════════════════════════════════
-  // PART 2: CODEBOOK ANALYTIC RELEVANCE BACKFILL
+  // PART 2: CODEBOOK ANALYTIC RELEVANCE — DIAGNOSTIC + EXPLICIT BACKFILL
+  //
+  // Dry-run: reports each code with current/suggested analytic_relevance.
+  // Suggestions are DIAGNOSTIC ONLY — the heuristic does not constitute
+  // authoritative classification.
+  //
+  // --fix: only applies governance_only to codes whose public_id appears
+  // in --governance-code-ids=<id1>,<id2>,... (explicit allowlist).
   // ═══════════════════════════════════════════════════════════════════
 
   console.log('\n\n=== CODEBOOK ANALYTIC RELEVANCE ===\n');
+
+  if (!dryRun && approvedGovernanceIds.size === 0) {
+    console.log('  (No --governance-code-ids provided. Skipping governance backfill.)');
+    console.log('  To backfill, re-run with: --fix --governance-code-ids=<public_id,...>');
+  }
 
   const codebooks = await CodebookModel.findAll({
     where: { status: 'accepted' },
@@ -204,81 +228,124 @@ async function main() {
       const label = code.label;
       const definition = code.definition;
 
-      // Inspect for governance-only indicators in the code definition/label.
-      // This is for DIAGNOSTIC REPORTING only — classification requires review.
-      const governanceIndicators = [
-        /\bcontact\s+information\b/i,
-        /\bpersonal\s+contact\b/i,
-        /\bfollow[\s-]?up\s+contact\b/i,
-        /\bsensitive\s+(personal\s+)?disclosure\b/i,
-        /\bthird[\s-]?party\b.*\bdisclosure\b/i,
-        /\bPII\b/i,
-        /\bredact/i,
+      // Heuristic suggestion — DIAGNOSTIC ONLY, never auto-persisted
+      const governanceIndicators: Array<{ pattern: RegExp; reason: string }> = [
+        { pattern: /\bcontact\s+information\b/i, reason: 'mentions contact information' },
+        { pattern: /\bpersonal\s+contact\b/i, reason: 'mentions personal contact' },
+        { pattern: /\bfollow[\s-]?up\s+contact\b/i, reason: 'mentions follow-up contact' },
+        { pattern: /\bsensitive\s+(personal\s+)?disclosure\b/i, reason: 'mentions sensitive disclosure' },
+        { pattern: /\bthird[\s-]?party\b.*\bdisclosure\b/i, reason: 'mentions third-party disclosure' },
+        { pattern: /\bPII\b/i, reason: 'mentions PII' },
+        { pattern: /\bredact/i, reason: 'mentions redaction' },
       ];
 
-      const suggestedRelevance = governanceIndicators.some(p =>
-        p.test(label) || p.test(definition),
-      ) ? 'governance_only' : 'research';
+      const matchedIndicator = governanceIndicators.find(ind =>
+        ind.pattern.test(label) || ind.pattern.test(definition),
+      );
+      const suggestedRelevance = matchedIndicator ? 'governance_only' : 'research';
+      const suggestionReason = matchedIndicator?.reason ?? 'no governance indicators detected';
 
       if (currentRelevance) {
-        console.log(`  ${code.public_id}: "${label}" → ${currentRelevance} (already set)`);
+        console.log(`  ${code.public_id}: "${label}"`);
+        console.log(`    current: ${currentRelevance}`);
       } else {
-        console.log(`  ${code.public_id}: "${label}" → MISSING (suggested: ${suggestedRelevance})`);
-        if (!dryRun && suggestedRelevance === 'governance_only') {
+        console.log(`  ${code.public_id}: "${label}"`);
+        console.log(`    definition: "${definition.slice(0, 100)}${definition.length > 100 ? '...' : ''}"`);
+        console.log(`    current: MISSING`);
+        console.log(`    suggested: ${suggestedRelevance} (reason: ${suggestionReason})`);
+
+        // Only persist if explicitly approved via --governance-code-ids
+        if (!dryRun && approvedGovernanceIds.has(code.public_id)) {
           await code.update({
-            metadata: { ...meta, analytic_relevance: suggestedRelevance },
+            metadata: { ...meta, analytic_relevance: 'governance_only' },
           });
-          console.log(`    ✅ Set analytic_relevance = governance_only`);
+          console.log(`    ✅ Set analytic_relevance = governance_only (explicitly approved)`);
         }
       }
     }
   }
 
   // ═══════════════════════════════════════════════════════════════════
-  // PART 3: SURVEY CONTEXT BACKFILL
+  // PART 3: SURVEY CONTEXT — DIAGNOSTIC + EXPLICIT BACKFILL
+  //
+  // Dry-run: reports current survey_context presence, available canonical
+  // DB state (project, evidence source metadata), and proposed recovery
+  // with provenance for each field.
+  //
+  // --fix: only backfills sources whose public_id appears in
+  // --backfill-context-ids=<id1>,<id2>,... (explicit allowlist).
+  // Does NOT auto-backfill by parsing source.label.
   // ═══════════════════════════════════════════════════════════════════
 
   console.log('\n\n=== SURVEY CONTEXT METADATA ===\n');
+
+  if (!dryRun && approvedContextIds.size === 0) {
+    console.log('  (No --backfill-context-ids provided. Skipping context backfill.)');
+    console.log('  To backfill, re-run with: --fix --backfill-context-ids=<source_public_id,...>');
+  }
 
   for (const source of sources) {
     const meta = source.metadata as Record<string, unknown> | null;
     const surveyContext = meta?.survey_context as Record<string, string> | undefined;
 
+    console.log(`Source ${source.public_id} (id=${source.id})`);
+    console.log(`  label: "${source.label}"`);
+
     if (surveyContext) {
-      console.log(`Source ${source.public_id}: survey_context PRESENT`);
-      console.log(`  topic: "${surveyContext.topic}"`);
-      console.log(`  topicSlug: "${surveyContext.topicSlug}"`);
-      console.log(`  surveyName: "${surveyContext.surveyName}"`);
+      console.log(`  survey_context: PRESENT`);
+      console.log(`    topic: "${surveyContext.topic}"`);
+      console.log(`    topicSlug: "${surveyContext.topicSlug}"`);
+      console.log(`    surveyName: "${surveyContext.surveyName}"`);
+      console.log(`    questionFocus: "${surveyContext.questionFocus || ''}"`);
+      console.log(`    sourceIntent: "${surveyContext.sourceIntent || ''}"`);
+      console.log(`    projectSlug: "${surveyContext.projectSlug || ''}"`);
     } else {
-      console.log(`Source ${source.public_id}: survey_context MISSING`);
+      console.log(`  survey_context: MISSING`);
 
-      // Attempt to reconstruct from canonical DB state
-      const label = source.label; // e.g., "Survey Name — filename.csv"
-      const labelParts = label.split(' — ');
-      const reconstructedName = labelParts[0] || 'Survey';
-
-      // Load project for projectSlug
+      // Report available canonical DB state
       const project = await sequelize.models.Project.findByPk(source.project_id);
-      const projectSlug = project
-        ? (project as unknown as { slug: string }).slug ?? ''
-        : '';
+      const projectName = project ? (project as unknown as { name: string }).name ?? '' : '';
+      const projectSlug = project ? (project as unknown as { slug: string }).slug ?? '' : '';
+      const projectProblem = project ? (project as unknown as { problem_statement: string | null }).problem_statement : null;
 
-      const reconstructed = {
-        topic: reconstructedName,
-        topicSlug: reconstructedName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, ''),
-        surveyName: reconstructedName,
-        questionFocus: '',
-        sourceIntent: '',
-        projectSlug,
-      };
+      const artifactRef = source.artifact_ref as Record<string, unknown> | null;
+      const filename = artifactRef?.filename as string ?? '';
 
-      console.log(`  Reconstructed: ${JSON.stringify(reconstructed)}`);
+      console.log(`\n  Available canonical DB state:`);
+      console.log(`    project.name: "${projectName}"`);
+      console.log(`    project.slug: "${projectSlug}"`);
+      console.log(`    project.problem_statement: "${projectProblem ?? '(null)'}"`);
+      console.log(`    evidence_source.label: "${source.label}"`);
+      console.log(`    artifact_ref.filename: "${filename}"`);
+      console.log(`    source_type: "${source.source_type}"`);
 
-      if (!dryRun) {
+      // Propose recovery with provenance for each field
+      // source.label has format: "Survey Name — filename.csv"
+      const labelParts = source.label.split(' — ');
+      const nameFromLabel = labelParts.length > 1 ? labelParts[0] : null;
+
+      console.log(`\n  Proposed survey_context (requires approval):`);
+      console.log(`    topic: "${nameFromLabel ?? '(needs manual entry)'}" — provenance: source.label prefix${nameFromLabel ? '' : ' (UNPARSEABLE)'}`);
+      console.log(`    topicSlug: "${nameFromLabel ? nameFromLabel.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') : '(needs manual entry)'}" — provenance: derived from topic`);
+      console.log(`    surveyName: "${nameFromLabel ?? '(needs manual entry)'}" — provenance: source.label prefix`);
+      console.log(`    questionFocus: "" — provenance: not persisted in legacy flow`);
+      console.log(`    sourceIntent: "" — provenance: not persisted in legacy flow`);
+      console.log(`    projectSlug: "${projectSlug}" — provenance: project.slug`);
+
+      // Only persist if explicitly approved
+      if (!dryRun && approvedContextIds.has(source.public_id) && nameFromLabel) {
+        const reconstructed = {
+          topic: nameFromLabel,
+          topicSlug: nameFromLabel.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, ''),
+          surveyName: nameFromLabel,
+          questionFocus: '',
+          sourceIntent: '',
+          projectSlug,
+        };
         await source.update({
           metadata: { ...(meta ?? {}), survey_context: reconstructed },
         });
-        console.log(`  ✅ Backfilled survey_context`);
+        console.log(`\n    ✅ Backfilled survey_context (explicitly approved)`);
       }
     }
   }

--- a/backend/scripts/repair-duplicate-constructs.ts
+++ b/backend/scripts/repair-duplicate-constructs.ts
@@ -42,6 +42,12 @@ const approvedGovernanceIds = new Set(
   governanceArg ? governanceArg.split('=')[1].split(',').filter(Boolean) : [],
 );
 
+// Explicit allowlist for research backfill: --research-code-ids=uuid1,uuid2,...
+const researchArg = process.argv.find(a => a.startsWith('--research-code-ids='));
+const approvedResearchIds = new Set(
+  researchArg ? researchArg.split('=')[1].split(',').filter(Boolean) : [],
+);
+
 // Explicit approval for survey_context backfill: --backfill-context-ids=sourcePublicId,...
 const contextArg = process.argv.find(a => a.startsWith('--backfill-context-ids='));
 const approvedContextIds = new Set(
@@ -254,12 +260,17 @@ async function main() {
         console.log(`    current: MISSING`);
         console.log(`    suggested: ${suggestedRelevance} (reason: ${suggestionReason})`);
 
-        // Only persist if explicitly approved via --governance-code-ids
+        // Only persist if explicitly approved via allowlist flags
         if (!dryRun && approvedGovernanceIds.has(code.public_id)) {
           await code.update({
             metadata: { ...meta, analytic_relevance: 'governance_only' },
           });
           console.log(`    ✅ Set analytic_relevance = governance_only (explicitly approved)`);
+        } else if (!dryRun && approvedResearchIds.has(code.public_id)) {
+          await code.update({
+            metadata: { ...meta, analytic_relevance: 'research' },
+          });
+          console.log(`    ✅ Set analytic_relevance = research (explicitly approved)`);
         }
       }
     }
@@ -333,19 +344,50 @@ async function main() {
       console.log(`    projectSlug: "${projectSlug}" — provenance: project.slug`);
 
       // Only persist if explicitly approved
-      if (!dryRun && approvedContextIds.has(source.public_id) && nameFromLabel) {
+      if (!dryRun && approvedContextIds.has(source.public_id)) {
+        // Check for explicit context override: --context-override=topic:value,topicSlug:value,...
+        const overrideArg = process.argv.find(a => a.startsWith('--context-override='));
+        const overrides: Record<string, string> = {};
+        if (overrideArg) {
+          // Parse key:value pairs separated by "|"
+          for (const pair of overrideArg.split('=')[1].split('|')) {
+            const [k, ...vParts] = pair.split(':');
+            if (k) overrides[k] = vParts.join(':');
+          }
+        }
+
+        const topic = overrides.topic ?? nameFromLabel ?? 'Survey';
+        const topicSlug = overrides.topicSlug ?? topic.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
         const reconstructed = {
-          topic: nameFromLabel,
-          topicSlug: nameFromLabel.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, ''),
-          surveyName: nameFromLabel,
-          questionFocus: '',
-          sourceIntent: '',
-          projectSlug,
+          topic,
+          topicSlug,
+          surveyName: overrides.surveyName ?? topic,
+          questionFocus: overrides.questionFocus ?? '',
+          sourceIntent: overrides.sourceIntent ?? '',
+          projectSlug: overrides.projectSlug ?? projectSlug,
         };
+
+        const recoveryProvenance = {
+          method: 'legacy_dev_backfill',
+          recovered_from: [
+            'canonical project state',
+            ...(overrideArg ? ['explicit CLI override'] : []),
+            ...(!overrideArg && nameFromLabel ? ['source.label prefix'] : []),
+            ...(nameFromLabel === null ? ['peer evidence sources for same uploaded survey'] : []),
+          ],
+          recovered_at: new Date().toISOString(),
+          unavailable_fields: ['questionFocus', 'sourceIntent'].filter(f => !overrides[f]),
+        };
+
         await source.update({
-          metadata: { ...(meta ?? {}), survey_context: reconstructed },
+          metadata: {
+            ...(meta ?? {}),
+            survey_context: reconstructed,
+            survey_context_recovery: recoveryProvenance,
+          },
         });
         console.log(`\n    ✅ Backfilled survey_context (explicitly approved)`);
+        console.log(`    Recovery provenance: ${JSON.stringify(recoveryProvenance)}`);
       }
     }
   }

--- a/backend/src/__tests__/unit/survey/persistedFacts.test.ts
+++ b/backend/src/__tests__/unit/survey/persistedFacts.test.ts
@@ -5,7 +5,7 @@
  * evidence constructs without any CSV/Redis dependency.
  */
 
-import { loadPersistedFacts } from '../../../helpers/survey/loadPersistedFacts';
+import { loadPersistedFacts, FactInvariantError } from '../../../helpers/survey/loadPersistedFacts';
 import type { SurveyComputedFacts } from '../../../types/survey';
 
 describe('loadPersistedFacts', () => {
@@ -129,6 +129,242 @@ describe('loadPersistedFacts', () => {
     // No raw CSV dependency needed
     expect(facts!.totalRespondents).toBe(10);
     expect(facts!.fieldStats[0].median).toBe('Good');
+  });
+});
+
+describe('fail-closed invariants', () => {
+  const makeSummary = (totalRespondents: number) => ({
+    construct_type: 'survey_dataset_summary',
+    payload: {
+      total_respondents: totalRespondents,
+      schema_summary: [],
+      nonresponse_limitation: 'Test',
+      source_content_hash: 'hash',
+    },
+  });
+
+  const makeField = (fieldName: string, nPresent: number, nMissing: number) => ({
+    construct_type: 'field_distribution',
+    payload: {
+      fieldName,
+      role: 'ordinal',
+      totalRespondents: 10,
+      nPresent,
+      nMissing,
+      distribution: { A: nPresent },
+      median: 'A',
+      nValidNumeric: null,
+      nInvalidNumeric: null,
+    },
+  });
+
+  const makeCrossTab = (rowField: string, colField: string, totalN: number) => ({
+    construct_type: 'cross_tab',
+    payload: { rowField, colField, cells: { row1: { col1: totalN } }, totalN },
+  });
+
+  it('rejects when nPresent > respondent_count', () => {
+    expect(() => loadPersistedFacts([
+      makeSummary(10),
+      makeField('satisfaction', 11, 0),
+    ])).toThrow(FactInvariantError);
+  });
+
+  it('rejects duplicate field_distribution for same field', () => {
+    expect(() => loadPersistedFacts([
+      makeSummary(10),
+      makeField('satisfaction', 8, 2),
+      makeField('satisfaction', 8, 2), // duplicate
+    ])).toThrow(FactInvariantError);
+  });
+
+  it('rejects duplicate cross_tab for same row+col', () => {
+    expect(() => loadPersistedFacts([
+      makeSummary(10),
+      makeCrossTab('completion', 'difficulty', 10),
+      makeCrossTab('completion', 'difficulty', 10), // duplicate
+    ])).toThrow(FactInvariantError);
+  });
+
+  it('rejects cross-tab totalN > respondent_count', () => {
+    expect(() => loadPersistedFacts([
+      makeSummary(10),
+      makeCrossTab('completion', 'difficulty', 11),
+    ])).toThrow(FactInvariantError);
+  });
+
+  it('rejects multiple dataset summaries', () => {
+    expect(() => loadPersistedFacts([
+      makeSummary(10),
+      makeSummary(10), // duplicate summary
+    ])).toThrow(FactInvariantError);
+  });
+
+  it('accepts valid coherent fact set', () => {
+    const facts = loadPersistedFacts([
+      makeSummary(10),
+      makeField('satisfaction', 10, 0),
+      makeField('difficulty', 8, 2),
+      makeCrossTab('satisfaction', 'difficulty', 8),
+    ]);
+
+    expect(facts).not.toBeNull();
+    expect(facts!.totalRespondents).toBe(10);
+    expect(facts!.fieldStats).toHaveLength(2);
+    expect(facts!.crossTabs).toHaveLength(1);
+  });
+
+  it('each field appears exactly once in valid fact set', () => {
+    const facts = loadPersistedFacts([
+      makeSummary(10),
+      makeField('satisfaction', 10, 0),
+      makeField('difficulty', 9, 1),
+      makeField('completion', 10, 0),
+    ]);
+
+    expect(facts).not.toBeNull();
+    const fieldNames = facts!.fieldStats.map(f => f.fieldName);
+    expect(new Set(fieldNames).size).toBe(fieldNames.length);
+  });
+
+  it('each cross-tab appears exactly once in valid fact set', () => {
+    const facts = loadPersistedFacts([
+      makeSummary(10),
+      makeCrossTab('completion', 'satisfaction', 10),
+      makeCrossTab('completion', 'difficulty', 8),
+    ]);
+
+    expect(facts).not.toBeNull();
+    const ctKeys = facts!.crossTabs.map(ct => `${ct.rowField}:${ct.colField}`);
+    expect(new Set(ctKeys).size).toBe(ctKeys.length);
+  });
+
+  it('nPresent never exceeds respondent_count in valid set', () => {
+    const facts = loadPersistedFacts([
+      makeSummary(10),
+      makeField('f1', 10, 0),
+      makeField('f2', 5, 5),
+      makeField('f3', 0, 10),
+    ]);
+
+    expect(facts).not.toBeNull();
+    for (const f of facts!.fieldStats) {
+      expect(f.nPresent).toBeLessThanOrEqual(10);
+    }
+  });
+
+  // ── Reconciliation invariants ──
+
+  it('rejects nPresent + nMissing ≠ respondent_count', () => {
+    // nPresent=9, nMissing=0 → sum=9, respondent_count=10 → FAIL
+    expect(() => loadPersistedFacts([
+      makeSummary(10),
+      { construct_type: 'field_distribution', payload: {
+        fieldName: 'f1', role: 'ordinal', totalRespondents: 10,
+        nPresent: 9, nMissing: 0,
+        distribution: { A: 9 }, median: 'A',
+        nValidNumeric: null, nInvalidNumeric: null,
+      }},
+    ])).toThrow(FactInvariantError);
+  });
+
+  it('accepts nPresent + nMissing == respondent_count', () => {
+    // nPresent=9, nMissing=1 → sum=10 → PASS
+    const facts = loadPersistedFacts([
+      makeSummary(10),
+      { construct_type: 'field_distribution', payload: {
+        fieldName: 'f1', role: 'ordinal', totalRespondents: 10,
+        nPresent: 9, nMissing: 1,
+        distribution: { A: 9 }, median: 'A',
+        nValidNumeric: null, nInvalidNumeric: null,
+      }},
+    ]);
+    expect(facts).not.toBeNull();
+    expect(facts!.fieldStats[0].nPresent).toBe(9);
+  });
+
+  it('rejects distribution sum ≠ nPresent', () => {
+    // distribution {A:5, B:3} sums to 8, nPresent=9 → FAIL
+    expect(() => loadPersistedFacts([
+      makeSummary(10),
+      { construct_type: 'field_distribution', payload: {
+        fieldName: 'f1', role: 'ordinal', totalRespondents: 10,
+        nPresent: 9, nMissing: 1,
+        distribution: { A: 5, B: 3 }, median: 'A',
+        nValidNumeric: null, nInvalidNumeric: null,
+      }},
+    ])).toThrow(FactInvariantError);
+  });
+
+  it('rejects cross-tab cell sum ≠ totalN', () => {
+    // cells sum to 9, totalN=10 → FAIL
+    expect(() => loadPersistedFacts([
+      makeSummary(10),
+      { construct_type: 'cross_tab', payload: {
+        rowField: 'a', colField: 'b',
+        cells: { r1: { c1: 5, c2: 4 } }, totalN: 10,
+      }},
+    ])).toThrow(FactInvariantError);
+  });
+
+  it('accepts cross-tab when cell sum == totalN', () => {
+    const facts = loadPersistedFacts([
+      makeSummary(10),
+      { construct_type: 'cross_tab', payload: {
+        rowField: 'a', colField: 'b',
+        cells: { r1: { c1: 5, c2: 5 } }, totalN: 10,
+      }},
+    ]);
+    expect(facts).not.toBeNull();
+    expect(facts!.crossTabs[0].totalN).toBe(10);
+  });
+});
+
+describe('retry idempotency simulation', () => {
+  it('same source persisted 3 times produces identical facts when deduplicated', () => {
+    // Simulates what loadPersistedFacts receives AFTER idempotent persistence:
+    // only one canonical construct per semantic identity.
+    const singleSet = [
+      {
+        construct_type: 'survey_dataset_summary',
+        payload: {
+          total_respondents: 10,
+          schema_summary: [{ fieldName: 'satisfaction', role: 'ordinal', nPresent: 10, nMissing: 0 }],
+          nonresponse_limitation: 'Test',
+          source_content_hash: 'abc',
+        },
+      },
+      {
+        construct_type: 'field_distribution',
+        payload: {
+          fieldName: 'satisfaction', role: 'ordinal', totalRespondents: 10,
+          nPresent: 10, nMissing: 0,
+          distribution: { Good: 6, Fair: 4 }, median: 'Good',
+          nValidNumeric: null, nInvalidNumeric: null,
+        },
+      },
+      {
+        construct_type: 'cross_tab',
+        payload: {
+          rowField: 'completion', colField: 'satisfaction',
+          cells: { Complete: { Good: 5, Fair: 2 } }, totalN: 7,
+        },
+      },
+    ];
+
+    // After idempotent persistence, retries produce the same single set
+    const facts1 = loadPersistedFacts(singleSet);
+    const facts2 = loadPersistedFacts(singleSet);
+    const facts3 = loadPersistedFacts(singleSet);
+
+    // All three produce identical results
+    expect(facts1).toEqual(facts2);
+    expect(facts2).toEqual(facts3);
+
+    // Respondent count is always 10, never inflated
+    expect(facts1!.totalRespondents).toBe(10);
+    expect(facts1!.fieldStats).toHaveLength(1);
+    expect(facts1!.crossTabs).toHaveLength(1);
   });
 });
 

--- a/backend/src/__tests__/unit/survey/v10ArtifactContract.test.ts
+++ b/backend/src/__tests__/unit/survey/v10ArtifactContract.test.ts
@@ -60,14 +60,14 @@ describe('v10 artifact structure', () => {
     expect(seIdx).toBeLessThan(wrdIdx);
   });
 
-  it('Integrated Interpretation appears after qualitative section', () => {
+  it('What This Means appears after qualitative section', () => {
     const wrdIdx = outputSection.indexOf('## What Respondents Described');
-    const iiIdx = outputSection.indexOf('## Integrated Interpretation');
+    const iiIdx = outputSection.indexOf('## What This Means');
     expect(wrdIdx).toBeLessThan(iiIdx);
   });
 
-  it('Evidence Gaps appears after Integrated Interpretation', () => {
-    const iiIdx = outputSection.indexOf('## Integrated Interpretation');
+  it('Evidence Gaps appears after What This Means', () => {
+    const iiIdx = outputSection.indexOf('## What This Means');
     const egIdx = outputSection.indexOf('## Evidence Gaps');
     expect(iiIdx).toBeLessThan(egIdx);
   });
@@ -77,24 +77,14 @@ describe('v10 artifact structure', () => {
 // EXECUTIVE SUMMARY WITH QUALITATIVE CODING
 // ═══════════════════════════════════════════════════════════════════════
 
-describe('Executive Summary with accepted coding', () => {
-  it('shows qualitative analysis complete when coding accepted', () => {
-    expect(outputSection).toContain('Qualitative analysis complete');
+describe('Executive Summary', () => {
+  it('uses AI-generated narrative', () => {
+    expect(outputSection).toContain('ai_generated.executive_summary');
   });
 
-  it('shows eligible respondent count', () => {
-    expect(outputSection).toContain('qualitative_coding.eligibleRespondentCount');
-  });
-
-  it('shows recurring pattern headlines', () => {
-    expect(outputSection).toContain('qualitative_coding.recurringPatterns');
-    expect(outputSection).toContain('this.displayFrequency');
-  });
-
-  it('does not contain unsupported number variables', () => {
-    // No raw numerator/denominator in executive summary
-    expect(outputSection).not.toContain('this.numerator');
-    expect(outputSection).not.toContain('this.denominator');
+  it('does not contain fact-list format', () => {
+    // No more median-listing format
+    expect(outputSection).not.toMatch(/\[!IMPORTANT\].*unique respondents.*analyzed/s);
   });
 });
 
@@ -234,8 +224,8 @@ describe('Method & Provenance with accepted coding', () => {
     expect(outputSection).not.toContain('Evidence Source ID');
   });
 
-  it('template version is v10.0', () => {
-    expect(outputSection).toContain('Survey Synthesis v10.0');
+  it('template version is v10.1', () => {
+    expect(outputSection).toContain('Survey Synthesis v10.1');
   });
 });
 
@@ -346,7 +336,7 @@ describe('Handlebars empty array conditionals', () => {
       privacyReview: { clear: 8, redacted: 1, restricted: 1 },
     },
     provenance: { source_filename: 'test.csv', reviewed_by: 'U_TEST', reviewed_at: '2026-08-16', ordinal_orders: '', model_used: 'test' },
-    ai_generated: { qualitative_observations: '', evidence_gaps: '' },
+    ai_generated: { qualitative_observations: '', evidence_gaps: '', executive_summary: 'Test summary.', integrated_interpretation: 'Test interpretation.' },
   };
 
   it('empty recurringPatterns → "Recurring Patterns" heading NOT rendered', () => {
@@ -414,11 +404,171 @@ describe('Handlebars empty array conditionals', () => {
     const data = {
       ...baseData,
       qualitative_coding: null,
-      ai_generated: { qualitative_observations: 'Some preliminary text', evidence_gaps: '' },
+      ai_generated: { qualitative_observations: 'Some preliminary text', evidence_gaps: '', executive_summary: 'Summary.', integrated_interpretation: 'Interpretation.' },
     };
     const result = compile(data);
     expect(result).toContain('## Preliminary Qualitative Observations');
     expect(result).toContain('Some preliminary text');
     expect(result).not.toContain('## What Respondents Described');
+  });
+
+  it('empty source_intent omits "This survey contributes:" line', () => {
+    const data = {
+      ...baseData,
+      project_problem_statement: 'Test problem',
+      source_intent: '',
+    };
+    const result = compile(data);
+    expect(result).toContain('**Research problem:**');
+    expect(result).not.toContain('**This survey contributes:**');
+  });
+
+  it('populated source_intent renders contribution line', () => {
+    const data = {
+      ...baseData,
+      project_problem_statement: 'Test problem',
+      source_intent: 'Understand scheduling experiences',
+    };
+    const result = compile(data);
+    expect(result).toContain('**This survey contributes:** Understand scheduling experiences');
+  });
+
+  it('What This Means uses AI-generated interpretation', () => {
+    const data = {
+      ...baseData,
+      ai_generated: {
+        ...baseData.ai_generated,
+        integrated_interpretation: 'The strongest pattern is convergence between completion and satisfaction.',
+      },
+    };
+    const result = compile(data);
+    expect(result).toContain('## What This Means');
+    expect(result).toContain('The strongest pattern is convergence');
+  });
+
+  it('What This Means does NOT contain reader instructions', () => {
+    const data = {
+      ...baseData,
+      ai_generated: {
+        ...baseData.ai_generated,
+        integrated_interpretation: 'Synthesis text here.',
+      },
+    };
+    const result = compile(data);
+    // The template should NOT contain these instruction phrases
+    expect(result).not.toContain('Readers should look for convergence');
+    expect(result).not.toContain('Readers should look for complementarity');
+    expect(result).not.toContain('Readers should look for dissonance');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// GITHUB URL
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('GitHub file URL', () => {
+  it('file creation returns /blob/ URLs', () => {
+    const githubFile = readFileSync(
+      join(__dirname, '../../../helpers/github.ts'),
+      'utf-8',
+    );
+    // The createOrUpdateFileOnGitHub function constructs a URL after the
+    // createOrUpdateFileContents API call. That URL must use /blob/ for files.
+    expect(githubFile).toContain("url: `https://github.com/${owner}/${repo}/blob/main/${filePath}`");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// GOVERNANCE EXCLUSION
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('governance-only code exclusion', () => {
+  it('codebook generator declares analytic_relevance in output format', () => {
+    const generatorFile = readFileSync(
+      join(__dirname, '../../../helpers/survey/codebookGenerator.ts'),
+      'utf-8',
+    );
+    expect(generatorFile).toContain('analytic_relevance');
+    expect(generatorFile).toContain('governance_only');
+  });
+
+  it('synthesis handler filters governance_only codes from patterns', () => {
+    const handlerFile = readFileSync(
+      join(__dirname, '../../../helpers/slack/commands/surveySubmissionHandler.ts'),
+      'utf-8',
+    );
+    expect(handlerFile).toContain('governanceCodeIds');
+    expect(handlerFile).toContain('governance_only');
+  });
+
+  it('ProposedCode interface includes analytic_relevance', () => {
+    const serviceFile = readFileSync(
+      join(__dirname, '../../../services/survey-codebook.service.ts'),
+      'utf-8',
+    );
+    expect(serviceFile).toContain("analytic_relevance?: 'research' | 'governance_only'");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// IDEMPOTENT PERSISTENCE
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('idempotent foundation persistence', () => {
+  it('handler checks existingSemanticKeys before creating constructs', () => {
+    const handlerFile = readFileSync(
+      join(__dirname, '../../../helpers/slack/commands/surveySubmissionHandler.ts'),
+      'utf-8',
+    );
+    expect(handlerFile).toContain('existingSemanticKeys');
+    expect(handlerFile).toContain('semantic_key');
+  });
+
+  it('handler uses source-scoped query via getConstructsForSource', () => {
+    const handlerFile = readFileSync(
+      join(__dirname, '../../../helpers/slack/commands/surveySubmissionHandler.ts'),
+      'utf-8',
+    );
+    expect(handlerFile).toContain('getConstructsForSource(evidenceSourceId');
+    expect(handlerFile).not.toMatch(/findAll\(\{\s*where:\s*\{\s*project_id:/);
+  });
+
+  it('infers semantic key from payload when derivation_context.semantic_key absent', () => {
+    const handlerFile = readFileSync(
+      join(__dirname, '../../../helpers/slack/commands/surveySubmissionHandler.ts'),
+      'utf-8',
+    );
+    // Must handle legacy constructs without explicit semantic_key
+    expect(handlerFile).toContain('Legacy inference');
+    expect(handlerFile).toContain("type === 'survey_dataset_summary'");
+    expect(handlerFile).toContain("type === 'field_distribution'");
+    expect(handlerFile).toContain("type === 'cross_tab'");
+  });
+
+  it('survey context stored in evidence_source metadata', () => {
+    const handlerFile = readFileSync(
+      join(__dirname, '../../../helpers/slack/commands/surveySubmissionHandler.ts'),
+      'utf-8',
+    );
+    expect(handlerFile).toContain('survey_context:');
+  });
+
+  it('synthesis action reloads context from evidence_source metadata', () => {
+    const actionFile = readFileSync(
+      join(__dirname, '../../../helpers/slack/commands/surveySynthesisAction.ts'),
+      'utf-8',
+    );
+    expect(actionFile).toContain('surveyContext');
+    expect(actionFile).toContain('survey_context');
+  });
+
+  it('synthesis action reconstructs from source.label when survey_context absent', () => {
+    const actionFile = readFileSync(
+      join(__dirname, '../../../helpers/slack/commands/surveySynthesisAction.ts'),
+      'utf-8',
+    );
+    // Must have canonical DB fallback for legacy sources
+    expect(actionFile).toContain('Reconstruct from canonical DB state');
+    expect(actionFile).toContain('source.label.split');
   });
 });

--- a/backend/src/__tests__/unit/survey/v10ArtifactContract.test.ts
+++ b/backend/src/__tests__/unit/survey/v10ArtifactContract.test.ts
@@ -562,13 +562,15 @@ describe('idempotent foundation persistence', () => {
     expect(actionFile).toContain('survey_context');
   });
 
-  it('synthesis action reconstructs from source.label when survey_context absent', () => {
+  it('synthesis action falls back to canonical DB state when survey_context absent', () => {
     const actionFile = readFileSync(
       join(__dirname, '../../../helpers/slack/commands/surveySynthesisAction.ts'),
       'utf-8',
     );
-    // Must have canonical DB fallback for legacy sources
-    expect(actionFile).toContain('Reconstruct from canonical DB state');
-    expect(actionFile).toContain('source.label.split');
+    // Must have canonical DB fallback for legacy sources — uses project + meta, NOT label parsing
+    expect(actionFile).toContain('Canonical DB state');
+    expect(actionFile).toContain('getProjectById');
+    // Must NOT parse source.label as canonical data
+    expect(actionFile).not.toContain('source.label.split');
   });
 });

--- a/backend/src/helpers/github.ts
+++ b/backend/src/helpers/github.ts
@@ -205,7 +205,7 @@ export async function createOrUpdateFileOnGitHub(
       return {
         path: data.content!.path!,
         sha: data.content!.sha!,
-        url: `https://github.com/${owner}/${repo}/tree/main/${filePath}`,
+        url: `https://github.com/${owner}/${repo}/blob/main/${filePath}`,
       };
     } catch (err: unknown) {
       const octokitErr = err as { status?: number; message?: string };

--- a/backend/src/helpers/slack/commands/surveySubmissionHandler.ts
+++ b/backend/src/helpers/slack/commands/surveySubmissionHandler.ts
@@ -49,7 +49,7 @@ import {
   formatComputedFacts,
   toDisplayLabel,
 } from '../../survey';
-import { loadPersistedFacts } from '../../survey/loadPersistedFacts';
+import { loadPersistedFacts, FactInvariantError } from '../../survey/loadPersistedFacts';
 import { buildQualitativeEntries, persistQualitativeEntries } from '../../survey/qualitativeEntryWriter';
 import {
   getAnalysisEligibleContent as getEligibleContent,
@@ -64,7 +64,7 @@ import {
   type SchemaReviewMeta,
 } from '../ui/surveySchemaReviewModal';
 import { processSlackFile } from '../../pdfProcessor';
-import { createSourceToConstruct } from '../../../services/evidence.service';
+import { createSourceToConstruct, getConstructsForSource } from '../../../services/evidence.service';
 import { fetchFileFromRepo, getConfigRepo, YAML_TEMPLATE_PATH } from '../../github';
 import { processYamlTemplate } from '../../yamlProcessor';
 import { getProjectById } from '../../../services/project.service';
@@ -240,6 +240,16 @@ export async function handleSurveyUploadPhase(
       column_count: survey.headers.length,
       headers: survey.headers,
       parse_warnings: survey.parseWarnings,
+      // Canonical survey context — reloaded during synthesis to avoid
+      // metadata loss through Slack button chains (codebook→match→synthesis).
+      survey_context: {
+        topic,
+        topicSlug,
+        surveyName,
+        questionFocus,
+        sourceIntent,
+        projectSlug,
+      },
     },
     created_by: userId,
   } as CreationAttributes<EvidenceSource>);
@@ -653,34 +663,78 @@ async function persistSurveyFoundation(
     const displayLabels = identities.map(id => id.displayLabel);
     const openTextContent = extractOpenTextContent(survey, confirmedFields, displayLabels);
 
-    // Create evidence constructs (deterministic, auto-accepted)
-    await sequelize.transaction(async (t) => {
-      const summaryConstruct = await EvidenceConstructModel.create({
-        project_id: ctx.projectId,
-        study_id: null,
-        construct_type: 'survey_dataset_summary',
-        label: `${ctx.surveyName} — ${computedFacts.totalRespondents} respondents`,
-        payload: {
-          total_respondents: computedFacts.totalRespondents,
-          schema_summary: computedFacts.schemaSummary,
-          nonresponse_limitation: computedFacts.nonresponseLimitation,
-          source_content_hash: contentHash,
-        },
-        derivation_type: 'deterministic',
-        derivation_context: { method: 'survey_structured_ingestion', version: '1.0' },
-        status: 'accepted',
-        created_by: ctx.userId,
-      }, { transaction: t });
+    // Create evidence constructs (deterministic, auto-accepted) — IDEMPOTENT.
+    //
+    // Semantic identity per construct type:
+    //   dataset_summary:    evidence_source + construct_type
+    //   field_distribution: evidence_source + construct_type + field_name
+    //   cross_tab:          evidence_source + construct_type + row_field + column_field
+    //
+    // Source→construct lineage (evidence_relationships) establishes scoping.
+    // If a construct with the same semantic_key already exists for this source,
+    // the duplicate is NOT created. This prevents retry duplication.
 
-      await createSourceToConstruct({
-        from_source_id: evidenceSourceId,
-        to_construct_id: (summaryConstruct as unknown as { id: number }).id,
-        relationship_type: 'DERIVED_FROM',
-        provenance: { method: 'survey_structured_ingestion' },
-      }, t);
+    // Load existing constructs for this source to check for duplicates.
+    // Supports BOTH new constructs (with explicit semantic_key in derivation_context)
+    // AND legacy constructs (without semantic_key — infer from construct_type + payload).
+    const existingConstructs = await getConstructsForSource(evidenceSourceId, {
+      derivation_type: 'deterministic',
+    });
+    const existingSemanticKeys = new Set(
+      existingConstructs
+        .map(c => {
+          const dc = (c as unknown as { derivation_context: Record<string, unknown> | null }).derivation_context;
+          const explicitKey = dc?.semantic_key as string | undefined;
+          if (explicitKey) return explicitKey;
+
+          // Legacy inference: derive semantic key from construct_type + payload
+          const type = (c as unknown as { construct_type: string }).construct_type;
+          const payload = (c as unknown as { payload: Record<string, unknown> | null }).payload;
+          if (type === 'survey_dataset_summary') return 'dataset_summary';
+          if (type === 'field_distribution' && payload?.fieldName) {
+            return `field_distribution:${payload.fieldName}`;
+          }
+          if (type === 'cross_tab' && payload?.rowField && payload?.colField) {
+            return `cross_tab:${payload.rowField}:${payload.colField}`;
+          }
+          return undefined;
+        })
+        .filter((k): k is string => !!k),
+    );
+
+    await sequelize.transaction(async (t) => {
+      const summaryKey = 'dataset_summary';
+      if (!existingSemanticKeys.has(summaryKey)) {
+        const summaryConstruct = await EvidenceConstructModel.create({
+          project_id: ctx.projectId,
+          study_id: null,
+          construct_type: 'survey_dataset_summary',
+          label: `${ctx.surveyName} — ${computedFacts.totalRespondents} respondents`,
+          payload: {
+            total_respondents: computedFacts.totalRespondents,
+            schema_summary: computedFacts.schemaSummary,
+            nonresponse_limitation: computedFacts.nonresponseLimitation,
+            source_content_hash: contentHash,
+          },
+          derivation_type: 'deterministic',
+          derivation_context: { method: 'survey_structured_ingestion', version: '1.0', semantic_key: summaryKey },
+          status: 'accepted',
+          created_by: ctx.userId,
+        }, { transaction: t });
+
+        await createSourceToConstruct({
+          from_source_id: evidenceSourceId,
+          to_construct_id: (summaryConstruct as unknown as { id: number }).id,
+          relationship_type: 'DERIVED_FROM',
+          provenance: { method: 'survey_structured_ingestion' },
+        }, t);
+      }
 
       for (const stat of computedFacts.fieldStats) {
         if (!stat.distribution && stat.nValidNumeric === null) continue;
+
+        const fieldKey = `field_distribution:${stat.fieldName}`;
+        if (existingSemanticKeys.has(fieldKey)) continue;
 
         const distConstruct = await EvidenceConstructModel.create({
           project_id: ctx.projectId,
@@ -689,7 +743,7 @@ async function persistSurveyFoundation(
           label: `${stat.fieldName} distribution`,
           payload: stat,
           derivation_type: 'deterministic',
-          derivation_context: { method: 'survey_structured_ingestion', version: '1.0' },
+          derivation_context: { method: 'survey_structured_ingestion', version: '1.0', semantic_key: fieldKey },
           status: 'accepted',
           created_by: ctx.userId,
         }, { transaction: t });
@@ -702,6 +756,9 @@ async function persistSurveyFoundation(
       }
 
       for (const ct of computedFacts.crossTabs) {
+        const ctKey = `cross_tab:${ct.rowField}:${ct.colField}`;
+        if (existingSemanticKeys.has(ctKey)) continue;
+
         const ctConstruct = await EvidenceConstructModel.create({
           project_id: ctx.projectId,
           study_id: null,
@@ -709,7 +766,7 @@ async function persistSurveyFoundation(
           label: `${ct.rowField} × ${ct.colField}`,
           payload: ct,
           derivation_type: 'deterministic',
-          derivation_context: { method: 'survey_structured_ingestion', version: '1.0' },
+          derivation_context: { method: 'survey_structured_ingestion', version: '1.0', semantic_key: ctKey },
           status: 'accepted',
           created_by: ctx.userId,
         }, { transaction: t });
@@ -768,10 +825,10 @@ export async function runSurveyQualitativeSynthesis(
   client: AllMiddlewareArgs['client'],
 ): Promise<void> {
   try {
-    // Load canonical persisted facts from evidence constructs — NOT recomputed from CSV
-    const evidenceConstructs = await EvidenceConstructModel.findAll({
-      where: { project_id: ctx.projectId },
-      order: [['created_at', 'ASC']],
+    // Load canonical persisted facts from evidence constructs via source lineage —
+    // NOT project_id scoped. One synthesis → one source → one coherent fact set.
+    const evidenceConstructs = await getConstructsForSource(evidenceSourceId, {
+      derivation_type: 'deterministic',
     });
 
     const computedFacts = loadPersistedFacts(
@@ -850,11 +907,24 @@ export async function runSurveyQualitativeSynthesis(
           });
         }
 
-        // Get code definitions from accepted codes
+        // Get code definitions and analytic relevance from accepted codes
         const codeDefMap = new Map(details.acceptedCodes.map(c => [c.public_id, c.definition]));
+        const codeRelevanceMap = new Map(details.acceptedCodes.map(c => [
+          c.public_id,
+          (c.metadata as Record<string, unknown>)?.analytic_relevance as string ?? 'research',
+        ]));
         for (const row of assignmentRows) {
           row.code_definition = codeDefMap.get(row.code_public_id) ?? '';
         }
+
+        // Filter out governance-only codes from research patterns/observations.
+        // governance_only codes remain in the audit trail but are NOT promoted
+        // to reader-facing research findings.
+        const governanceCodeIds = new Set(
+          [...codeRelevanceMap.entries()]
+            .filter(([, relevance]) => relevance === 'governance_only')
+            .map(([id]) => id),
+        );
 
         const eligibleRespondentKeys = new Set(allEntries.filter(e => getEligibleContent(e)).map(e => (e as SurveyQualitativeEntry).respondent_key));
         const aggregation = computeQualitativeAggregation(assignmentRows, eligibleRespondentKeys);
@@ -867,6 +937,7 @@ export async function runSurveyQualitativeSynthesis(
 
         const recurringPatterns = [];
         for (const p of aggregation.recurringPatterns) {
+          if (governanceCodeIds.has(p.codePublicId)) continue;
           recurringPatterns.push({
             label: p.codeLabel,
             definition: p.codeDefinition,
@@ -877,6 +948,7 @@ export async function runSurveyQualitativeSynthesis(
 
         const individualObservations = [];
         for (const p of aggregation.individualObservations) {
+          if (governanceCodeIds.has(p.codePublicId)) continue;
           individualObservations.push({
             label: p.codeLabel,
             definition: p.codeDefinition,
@@ -993,7 +1065,7 @@ export async function runSurveyQualitativeSynthesis(
           elements: [
             {
               type: 'mrkdwn',
-              text: `Evidence entities created: 1 source, ${computedFacts.fieldStats.length + computedFacts.crossTabs.length + 1} constructs with lineage`,
+              text: `<${url}|Open in GitHub> · Evidence entities: 1 source, ${computedFacts.fieldStats.length + computedFacts.crossTabs.length + 1} constructs with lineage`,
             },
           ],
         },
@@ -1009,6 +1081,14 @@ export async function runSurveyQualitativeSynthesis(
       text: `Survey synthesis complete for "${ctx.surveyName}". View: ${url}`,
     });
   } catch (error) {
+    if (error instanceof FactInvariantError) {
+      console.error('❌ Fact invariant violations:', error.violations);
+      await client.chat.postMessage({
+        channel: ctx.userId,
+        text: '❌ Qori found inconsistent survey evidence and couldn\'t create the summary.\n\nThis may be caused by duplicate data from a previous attempt. Please contact support or re-upload the survey.',
+      });
+      return;
+    }
     const message = error instanceof Error ? error.message : String(error);
     console.error('Error in survey analysis:', error);
     await client.chat.postMessage({

--- a/backend/src/helpers/slack/commands/surveySynthesisAction.ts
+++ b/backend/src/helpers/slack/commands/surveySynthesisAction.ts
@@ -23,6 +23,7 @@ import type { ConfirmedField } from '../../../types/survey';
 import { parseCsvBuffer, computeContentHash } from '../../survey';
 import { isPrivacyReviewComplete } from '../../../services/content-governance.service';
 import { findAcceptedCodingRun } from '../../../services/survey-coding-run.service';
+import { getProjectById } from '../../../services/project.service';
 import { runSurveyQualitativeSynthesis } from './surveySubmissionHandler';
 
 const EvidenceSourceModel = sequelize.models.EvidenceSource as typeof EvidenceSource;
@@ -137,11 +138,15 @@ export async function handleRunSynthesisAction(
     // 6. Invoke qualitative synthesis
     // Resolution order for survey context:
     //   1. evidence_source.metadata.survey_context (authoritative, written during upload)
-    //   2. Canonical DB state (evidence_source.label, project) — for legacy sources
-    //   3. Slack button metadata — last resort, may be fragile/incomplete
+    //   2. Persisted canonical DB state (project, evidence_source metadata)
+    //   3. evidence_source.label as last-resort display fallback (never mutated back)
+    //   4. Slack button metadata as final legacy fallback
     //
     // This avoids title corruption from metadata loss through the Slack button chain.
     const surveyContext = (sourceMetadata?.survey_context as Record<string, string> | undefined);
+
+    // Load canonical project state for fallback
+    const project = await getProjectById(meta.projectId);
 
     let resolvedTopic: string;
     let resolvedTopicSlug: string;
@@ -151,7 +156,7 @@ export async function handleRunSynthesisAction(
     let resolvedSourceIntent: string;
 
     if (surveyContext?.topic) {
-      // Priority 1: Persisted survey_context
+      // Priority 1: Persisted survey_context (authoritative)
       resolvedTopic = surveyContext.topic;
       resolvedTopicSlug = surveyContext.topicSlug ?? 'survey';
       resolvedSurveyName = surveyContext.surveyName ?? surveyContext.topic;
@@ -159,13 +164,14 @@ export async function handleRunSynthesisAction(
       resolvedQuestionFocus = surveyContext.questionFocus ?? '';
       resolvedSourceIntent = surveyContext.sourceIntent ?? '';
     } else {
-      // Priority 2: Reconstruct from canonical DB state
-      const labelParts = source.label.split(' — ');
-      const nameFromLabel = labelParts[0] || 'Survey';
-      resolvedSurveyName = nameFromLabel;
-      resolvedTopic = nameFromLabel;
-      resolvedTopicSlug = nameFromLabel.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'survey';
-      resolvedProjectSlug = meta.projectSlug ?? '';
+      // Priority 2-4: Canonical DB state + legacy fallbacks
+      // Use project slug from DB, survey name from Slack meta or source label
+      const projectSlug = project?.slug ?? meta.projectSlug ?? '';
+      const surveyName = meta.surveyName ?? source.label ?? 'Survey';
+      resolvedSurveyName = surveyName;
+      resolvedTopic = meta.topic ?? surveyName;
+      resolvedTopicSlug = meta.topicSlug ?? 'survey';
+      resolvedProjectSlug = projectSlug;
       resolvedQuestionFocus = meta.questionFocus ?? '';
       resolvedSourceIntent = meta.sourceIntent ?? '';
     }

--- a/backend/src/helpers/slack/commands/surveySynthesisAction.ts
+++ b/backend/src/helpers/slack/commands/surveySynthesisAction.ts
@@ -135,19 +135,51 @@ export async function handleRunSynthesisAction(
     });
 
     // 6. Invoke qualitative synthesis
-    // Build a minimal survey-like object for the synthesis function
-    // The function needs: sourceFilename, rows for respondent identity, headers for field context
-    // Since CSV is gone from Redis, we reconstruct from evidence entries + stored metadata
+    // Resolution order for survey context:
+    //   1. evidence_source.metadata.survey_context (authoritative, written during upload)
+    //   2. Canonical DB state (evidence_source.label, project) — for legacy sources
+    //   3. Slack button metadata — last resort, may be fragile/incomplete
+    //
+    // This avoids title corruption from metadata loss through the Slack button chain.
+    const surveyContext = (sourceMetadata?.survey_context as Record<string, string> | undefined);
+
+    let resolvedTopic: string;
+    let resolvedTopicSlug: string;
+    let resolvedSurveyName: string;
+    let resolvedProjectSlug: string;
+    let resolvedQuestionFocus: string;
+    let resolvedSourceIntent: string;
+
+    if (surveyContext?.topic) {
+      // Priority 1: Persisted survey_context
+      resolvedTopic = surveyContext.topic;
+      resolvedTopicSlug = surveyContext.topicSlug ?? 'survey';
+      resolvedSurveyName = surveyContext.surveyName ?? surveyContext.topic;
+      resolvedProjectSlug = surveyContext.projectSlug ?? meta.projectSlug ?? '';
+      resolvedQuestionFocus = surveyContext.questionFocus ?? '';
+      resolvedSourceIntent = surveyContext.sourceIntent ?? '';
+    } else {
+      // Priority 2: Reconstruct from canonical DB state
+      const labelParts = source.label.split(' — ');
+      const nameFromLabel = labelParts[0] || 'Survey';
+      resolvedSurveyName = nameFromLabel;
+      resolvedTopic = nameFromLabel;
+      resolvedTopicSlug = nameFromLabel.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'survey';
+      resolvedProjectSlug = meta.projectSlug ?? '';
+      resolvedQuestionFocus = meta.questionFocus ?? '';
+      resolvedSourceIntent = meta.sourceIntent ?? '';
+    }
+
     const ctx = {
       userId,
       projectId: meta.projectId,
-      projectSlug: meta.projectSlug ?? '',
+      projectSlug: resolvedProjectSlug,
       channelId: userId,
-      topic: meta.topic ?? 'Survey',
-      topicSlug: meta.topicSlug ?? 'survey',
-      surveyName: meta.surveyName ?? 'Survey',
-      questionFocus: meta.questionFocus ?? '',
-      sourceIntent: meta.sourceIntent ?? '',
+      topic: resolvedTopic,
+      topicSlug: resolvedTopicSlug,
+      surveyName: resolvedSurveyName,
+      questionFocus: resolvedQuestionFocus,
+      sourceIntent: resolvedSourceIntent,
     };
 
     // Create a minimal ParsedSurvey-compatible object from stored metadata

--- a/backend/src/helpers/survey/codebookGenerator.ts
+++ b/backend/src/helpers/survey/codebookGenerator.ts
@@ -23,6 +23,8 @@ import type { SurveyQualitativeEntry } from '../../database/models/survey_qualit
 const MAX_CODES = 12;
 const MAX_RETRIES = 1;
 
+export type AnalyticRelevance = 'research' | 'governance_only';
+
 export interface GeneratedCode {
   code_key: string;
   label: string;
@@ -30,6 +32,8 @@ export interface GeneratedCode {
   include_when: string;
   exclude_when?: string;
   example_entry_public_ids: string[];
+  /** Whether this grouping is substantive research or governance metadata. */
+  analytic_relevance?: AnalyticRelevance;
 }
 
 export class CodebookGenerationError extends Error {
@@ -149,6 +153,16 @@ RULES
    - Attend to the research problem and focus questions (deductive)
    - Allow categories to emerge from the evidence (inductive)
 
+7. ANALYTIC RELEVANCE: Every category must be classified as either:
+   - "research" — substantively relevant to the research problem/question.
+     Describes what respondents experienced, thought, or described about
+     the topic under study.
+   - "governance_only" — describes a privacy/data-handling property rather
+     than substantive content. Examples: contact information offered,
+     sensitive personal disclosure, third-party mention, redaction state.
+     These categories are important for data governance but are NOT
+     research findings about the topic.
+
 ============================================================
 CONTEXT
 ============================================================
@@ -176,10 +190,13 @@ Respond with ONLY a JSON object. No markdown, no explanation.
       "definition": "What this category means — one coherent analytical idea",
       "include_when": "When a response should receive this category",
       "exclude_when": "When a response should NOT receive this category (optional)",
-      "example_entry_public_ids": ["uuid-from-entries-above"]
+      "example_entry_public_ids": ["uuid-from-entries-above"],
+      "analytic_relevance": "research"
     }
   ]
-}`;
+}
+
+IMPORTANT: analytic_relevance is REQUIRED. Use "research" for substantive findings about the research topic. Use "governance_only" for categories that describe data properties (PII, contact info, sensitive disclosure) rather than research content.`;
 }
 
 function parseCodebookResponse(responseText: string): GeneratedCode[] {
@@ -242,6 +259,7 @@ function validateCodes(
     validatedCodes.push({
       ...code,
       example_entry_public_ids: validExamples,
+      analytic_relevance: code.analytic_relevance === 'governance_only' ? 'governance_only' : 'research',
     });
   }
 

--- a/backend/src/helpers/survey/loadPersistedFacts.ts
+++ b/backend/src/helpers/survey/loadPersistedFacts.ts
@@ -7,6 +7,10 @@
  *
  * This function loads those constructs and rebuilds a SurveyComputedFacts
  * object identical to what was originally computed (deterministic invariant).
+ *
+ * FAIL-CLOSED: If invariants are violated (duplicate semantic keys,
+ * n_present > respondent_count, etc.), returns null with logged details.
+ * The caller must NOT generate a synthesis artifact without valid facts.
  */
 
 import type { SurveyComputedFacts, FieldStat, FieldStatSummary, CrossTab } from '../../types/survey';
@@ -17,32 +21,140 @@ interface EvidenceConstructRecord {
 }
 
 /**
+ * Invariant violation — logged internally, researcher gets safe message.
+ */
+export class FactInvariantError extends Error {
+  constructor(
+    message: string,
+    public readonly violations: string[],
+  ) {
+    super(message);
+    this.name = 'FactInvariantError';
+  }
+}
+
+/**
  * Reconstruct SurveyComputedFacts from persisted evidence constructs.
  *
- * @param constructs — evidence constructs for the survey source
+ * @param constructs — evidence constructs for the survey source (source-scoped)
  * @returns SurveyComputedFacts or null if summary construct not found
+ * @throws FactInvariantError if invariants are violated
  */
 export function loadPersistedFacts(
   constructs: EvidenceConstructRecord[],
 ): SurveyComputedFacts | null {
-  // Find the dataset summary
-  const summary = constructs.find(c => c.construct_type === 'survey_dataset_summary');
-  if (!summary?.payload) return null;
+  // Find the dataset summary — must be exactly one
+  const summaries = constructs.filter(c => c.construct_type === 'survey_dataset_summary');
+  if (summaries.length === 0) return null;
+
+  const violations: string[] = [];
+
+  if (summaries.length > 1) {
+    violations.push(`Multiple dataset summaries found: ${summaries.length} (expected 1)`);
+  }
+
+  const summary = summaries[0];
+  if (!summary.payload) {
+    violations.push('Dataset summary has null payload');
+    throw new FactInvariantError('Inconsistent survey evidence', violations);
+  }
 
   const totalRespondents = summary.payload.total_respondents as number;
   const schemaSummary = (summary.payload.schema_summary as FieldStatSummary[]) ?? [];
   const nonresponseLimitation = (summary.payload.nonresponse_limitation as string) ?? '';
   const sourceContentHash = (summary.payload.source_content_hash as string) ?? '';
 
-  // Load field distributions
-  const fieldStats: FieldStat[] = constructs
-    .filter(c => c.construct_type === 'field_distribution' && c.payload)
-    .map(c => c.payload as unknown as FieldStat);
+  if (!totalRespondents || totalRespondents <= 0) {
+    violations.push(`Invalid respondent count: ${totalRespondents}`);
+  }
 
-  // Load cross-tabs
-  const crossTabs: CrossTab[] = constructs
-    .filter(c => c.construct_type === 'cross_tab' && c.payload)
-    .map(c => c.payload as unknown as CrossTab);
+  // Load field distributions — check for duplicates by fieldName
+  const fieldRecords = constructs.filter(c => c.construct_type === 'field_distribution' && c.payload);
+  const fieldStats: FieldStat[] = [];
+  const seenFieldNames = new Set<string>();
+
+  for (const rec of fieldRecords) {
+    const stat = rec.payload as unknown as FieldStat;
+    if (seenFieldNames.has(stat.fieldName)) {
+      violations.push(`Duplicate field_distribution for: ${stat.fieldName}`);
+      continue; // Don't include the duplicate
+    }
+    seenFieldNames.add(stat.fieldName);
+
+    // Validate n_present and n_missing against respondent count
+    if (totalRespondents > 0) {
+      if (stat.nPresent > totalRespondents) {
+        violations.push(`${stat.fieldName}: nPresent (${stat.nPresent}) > respondent_count (${totalRespondents})`);
+      }
+      if (stat.nMissing > totalRespondents) {
+        violations.push(`${stat.fieldName}: nMissing (${stat.nMissing}) > respondent_count (${totalRespondents})`);
+      }
+      // Missingness reconciliation: nPresent + nMissing must equal respondent_count
+      if (stat.nPresent + stat.nMissing !== totalRespondents) {
+        violations.push(
+          `${stat.fieldName}: nPresent (${stat.nPresent}) + nMissing (${stat.nMissing}) = ${stat.nPresent + stat.nMissing}, expected ${totalRespondents}`,
+        );
+      }
+    }
+
+    // Distribution count reconciliation: SUM(values) must equal nPresent
+    if (stat.distribution) {
+      const distSum = Object.values(stat.distribution).reduce((a, b) => a + b, 0);
+      if (distSum !== stat.nPresent) {
+        violations.push(
+          `${stat.fieldName}: distribution sum (${distSum}) ≠ nPresent (${stat.nPresent})`,
+        );
+      }
+    }
+
+    fieldStats.push(stat);
+  }
+
+  // Load cross-tabs — check for duplicates by row+col identity
+  const crossTabRecords = constructs.filter(c => c.construct_type === 'cross_tab' && c.payload);
+  const crossTabs: CrossTab[] = [];
+  const seenCrossTabs = new Set<string>();
+
+  for (const rec of crossTabRecords) {
+    const ct = rec.payload as unknown as CrossTab;
+    const ctKey = `${ct.rowField}:${ct.colField}`;
+    if (seenCrossTabs.has(ctKey)) {
+      violations.push(`Duplicate cross_tab for: ${ctKey}`);
+      continue;
+    }
+    seenCrossTabs.add(ctKey);
+
+    // Validate cross-tab n <= respondent_count
+    if (totalRespondents > 0 && ct.totalN > totalRespondents) {
+      violations.push(`Cross-tab ${ctKey}: totalN (${ct.totalN}) > respondent_count (${totalRespondents})`);
+    }
+
+    // Cross-tab cell sum reconciliation: SUM(all cells) must equal totalN
+    if (ct.cells) {
+      let cellSum = 0;
+      for (const rowValues of Object.values(ct.cells)) {
+        for (const count of Object.values(rowValues)) {
+          cellSum += count;
+        }
+      }
+      if (cellSum !== ct.totalN) {
+        violations.push(
+          `Cross-tab ${ctKey}: cell sum (${cellSum}) ≠ totalN (${ct.totalN})`,
+        );
+      }
+    }
+
+    crossTabs.push(ct);
+  }
+
+  // Fail closed if any violations detected
+  if (violations.length > 0) {
+    console.error('❌ Fact invariant violations detected:', violations);
+    throw new FactInvariantError(
+      'Qori found inconsistent survey evidence and couldn\'t create the summary.',
+      violations,
+    );
+  }
 
   return {
     sourceContentHash,

--- a/backend/src/services/evidence.service.ts
+++ b/backend/src/services/evidence.service.ts
@@ -351,6 +351,53 @@ export async function createDerivation(input: DerivationInput): Promise<{
 }
 
 // ═══════════════════════════════════════════════════════════════════════
+// SOURCE-SCOPED CONSTRUCT RETRIEVAL
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * Load all constructs derived from a specific evidence source.
+ * Uses source→construct lineage (evidence_relationships) as the authority,
+ * NOT project_id scoping.
+ *
+ * One synthesis request → one evidence_source → one coherent fact set.
+ */
+export async function getConstructsForSource(
+  sourceId: number,
+  filters?: {
+    construct_type?: ConstructType;
+    status?: ConstructStatus;
+    derivation_type?: string;
+  },
+): Promise<EvidenceConstruct[]> {
+  // Find all construct IDs linked from this source via DERIVED_FROM
+  const relationships = await EvidenceRelationshipModel.findAll({
+    where: {
+      from_source_id: sourceId,
+      relationship_type: 'DERIVED_FROM',
+    },
+    attributes: ['to_construct_id'],
+  });
+
+  const constructIds = relationships
+    .map(r => (r as unknown as { to_construct_id: number | null }).to_construct_id)
+    .filter((id): id is number => id !== null);
+
+  if (constructIds.length === 0) return [];
+
+  const where: Record<string, unknown> = {
+    id: { [Op.in]: constructIds },
+  };
+  if (filters?.construct_type) where.construct_type = filters.construct_type;
+  if (filters?.status) where.status = filters.status;
+  if (filters?.derivation_type) where.derivation_type = filters.derivation_type;
+
+  return EvidenceConstructModel.findAll({
+    where,
+    order: [['created_at', 'ASC']],
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════
 // EVIDENCE RECORD COUNTS (for audit/deletion)
 // ═══════════════════════════════════════════════════════════════════════
 

--- a/backend/src/services/survey-codebook.service.ts
+++ b/backend/src/services/survey-codebook.service.ts
@@ -30,6 +30,7 @@ export interface ProposedCode {
   include_when: string;
   exclude_when?: string;
   example_entry_public_ids: string[];
+  analytic_relevance?: 'research' | 'governance_only';
 }
 
 export class CodebookNotReadyError extends Error {
@@ -122,7 +123,9 @@ export async function createDraftCodebook(
         origin: 'qori_proposed',
         status: 'proposed',
         sort_order: i,
-        metadata: {},
+        metadata: {
+          ...(pc.analytic_relevance ? { analytic_relevance: pc.analytic_relevance } : {}),
+        },
       } as CreationAttributes<SurveyCode>, { transaction: t });
 
       // Create example references

--- a/backend/src/services/survey-coding-run.service.ts
+++ b/backend/src/services/survey-coding-run.service.ts
@@ -72,7 +72,7 @@ export interface CodingRunDetails {
     code_label: string;
   }>;
   entryReviews: SurveyCodingEntryReview[];
-  acceptedCodes: Array<{ id: number; public_id: string; label: string; definition: string; include_when: string; exclude_when: string | null }>;
+  acceptedCodes: Array<{ id: number; public_id: string; label: string; definition: string; include_when: string; exclude_when: string | null; metadata: Record<string, unknown> }>;
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -267,6 +267,7 @@ export async function getCodingRunWithDetails(
       definition: c.definition,
       include_when: c.include_when,
       exclude_when: c.exclude_when ?? null,
+      metadata: c.metadata ?? {},
     })),
   };
 }

--- a/config/prompts/survey_synthesis.yaml
+++ b/config/prompts/survey_synthesis.yaml
@@ -4,7 +4,7 @@
 id: survey_synthesis
 name: survey_response_synthesizer
 label: "Survey Synthesis"
-version: "v10.0"
+version: "v10.1"
 
 description: |
   Analyze survey data with deterministic structured evidence and bounded
@@ -100,7 +100,7 @@ emits:
       type: array
       items:
         $ref: schemas/survey_finding.yaml
-    extract_from: "Integrated Interpretation or Structured Evidence sections. Assign sequential IDs (finding-001). metric_name and sample_size must come from Structured Evidence values only — do not invent or re-count. Include source_question where applicable."
+    extract_from: "What This Means or Structured Evidence sections. Assign sequential IDs (finding-001). metric_name and sample_size must come from Structured Evidence values only — do not invent or re-count. Include source_question where applicable."
 
   - key: knowledge_gaps
     pool: true
@@ -253,7 +253,164 @@ ai_generation_tasks:
       evidence, methodology, footer, or any other structural element.
       Output observation groups only.
 
-  # Task 2: Evidence gaps — what the survey cannot answer
+  # Task 2: Executive Summary — bounded research narrative
+  - task_id: "executive_summary"
+    prompt: |
+      Write a research narrative summarizing the key findings from this survey.
+
+      ============================================================
+      RULES
+      ============================================================
+
+      RULE 1 — NARRATIVE SYNTHESIS, NOT FACT RECITAL
+      Synthesize the evidence into a concise story. Do NOT:
+      - List medians/distributions as bullet points
+      - Repeat the same statistic multiple times
+      - Produce a "key metric: value" format
+
+      RULE 2 — NUMERIC AUTHORITY
+      Every number in the summary must come from the structured evidence
+      below. Do not calculate, re-count, or modify any supplied value.
+      You may cite numbers to support narrative claims.
+
+      RULE 3 — STRUCTURE
+      Write 2–4 short paragraphs (120–220 words total):
+      - Paragraph 1: main outcome pattern from the structured evidence
+      - Paragraph 2: what qualitative evidence helps explain
+      - Paragraph 3: uncertainty, limitation, or research implication
+
+      RULE 4 — NO PREVALENCE LANGUAGE
+      Do not use "most respondents," "some participants," "frequently,"
+      or other soft prevalence terms. State facts with their actual
+      counts/percentages from the structured evidence.
+
+      ============================================================
+      AVAILABLE EVIDENCE
+      ============================================================
+
+      **Respondents:** {{computed_facts.totalRespondents}}
+      **Fields:** {{computed_facts.schemaSummary}}
+
+      **Field distributions:**
+      {{#each computed_facts.fieldStats}}
+      {{this.displayName}} ({{this.role}}): Present {{this.nPresent}}/{{../computed_facts.totalRespondents}}{{#if this.median}}, Median: {{this.median}}{{/if}}
+      {{/each}}
+
+      {{#if computed_facts.crossTabs}}
+      **Cross-tabulations:**
+      {{#each computed_facts.crossTabs}}
+      {{this.rowDisplayName}} × {{this.colDisplayName}} (n={{this.totalN}})
+      {{/each}}
+      {{/if}}
+
+      {{#if qualitative_coding}}
+      {{#if qualitative_coding.hasAcceptedCoding}}
+      **Accepted qualitative groupings:**
+      {{#each qualitative_coding.recurringPatterns}}
+      {{this.label}} — {{this.displayFrequency}}
+      {{/each}}
+      {{#each qualitative_coding.individualObservations}}
+      {{this.label}} — {{this.displayFrequency}}
+      {{/each}}
+      {{/if}}
+      {{/if}}
+
+      **Research problem:** {{project_problem_statement}}
+      **Source intent:** {{source_intent}}
+
+      ============================================================
+      OUTPUT
+      ============================================================
+
+      Write the narrative paragraphs directly. No heading, no markdown
+      formatting beyond basic bold/italic. No bullet lists. Just prose.
+
+  # Task 3: Integrated interpretation — bounded synthesis across evidence types
+  - task_id: "integrated_interpretation"
+    prompt: |
+      Synthesize the structured and qualitative evidence from this survey into
+      an interpretation that tells researchers what the evidence means together.
+
+      ============================================================
+      RULES
+      ============================================================
+
+      RULE 1 — YOU PERFORM THE SYNTHESIS
+      State where evidence converges, complements, or conflicts.
+      Do NOT instruct readers to look for convergence or dissonance.
+      Do NOT write methodology instructions.
+
+      RULE 2 — NUMERIC AUTHORITY
+      Every number must come from the structured evidence below.
+      Do not calculate, re-count, or modify any supplied value.
+
+      RULE 3 — NO PREVALENCE LANGUAGE
+      Do not use "most respondents," "some participants," "frequently,"
+      or other soft prevalence language.
+
+      RULE 4 — STRUCTURE
+      Write 2–4 concise paragraphs covering:
+      - Strongest convergence between structured and qualitative evidence
+      - What qualitative evidence explains about structured patterns
+      - Any dissonance or exceptions worth noting
+      - What CANNOT be concluded from this evidence
+
+      RULE 5 — NO CAUSAL CLAIMS
+      This survey is descriptive. Do not assert that one variable causes
+      another. Associations and co-occurrence are acceptable.
+
+      ============================================================
+      AVAILABLE EVIDENCE
+      ============================================================
+
+      **Respondents:** {{computed_facts.totalRespondents}}
+
+      **Field distributions:**
+      {{#each computed_facts.fieldStats}}
+      {{this.displayName}} ({{this.role}}): Present {{this.nPresent}}/{{../computed_facts.totalRespondents}}{{#if this.median}}, Median: {{this.median}}{{/if}}
+      {{/each}}
+
+      {{#if computed_facts.crossTabs}}
+      **Cross-tabulations:**
+      {{#each computed_facts.crossTabs}}
+      {{this.rowDisplayName}} × {{this.colDisplayName}} (n={{this.totalN}})
+      {{/each}}
+      {{/if}}
+
+      {{#if qualitative_coding}}
+      {{#if qualitative_coding.hasAcceptedCoding}}
+      **Accepted qualitative groupings:**
+      {{#each qualitative_coding.recurringPatterns}}
+      {{this.label}} — {{this.displayFrequency}}: {{this.definition}}
+      {{/each}}
+      {{#each qualitative_coding.individualObservations}}
+      {{this.label}} — {{this.displayFrequency}}: {{this.definition}}
+      {{/each}}
+      {{/if}}
+      {{/if}}
+
+      {{#if open_text_content}}
+      **Open-text responses (for contextual reference):**
+      ---BEGIN DATA---
+      {{open_text_content}}
+      ---END DATA---
+      {{/if}}
+
+      **Research problem:** {{project_problem_statement}}
+      **Source intent:** {{source_intent}}
+
+      ============================================================
+      OUTPUT
+      ============================================================
+
+      Write the interpretation paragraphs directly. No heading, no bullet
+      lists. Just prose that synthesizes across evidence types.
+
+      Do NOT output:
+      - "Readers should look for..."
+      - "Readers should consider..."
+      - Instructions or methodology guidance
+
   - task_id: "evidence_gaps"
     skip_when: "not project_problem_statement"
     skip_output: |
@@ -360,19 +517,7 @@ output_template: |
 
   ## Executive Summary
 
-  {{#if computed_facts}}
-  > [!IMPORTANT]
-  > **{{computed_facts.totalRespondents}} unique respondents** analyzed.{{#each computed_facts.fieldStats}}{{#if this.median}} {{this.displayName}} median: **{{this.median}}**.{{/if}}{{/each}}
-  {{#if qualitative_coding}}
-  {{#if qualitative_coding.hasAcceptedCoding}}
-  >
-  > **Qualitative analysis complete.** {{qualitative_coding.eligibleRespondentCount}} respondents with eligible open-text entries.{{#each qualitative_coding.recurringPatterns}} **{{this.label}}** — {{this.displayFrequency}}.{{/each}}
-  {{/if}}
-  {{/if}}
-  {{else}}
-  > [!WARNING]
-  > No computed facts available. This synthesis relies on qualitative interpretation only.
-  {{/if}}
+  {{ai_generated.executive_summary}}
 
   ---
 
@@ -381,7 +526,9 @@ output_template: |
   {{#if project_problem_statement}}
   **Research problem:** {{project_problem_statement}}
 
+  {{#if source_intent}}
   **This survey contributes:** {{source_intent}}
+  {{/if}}
   {{else}}
   > [!WARNING]
   > No project problem statement set. Run `/qori-start` to set one.
@@ -479,28 +626,9 @@ output_template: |
 
   {{/if}}
 
-  ## Integrated Interpretation
+  ## What This Means
 
-  {{#if computed_facts}}
-  The structured evidence above establishes the distributional baseline from {{computed_facts.totalRespondents}} unique respondents.
-  {{#if qualitative_coding}}
-  {{#if qualitative_coding.hasAcceptedCoding}}
-  The qualitative findings represent researcher-reviewed groupings with deterministic counts. Readers should:
-  {{else}}
-  The qualitative observations offer preliminary interpretation of open-text entries. Readers should:
-  {{/if}}
-  {{else}}
-  The qualitative observations offer preliminary interpretation of open-text entries. Readers should:
-  {{/if}}
-
-  - **Look for convergence** — where structured distributions and qualitative findings point the same direction
-  - **Look for complementarity** — where open-text entries explain patterns visible in the distributions
-  - **Look for dissonance** — where qualitative findings seem to contradict distributional patterns (these warrant investigation, not resolution)
-
-  No new arithmetic is introduced in this section. No causal claims are made.
-  {{else}}
-  Without computed facts, integration is limited to the qualitative analysis above.
-  {{/if}}
+  {{ai_generated.integrated_interpretation}}
 
   ---
 
@@ -598,7 +726,7 @@ output_template: |
 
   > **Generation**
   >
-  > Template: Survey Synthesis v10.0
+  > Template: Survey Synthesis v10.1
   > Model: {{#if provenance}}{{provenance.model_used}}{{else}}Unknown{{/if}}
   > Generated: {{current_date_iso}}
 
@@ -646,6 +774,12 @@ slack_ui:
     processing_failed: "Analysis failed. Please check that your file is valid CSV format."
 
 notes: |
+  v10.1: Artifact correctness — idempotent foundation, narrative summary, bounded interpretation.
+  - Executive Summary is now AI-generated narrative (not fact-list)
+  - "Integrated Interpretation" renamed to "What This Means" with actual synthesis
+  - governance_only groupings excluded from research findings
+  - Empty "This survey contributes:" conditionally omitted
+
   v10.0: Slice 2B — accepted qualitative coding integration.
   - "What Respondents Described" section replaces "Preliminary Qualitative
     Observations" when accepted coding run exists


### PR DESCRIPTION
## Summary

Fixes duplicate deterministic constructs from retry clicks, corrupted titles, broken GitHub links, governance categories appearing as research findings, and empty/instructional artifact sections.

### Data integrity (must land before rendering changes)
- **Source-scoped reconstruction**: synthesis loads constructs via `evidence_relationships` lineage, not `project_id`
- **Idempotent persistence**: `semantic_key` per construct type prevents duplicates on retry. Supports legacy constructs via payload inference.
- **Fail-closed invariants**: `loadPersistedFacts()` rejects duplicate semantic keys, `nPresent > respondent_count`, missingness reconciliation (`nPresent + nMissing ≠ respondent_count`), distribution sum reconciliation, cross-tab cell sum reconciliation

### Context and links
- **Survey context**: stored in `evidence_source.metadata.survey_context` during upload; synthesis reloads from DB, not Slack button chain. Legacy fallback from `source.label`.
- **GitHub URL**: `/blob/` not `/tree/` for file URLs. Fallback text link added.

### Governance
- **Analytic relevance**: codebook generator classifies codes as `research` or `governance_only`. Persisted in `survey_codes.metadata`. Synthesis filters governance-only from patterns/observations.
- Existing codebooks require explicit backfill via repair script.

### Template v10.1
- **Executive Summary**: AI-generated narrative (2-4 paragraphs), not fact-list
- **What This Means**: replaces "Integrated Interpretation" reader instructions with actual bounded synthesis
- **Research Context**: empty `source_intent` omits "This survey contributes:" line

### Repair script
- `backend/scripts/repair-duplicate-constructs.ts` — dry-run/fix for duplicate constructs, codebook relevance backfill, survey_context backfill

## Test plan

- [x] Typecheck clean
- [x] 448 unit tests pass (7 new)
- [ ] CI passes
- [ ] Run repair script dry-run against dev DB
- [ ] Review dry-run output before --fix
- [ ] Regenerate artifact after repair
- [ ] Manual artifact review

🤖 Generated with [Claude Code](https://claude.com/claude-code)